### PR TITLE
feat: add --base flag to diff command for base commit comparison

### DIFF
--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -40,6 +40,8 @@ interface FileChangeStat {
 interface TaskInspectionOutput {
   /** Whether the operation was successful */
   success: boolean;
+  /** The base commit hash when the worktree was created */
+  baseCommit?: string;
   /** Git branch name for the task worktree */
   branchName: string;
   /** ISO timestamp when task was completed */
@@ -118,6 +120,7 @@ const jsonErrorOutput = (
 ): TaskInspectionOutput => {
   return {
     success: false,
+    baseCommit: task?.baseCommit,
     branchName: task?.branchName || '',
     completedAt: task?.completedAt,
     createdAt: task?.createdAt || new Date().toISOString(),
@@ -297,6 +300,7 @@ export const inspectCommand = async (
       // Output JSON format
       const jsonOutput: TaskInspectionOutput = {
         success: true,
+        baseCommit: task.baseCommit,
         branchName: task.branchName,
         completedAt: task.completedAt,
         createdAt: task.createdAt,

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -338,6 +338,12 @@ const createTaskForAgent = async (
   try {
     git.createWorktree(worktreePath, branchName, baseBranch);
 
+    // Capture the base commit hash (the commit when the worktree was created)
+    const baseCommit = git.getCommitHash('HEAD', { worktreePath });
+    if (baseCommit) {
+      task.setBaseCommit(baseCommit);
+    }
+
     // Copy user .env development files
     copyEnvironmentFiles(projectPath, worktreePath);
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -354,6 +354,7 @@ export function createProgram(
     .description('Show git diff between task worktree and main branch')
     .argument('<taskId>', 'Task ID to show diff for')
     .argument('[filePath]', 'Optional file path to show diff for specific file')
+    .option('--base', 'Compare against the base commit when task was created')
     .option('-b, --branch <name>', 'Compare changes with a specific branch')
     .option('--only-files', 'Show only changed filenames')
     .action(diffCommand);

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -243,6 +243,9 @@ export class TaskDescriptionManager {
       };
     }
 
+    // Preserve baseCommit field
+    migrated.baseCommit = data.baseCommit;
+
     return migrated as TaskDescription;
   }
 
@@ -708,6 +711,9 @@ export class TaskDescriptionManager {
   get source(): TaskDescription['source'] {
     return this.data.source;
   }
+  get baseCommit(): string | undefined {
+    return this.data.baseCommit;
+  }
 
   // ============================================================
   // Data Modification (Setters)
@@ -734,6 +740,14 @@ export class TaskDescriptionManager {
    */
   setAgentImage(agentImage: string): void {
     this.data.agentImage = agentImage;
+    this.save();
+  }
+
+  /**
+   * Set the base commit hash (the commit when the worktree was created)
+   */
+  setBaseCommit(commit: string): void {
+    this.data.baseCommit = commit;
     this.save();
   }
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -495,6 +495,29 @@ export class Git {
   }
 
   /**
+   * Get the commit hash for a given ref (branch, tag, HEAD, etc.)
+   * @param ref The ref to get the commit hash for (defaults to HEAD)
+   * @param options Optional worktree path
+   * @returns The full commit hash
+   */
+  getCommitHash(
+    ref: string = 'HEAD',
+    options: GitWorktreeOptions = {}
+  ): string {
+    try {
+      return (
+        launchSync('git', ['rev-parse', ref], {
+          cwd: options.worktreePath ?? this.cwd,
+        })
+          .stdout?.toString()
+          .trim() || ''
+      );
+    } catch (error) {
+      return '';
+    }
+  }
+
+  /**
    * Check if a given branch exists
    */
   branchExists(branch: string): boolean {

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -59,6 +59,7 @@ export const TaskDescriptionSchema = z.object({
   agent: z.string().optional(),
   agentModel: z.string().optional(),
   sourceBranch: z.string().optional(),
+  baseCommit: z.string().optional(),
 
   // Docker Execution
   containerId: z.string().optional(),


### PR DESCRIPTION
## Summary

- Track the base commit hash when a worktree is created
- Add `rover diff --base` to compare against the base commit
- This shows only what the task changed from its starting point

## Changes

- Add `baseCommit` field to `TaskDescriptionSchema` (bump version to 1.3)
- Add `getCommitHash()` method to `Git` class
- Add `baseCommit` getter/setter to `TaskDescriptionManager`
- Capture base commit after worktree creation in task command
- Add `--base` flag to diff command (mutually exclusive with `--branch`)
- Expose `baseCommit` in inspect command JSON output

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Create a new task - verify `description.json` has `baseCommit`
- [x] `rover diff <id> --base` shows only task changes from starting point
- [x] `rover inspect <id> --json` includes `baseCommit` field
- [x] Using `--base` and `--branch` together shows error message
- [x] Old tasks without `baseCommit` show helpful error suggesting `--branch`

Closes endorhq/rover#435

🤖 Generated with [Claude Code](https://claude.ai/code)