### PR TITLE
feat: support cached multi-repo task workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Agents
-.claude/settings.local.json
-
 # Logs
 logs
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ demos/*
 !demos/*.tape
 !demos/README.md
 !demos/run.sh
+!demos/create-multi-env-demo.sh

--- a/demos/create-multi-env-demo.sh
+++ b/demos/create-multi-env-demo.sh
@@ -1,0 +1,907 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEST="${1:-/tmp/rover-multi-env-demo}"
+SEED_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$SEED_DIR"
+}
+trap cleanup EXIT
+
+git_init_repo() {
+  local dir="$1"
+  git -C "$dir" init -b main >/dev/null
+  git -C "$dir" config user.name "Rover Demo"
+  git -C "$dir" config user.email "demo@example.com"
+}
+
+commit_all() {
+  local dir="$1"
+  local message="$2"
+  git -C "$dir" add -A
+  git -C "$dir" commit -m "$message" >/dev/null
+}
+
+materialize_bare_ref() {
+  local bare_dir="$1"
+  local branch="${2:-main}"
+  local sha
+  sha="$(git --git-dir="$bare_dir" rev-parse "refs/heads/$branch")"
+  mkdir -p "$bare_dir/refs/heads"
+  printf '%s\n' "$sha" >"$bare_dir/refs/heads/$branch"
+}
+
+mkdir -p "$DEST"
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+FRONTEND_SRC="$SEED_DIR/frontend-src"
+BACKEND_SRC="$SEED_DIR/backend-src"
+E2E_SRC="$SEED_DIR/e2e-src"
+
+mkdir -p "$FRONTEND_SRC/lib" "$FRONTEND_SRC/test" "$FRONTEND_SRC/scripts" "$FRONTEND_SRC/web"
+cat >"$FRONTEND_SRC/.metadata" <<'EOF'
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa"
+  channel: "stable"
+
+project_type: app
+
+migration:
+  platforms:
+    - platform: root
+      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+    - platform: web
+      create_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+      base_revision: 2c9eb20739dfec95e2c74bd3dfa4601b0a8a36aa
+
+  unmanaged_files:
+    - 'lib/main.dart'
+EOF
+cat >"$FRONTEND_SRC/pubspec.yaml" <<'EOF'
+name: joke_frontend
+description: Flutter web frontend for the Rover multi-env demo.
+publish_to: none
+version: 0.1.0
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.2.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true
+EOF
+cat >"$FRONTEND_SRC/web/index.html" <<'EOF'
+<!DOCTYPE html>
+<html>
+<head>
+  <base href="$FLUTTER_BASE_HREF">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="description" content="Rover multi-env Flutter demo.">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="joke_frontend">
+  <title>joke_frontend</title>
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+</html>
+EOF
+cat >"$FRONTEND_SRC/web/manifest.json" <<'EOF'
+{
+  "name": "joke_frontend",
+  "short_name": "joke_frontend",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "description": "Rover multi-env Flutter demo.",
+  "orientation": "portrait-primary",
+  "prefer_related_applications": false,
+  "icons": []
+}
+EOF
+cat >"$FRONTEND_SRC/lib/main.dart" <<'EOF'
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'browser_storage_stub.dart'
+    if (dart.library.html) 'browser_storage_web.dart' as browser_storage;
+
+const apiBaseUrl = String.fromEnvironment(
+  'API_BASE_URL',
+  defaultValue: 'http://127.0.0.1:8080',
+);
+
+void main() {
+  runApp(const JokeApp());
+}
+
+class JokeApp extends StatelessWidget {
+  const JokeApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Joke Demo',
+      theme: ThemeData(colorSchemeSeed: Colors.orange),
+      home: const JokeHomePage(),
+    );
+  }
+}
+
+class JokeHomePage extends StatefulWidget {
+  const JokeHomePage({super.key});
+
+  @override
+  State<JokeHomePage> createState() => _JokeHomePageState();
+}
+
+class _JokeHomePageState extends State<JokeHomePage> {
+  final _nameController = TextEditingController(text: 'Rover');
+  final _random = Random();
+  Timer? _debounce;
+  String _joke = 'Press the button to fetch a joke.';
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    browser_storage.markReady();
+    browser_storage.registerFetchHook((name) {
+      _nameController.text = name;
+      _fetchJoke();
+    });
+  }
+
+  void _scheduleFetch() {
+    _debounce?.cancel();
+    if (_nameController.text.trim().isEmpty) {
+      return;
+    }
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      if (mounted && !_loading) {
+        _fetchJoke();
+      }
+    });
+  }
+
+  Future<void> _fetchJoke() async {
+    setState(() {
+      _loading = true;
+    });
+
+    final response = await http.get(
+      Uri.parse(
+        '$apiBaseUrl/api/joke?name=${Uri.encodeQueryComponent(_nameController.text)}&seed=${_random.nextInt(10)}',
+      ),
+    );
+    final payload = jsonDecode(response.body) as Map<String, dynamic>;
+    final joke = payload['joke'] as String;
+
+    setState(() {
+      _joke = joke;
+      _loading = false;
+    });
+    browser_storage.storeJoke(joke);
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Rover Joke Demo')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Enter a name and fetch a random joke from the Go API.'),
+            const SizedBox(height: 16),
+            TextField(
+              key: const Key('name-field'),
+              controller: _nameController,
+              textInputAction: TextInputAction.done,
+              onChanged: (_) => _scheduleFetch(),
+              onSubmitted: (_) => _fetchJoke(),
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'Name',
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              key: const Key('fetch-joke'),
+              onPressed: _loading ? null : _fetchJoke,
+              child: Text(_loading ? 'Loading...' : 'Get joke'),
+            ),
+            const SizedBox(height: 24),
+            SelectableText(
+              _joke,
+              key: const Key('joke-output'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+EOF
+cat >"$FRONTEND_SRC/lib/browser_storage_stub.dart" <<'EOF'
+void storeJoke(String value) {}
+
+void markReady() {}
+
+void registerFetchHook(void Function(String name) callback) {}
+EOF
+cat >"$FRONTEND_SRC/lib/browser_storage_web.dart" <<'EOF'
+import 'dart:html' as html;
+
+void storeJoke(String value) {
+  html.window.localStorage['rover_demo_joke'] = value;
+}
+
+void markReady() {
+  html.window.localStorage['rover_demo_ready'] = '1';
+}
+
+void registerFetchHook(void Function(String name) callback) {
+  html.window.addEventListener('rover-demo-fetch', (event) {
+    final customEvent = event as html.CustomEvent;
+    final detail = customEvent.detail;
+    if (detail is String) {
+      callback(detail);
+    }
+  });
+}
+EOF
+cat >"$FRONTEND_SRC/test/widget_test.dart" <<'EOF'
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:joke_frontend/main.dart';
+
+void main() {
+  testWidgets('renders the input and button', (tester) async {
+    await tester.pumpWidget(const JokeApp());
+
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'Get joke'), findsOneWidget);
+    expect(find.textContaining('Press the button'), findsOneWidget);
+  });
+}
+EOF
+cat >"$FRONTEND_SRC/scripts/init.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+flutter pub get >/dev/null
+EOF
+cat >"$FRONTEND_SRC/Makefile" <<'EOF'
+.PHONY: setup test build
+
+API_BASE_URL ?= http://127.0.0.1:8080
+
+setup:
+	flutter pub get
+
+test:
+	flutter test
+
+build:
+	flutter build web --dart-define=API_BASE_URL=$(API_BASE_URL)
+EOF
+git_init_repo "$FRONTEND_SRC"
+commit_all "$FRONTEND_SRC" "Initial frontend demo"
+
+mkdir -p "$BACKEND_SRC" "$BACKEND_SRC/scripts"
+cat >"$BACKEND_SRC/go.mod" <<'EOF'
+module example.com/joke-backend
+
+go 1.23.0
+
+require (
+	github.com/go-chi/chi/v5 v5.2.1
+	github.com/lib/pq v1.10.9
+	github.com/rs/cors v1.11.1
+)
+EOF
+cat >"$BACKEND_SRC/go.sum" <<'EOF'
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+EOF
+cat >"$BACKEND_SRC/main.go" <<'EOF'
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/rand/v2"
+	"net/http"
+	"os"
+
+	"github.com/go-chi/chi/v5"
+	_ "github.com/lib/pq"
+	"github.com/rs/cors"
+)
+
+var seedJokes = []string{
+	"%s's code compiled on the first try. Nobody believed the logs.",
+	"%s taught a rubber duck to file bug reports.",
+	"%s replaced a flaky test with a passing one and then fixed the bug too.",
+	"%s wrote a TODO so clear it gained sentience.",
+	"%s refactored the joke service until the jokes had interfaces.",
+	"%s shipped a hotfix so cold it needed a sweater.",
+	"%s opened devtools and the browser confessed immediately.",
+	"%s added telemetry to the punchline and measured 100%% laughter.",
+	"%s made the backend faster by politely asking it to stop blocking.",
+	"%s clicked deploy and the CI pipeline asked for an autograph.",
+}
+
+var db *sql.DB
+
+func initDB() *sql.DB {
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://postgres:postgres@postgres:5432/jokes?sslmode=disable"
+	}
+
+	conn, err := sql.Open("postgres", dsn)
+	if err != nil {
+		log.Fatalf("failed to connect to database: %v", err)
+	}
+
+	if _, err := conn.Exec(`
+		CREATE TABLE IF NOT EXISTS jokes (
+			id SERIAL PRIMARY KEY,
+			template TEXT NOT NULL UNIQUE
+		)
+	`); err != nil {
+		log.Fatalf("failed to create jokes table: %v", err)
+	}
+
+	for _, j := range seedJokes {
+		_, _ = conn.Exec("INSERT INTO jokes (template) VALUES ($1) ON CONFLICT DO NOTHING", j)
+	}
+
+	return conn
+}
+
+func jokesFromDB() []string {
+	if db == nil {
+		return seedJokes
+	}
+	rows, err := db.Query("SELECT template FROM jokes ORDER BY id")
+	if err != nil {
+		return seedJokes
+	}
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err == nil {
+			result = append(result, t)
+		}
+	}
+	if len(result) == 0 {
+		return seedJokes
+	}
+	return result
+}
+
+func jokeHandler(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		name = "Rover"
+	}
+
+	jokes := jokesFromDB()
+	joke := fmt.Sprintf(jokes[rand.IntN(len(jokes))], name)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"joke": joke})
+}
+
+func jokeCountHandler(w http.ResponseWriter, _ *http.Request) {
+	jokes := jokesFromDB()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]int{"count": len(jokes)})
+}
+
+func newRouter() http.Handler {
+	router := chi.NewRouter()
+	router.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	router.Get("/api/joke", jokeHandler)
+	router.Get("/api/joke/count", jokeCountHandler)
+
+	return cors.AllowAll().Handler(router)
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	db = initDB()
+	defer db.Close()
+
+	log.Printf("listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, newRouter()); err != nil {
+		panic(err)
+	}
+}
+EOF
+cat >"$BACKEND_SRC/main_test.go" <<'EOF'
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestJokeHandlerIncludesProvidedName(t *testing.T) {
+	// db is nil in unit tests — falls back to seedJokes slice
+	req := httptest.NewRequest(http.MethodGet, "/api/joke?name=Flutter", nil)
+	rec := httptest.NewRecorder()
+
+	newRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+
+	if !strings.Contains(payload["joke"], "Flutter") {
+		t.Fatalf("expected joke to include provided name, got %q", payload["joke"])
+	}
+}
+
+func TestJokeCountHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/joke/count", nil)
+	rec := httptest.NewRecorder()
+
+	newRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var payload map[string]int
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+
+	if payload["count"] != len(seedJokes) {
+		t.Fatalf("expected count %d, got %d", len(seedJokes), payload["count"])
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+
+	newRouter().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+}
+EOF
+cat >"$BACKEND_SRC/scripts/init.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+go mod download
+EOF
+cat >"$BACKEND_SRC/Makefile" <<'EOF'
+.PHONY: setup test run
+
+PORT ?= 8080
+
+setup:
+	go mod download
+
+test:
+	go test ./...
+
+run:
+	PORT=$(PORT) go run .
+EOF
+git_init_repo "$BACKEND_SRC"
+commit_all "$BACKEND_SRC" "Initial backend demo"
+
+mkdir -p "$E2E_SRC/tests" "$E2E_SRC/scripts"
+cat >"$E2E_SRC/pyproject.toml" <<'EOF'
+[project]
+name = "joke-e2e"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "nodriver==0.48.1",
+  "pytest==8.3.5",
+  "pytest-asyncio==0.25.3",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+EOF
+cat >"$E2E_SRC/conftest.py" <<'EOF'
+import asyncio
+import os
+
+from nodriver.core import browser as browser_module
+from nodriver.core.config import Config
+
+
+def pytest_configure(config):
+    if "BROWSER_BIN" not in os.environ:
+        os.environ["BROWSER_BIN"] = "/usr/bin/chromium"
+    if "FRONTEND_URL" not in os.environ:
+        os.environ["FRONTEND_URL"] = "http://127.0.0.1:3000"
+
+
+_original_config_init = Config.__init__
+
+
+def _patched_config_init(self, *args, **kwargs):
+    _original_config_init(self, *args, **kwargs)
+    self.sandbox = False
+
+    extra_args = [
+        "--disable-gpu",
+        "--enable-automation",
+        "--no-zygote",
+        "--disable-namespace-sandbox",
+        "--disable-setuid-sandbox",
+    ]
+    for arg in extra_args:
+        if not any(existing == arg or existing.startswith(f"{arg}=") for existing in self.browser_args):
+            self.add_argument(arg)
+
+
+Config.__init__ = _patched_config_init
+
+_original_stop = browser_module.Browser.stop
+
+
+async def _async_stop(self):
+    return _original_stop(self)
+
+
+browser_module.Browser.stop = _async_stop
+EOF
+cat >"$E2E_SRC/tests/test_joke_flow.py" <<'EOF'
+import os
+
+import nodriver as uc
+import pytest
+
+JOKE_MARKERS = [
+    "Nobody believed the logs.",
+    "file bug reports.",
+    "fixed the bug too.",
+    "gained sentience.",
+    "had interfaces.",
+    "needed a sweater.",
+    "confessed immediately.",
+    "100% laughter.",
+    "stop blocking.",
+    "asked for an autograph.",
+]
+
+
+def _extract_text(result) -> str:
+    value = getattr(result, "value", result)
+    deep_value = getattr(value, "value", value)
+    return "" if deep_value is None else str(deep_value)
+
+
+@pytest.mark.asyncio
+async def test_joke_flow():
+    browser = await uc.start(
+        browser_executable_path=os.environ.get("BROWSER_BIN", "/usr/bin/chromium"),
+        headless=True,
+        no_sandbox=True,
+    )
+    try:
+        page = await browser.get(os.environ.get("FRONTEND_URL", "http://127.0.0.1:3000"))
+        name_field = await page.find("Name")
+        await name_field.click()
+        ready = ""
+        for _ in range(20):
+            ready = _extract_text(
+                await page.evaluate(
+                    "window.localStorage.getItem('rover_demo_ready')",
+                    return_by_value=True,
+                )
+            )
+            if ready == "1":
+                break
+            await page.sleep(0.5)
+        assert ready == "1"
+
+        dispatched_name = _extract_text(
+            await page.evaluate(
+                """
+                (() => {
+                  const name = "Go + Flutter + Python";
+                  window.dispatchEvent(
+                    new CustomEvent("rover-demo-fetch", {
+                      detail: name,
+                    }),
+                  );
+                  return name;
+                })()
+                """,
+                return_by_value=True,
+            )
+        )
+        assert dispatched_name == "Go + Flutter + Python"
+
+        joke_text = ""
+        for _ in range(20):
+            joke_text = _extract_text(
+                await page.evaluate(
+                    "window.localStorage.getItem('rover_demo_joke')",
+                    return_by_value=True,
+                )
+            )
+            if any(marker in joke_text for marker in JOKE_MARKERS):
+                break
+            await page.sleep(0.5)
+
+        assert any(marker in joke_text for marker in JOKE_MARKERS), joke_text
+    finally:
+        await browser.stop()
+EOF
+cat >"$E2E_SRC/scripts/init.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+uv sync --all-extras >/dev/null || uv sync >/dev/null
+uv run python - <<'PY'
+import nodriver
+print(f"nodriver ready: {nodriver.__file__}")
+PY
+EOF
+cat >"$E2E_SRC/Makefile" <<'EOF'
+FRONTEND_URL ?= http://127.0.0.1:3000
+BROWSER_BIN ?= /usr/bin/chromium
+
+.PHONY: setup test
+
+setup:
+	uv sync --all-extras || uv sync
+
+test:
+	FRONTEND_URL='$(FRONTEND_URL)' BROWSER_BIN='$(BROWSER_BIN)' uv run pytest -q
+EOF
+git_init_repo "$E2E_SRC"
+commit_all "$E2E_SRC" "Initial e2e demo"
+
+mkdir -p "$DEST/sources"
+git -C "$FRONTEND_SRC" clone --bare "$FRONTEND_SRC" "$DEST/sources/frontend.git" >/dev/null
+git -C "$BACKEND_SRC" clone --bare "$BACKEND_SRC" "$DEST/sources/backend.git" >/dev/null
+git -C "$E2E_SRC" clone --bare "$E2E_SRC" "$DEST/sources/e2e.git" >/dev/null
+materialize_bare_ref "$DEST/sources/frontend.git"
+materialize_bare_ref "$DEST/sources/backend.git"
+materialize_bare_ref "$DEST/sources/e2e.git"
+
+mkdir -p "$DEST/scripts"
+cat >"$DEST/Makefile" <<'EOF'
+PROJECTS=frontend backend e2e
+ROOT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: setup test test-frontend test-backend test-e2e validate
+
+BACKEND_PORT ?= 18080
+FRONTEND_PORT ?= 13000
+
+setup:
+	@if [ ! -d frontend/.git ]; then git clone sources/frontend.git frontend; fi
+	@if [ ! -d backend/.git ]; then git clone sources/backend.git backend; fi
+	@if [ ! -d e2e/.git ]; then git clone sources/e2e.git e2e; fi
+	$(MAKE) -C frontend setup
+	$(MAKE) -C backend setup
+	$(MAKE) -C e2e setup
+
+test: test-frontend test-backend
+
+test-frontend:
+	$(MAKE) -C frontend test
+
+test-backend:
+	$(MAKE) -C backend test
+
+test-e2e:
+	bash -euo pipefail -c '\
+	FRONTEND_PID=""; \
+	DATABASE_URL=$${DATABASE_URL:-postgres://postgres:postgres@postgres:5432/jokes?sslmode=disable} \
+	$(MAKE) -C $(ROOT_DIR)/backend run PORT=$(BACKEND_PORT) > /tmp/rover-demo-backend.log 2>&1 & BACKEND_PID=$$!; \
+	trap "kill $$BACKEND_PID $$FRONTEND_PID 2>/dev/null || true" EXIT; \
+	until curl -sf http://127.0.0.1:$(BACKEND_PORT)/healthz >/dev/null; do sleep 1; done; \
+	$(MAKE) -C $(ROOT_DIR)/frontend build API_BASE_URL=http://127.0.0.1:$(BACKEND_PORT) > /tmp/rover-demo-frontend-build.log 2>&1; \
+	python3 -m http.server $(FRONTEND_PORT) --directory $(ROOT_DIR)/frontend/build/web > /tmp/rover-demo-frontend.log 2>&1 & FRONTEND_PID=$$!; \
+	sleep 2; \
+	$(MAKE) -C $(ROOT_DIR)/e2e test FRONTEND_URL=http://127.0.0.1:$(FRONTEND_PORT) BROWSER_BIN=/usr/bin/chromium'
+
+validate: setup test test-e2e
+EOF
+cat >"$DEST/rover.json" <<'EOF'
+{
+  "version": "1.5",
+  "languages": [],
+  "mcps": [],
+  "packageManagers": [],
+  "taskManagers": [
+    "make"
+  ],
+  "attribution": true,
+  "sandbox": {
+    "agentImage": "rover-agent-local:latest",
+    "initScript": "scripts/system-init.sh",
+    "services": [
+      {
+        "name": "postgres",
+        "image": "postgres:15-alpine",
+        "ports": [5432],
+        "env": [
+          "POSTGRES_USER=postgres",
+          "POSTGRES_PASSWORD=postgres",
+          "POSTGRES_DB=jokes"
+        ],
+        "healthcheck": {
+          "cmd": "pg_isready -U postgres",
+          "interval": 5,
+          "timeout": 5,
+          "retries": 3,
+          "startPeriod": 10
+        },
+        "readyTimeout": 30
+      }
+    ]
+  },
+  "projects": [
+    {
+      "name": "frontend",
+      "path": "frontend",
+      "repository": "/workspace/sources/frontend.git",
+      "languages": [
+        "dart"
+      ],
+      "packageManagers": [
+        "pub"
+      ],
+      "initScript": "scripts/init.sh"
+    },
+    {
+      "name": "backend",
+      "path": "backend",
+      "repository": "/workspace/sources/backend.git",
+      "languages": [
+        "go"
+      ],
+      "packageManagers": [
+        "gomod"
+      ],
+      "initScript": "scripts/init.sh"
+    },
+    {
+      "name": "e2e",
+      "path": "e2e",
+      "repository": "/workspace/sources/e2e.git",
+      "languages": [
+        "python"
+      ],
+      "packageManagers": [
+        "uv"
+      ],
+      "initScript": "scripts/init.sh"
+    }
+  ]
+}
+EOF
+cat >"$DEST/scripts/system-init.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+sudo apt-get update -qq
+sudo apt-get install -y -qq chromium curl postgresql-client
+EOF
+cat >"$DEST/README.md" <<'EOF'
+# Rover Multi-Env Demo
+
+This workspace is generated for validating Rover against a single task that spans:
+
+- `frontend`: Flutter web UI
+- `backend`: Go API (backed by PostgreSQL)
+- `e2e`: Python `nodriver` browser tests
+- `postgres`: PostgreSQL 15 sidecar container (managed by Rover)
+
+The backend stores jokes in a Postgres database. When running under Rover, the
+Postgres sidecar is started automatically and is reachable at `postgres:5432`.
+Unit tests run without a database (the backend falls back to an in-memory list).
+
+Useful commands:
+
+- `make setup`
+- `make test`
+- `make test-e2e`
+- `make validate`
+EOF
+cat >"$DEST/AGENTS.md" <<'EOF'
+# Workspace Guide
+
+This workspace has 3 parts plus a database sidecar:
+
+- `frontend`: Flutter web UI
+- `backend`: Go API (stores jokes in PostgreSQL)
+- `e2e`: Python `nodriver` browser tests
+- `postgres` sidecar: PostgreSQL 15 (auto-started by Rover, reachable at `postgres:5432`)
+
+The backend connects to Postgres via `DATABASE_URL` env var.
+Default: `postgres://postgres:postgres@postgres:5432/jokes?sslmode=disable`
+Unit tests run without a database (falls back to in-memory seed list).
+
+Use the root commands first:
+
+- `make setup`: clone local child repos if needed and install each project
+- `make test`: run frontend and backend tests (no DB needed)
+- `make test-e2e`: run the full backend + frontend + browser flow (needs DB)
+- `make validate`: run `make setup`, `make test`, and `make test-e2e` in order
+
+Project-local commands also exist:
+
+- `make -C frontend test`
+- `make -C backend test`
+- `make -C e2e test`
+EOF
+cp "$DEST/AGENTS.md" "$DEST/CLAUDE.md"
+
+git -C "$DEST" init -b main >/dev/null
+git -C "$DEST" config user.name "Rover Demo"
+git -C "$DEST" config user.email "demo@example.com"
+git -C "$DEST" add -A
+git -C "$DEST" commit -m "Initial multi-env demo workspace" >/dev/null
+
+printf 'Demo workspace created at %s\n' "$DEST"

--- a/docs/branch-targeting-guide.md
+++ b/docs/branch-targeting-guide.md
@@ -1,0 +1,201 @@
+# Branch Targeting Guide
+
+How to create tasks from non-default branches and how branch state flows through the full rover lifecycle.
+
+## Quick reference
+
+| Operation | Branch used | Must specify? |
+| --------- | ----------- | ------------- |
+| `rover task --source-branch X` | Creates task branch from `X` | Only if not using current branch |
+| `rover iterate <id>` | Inherits from task creation | No |
+| `rover diff <id>` | Shows changes vs task branch tip | No |
+| `rover diff <id> --base` | Shows changes vs source branch HEAD at creation time | No |
+| `rover push <id>` | Pushes the task branch (not source) | No |
+| `rover rebase <id>` | Rebases onto current branch or `--base` | Optional `--base` |
+| `rover merge <id>` | Merges task branch into current branch | No |
+
+## Single-repo: task from a feature branch
+
+### Setup
+
+Any repo with a `rover.json` and multiple branches works. Example:
+
+```
+my-project/
+  main              ← default branch
+  feature/my-work   ← branch you want to task from
+  rover.json
+```
+
+### Create the task
+
+```bash
+cd my-project
+rover build -a claude:haiku            # build cache (once)
+rover task -a claude:haiku -w swe-tdd \
+  --source-branch feature/my-work \
+  "Add a /healthz endpoint. Add a test."
+```
+
+Rover creates a git worktree from `feature/my-work` with a new task branch (e.g. `rover/task-1-Abc123`). The task branch contains all commits from `feature/my-work`.
+
+### Verify
+
+```bash
+rover inspect <id>
+# Shows: Branch Name: rover/task-1-Abc123
+
+rover diff <id> --base
+# Shows: Comparing with base commit (<feature branch HEAD>)
+```
+
+### Iterate
+
+No need to re-specify the branch:
+
+```bash
+rover iterate <id> "Also add a timestamp to the response"
+```
+
+The iterate runs in the same worktree, on the same task branch, with the same base.
+
+### Push
+
+```bash
+rover push <id>
+```
+
+Pushes the **task branch** (`rover/task-1-Abc123`) to the remote. Does NOT push to `feature/my-work`.
+
+### Rebase
+
+```bash
+rover rebase <id>
+```
+
+Rebases the task branch onto the **current** branch (whatever you have checked out in the main repo). To rebase onto a specific branch:
+
+```bash
+rover rebase <id> --base feature/my-work
+```
+
+### Merge
+
+```bash
+git checkout feature/my-work   # switch to target branch first
+rover merge <id>               # merges task branch into current branch
+```
+
+## Multi-repo: task from a feature branch
+
+### Setup
+
+A workspace with child repos defined in `rover.json`:
+
+```json
+{
+  "version": "1.5",
+  "projects": [
+    {
+      "name": "backend",
+      "path": "backend",
+      "repository": "/workspace/sources/backend.git",
+      "ref": "main",
+      "languages": ["go"],
+      "packageManagers": ["gomod"]
+    },
+    {
+      "name": "frontend",
+      "path": "frontend",
+      "repository": "/workspace/sources/frontend.git",
+      "ref": "main",
+      "languages": ["python"],
+      "packageManagers": ["uv"]
+    }
+  ]
+}
+```
+
+The root workspace has branches (`main`, `feature/filters`). Each child repo also has its own branches (`main`, `feature/priority`, `feature/dark-mode`).
+
+### How branches map
+
+- `--source-branch` applies to the **root workspace** only
+- Child repos are cloned from their configured `ref` (e.g. `"ref": "main"`)
+- All repos share the same **task branch name** (e.g. `rover/task-1-Abc123`)
+
+```
+Root workspace:  feature/filters → rover/task-1-Abc123
+Backend child:   main            → rover/task-1-Abc123
+Frontend child:  main            → rover/task-1-Abc123
+```
+
+### Create the task
+
+```bash
+cd my-workspace
+rover build -a claude:haiku
+rover task -a claude:haiku -w swe-tdd \
+  --source-branch feature/filters \
+  "Add a GET /api/todos/count endpoint to the backend. Add a test."
+```
+
+The root worktree is created from `feature/filters`. Inside the container, child repos are cloned from their bare repos and checked out to their configured `ref`, then a task branch is created.
+
+### Push (multi-repo)
+
+```bash
+rover push <id>
+```
+
+Pushes the task branch from **all repos** (root + each child) to their respective remotes.
+
+### Rebase (multi-repo)
+
+```bash
+rover rebase <id>
+```
+
+- Root workspace: rebases onto current branch (or `--base`)
+- Each child repo: rebases onto its configured `ref` (from `rover.json`)
+
+### Changing child repo branches
+
+To have a child repo start from a different branch, change its `ref` in `rover.json`:
+
+```json
+{
+  "name": "backend",
+  "path": "backend",
+  "repository": "/workspace/sources/backend.git",
+  "ref": "feature/priority"
+}
+```
+
+Rebuild the cache after changing refs (`rover build`).
+
+## Key behaviors
+
+1. **Source branch is set once at task creation.** You do NOT need to re-specify it for iterate, push, rebase, or merge.
+
+2. **The task branch is what gets pushed/merged.** The source branch is only used to create the initial worktree. All subsequent operations work with the task branch.
+
+3. **Iterate inherits everything.** No branch flags needed — it runs in the existing task workspace.
+
+4. **Rebase uses current branch by default.** If you want to rebase onto a specific branch, use `--base`. For multi-repo, each child repo rebases onto its own `ref`.
+
+5. **Cache is branch-independent.** The same cache image works regardless of which source branch you use. You only need to rebuild when languages, packages, or init scripts change.
+
+## Verified end-to-end
+
+These scenarios were tested and confirmed working:
+
+| Scenario | Result |
+| -------- | ------ |
+| Single-repo: `rover task --source-branch feature/X` | Worktree created from feature branch |
+| Single-repo: `rover iterate <id>` (no branch flag) | Inherits source branch, runs in same worktree |
+| Single-repo: `rover diff <id> --base` | Shows base commit = feature branch HEAD |
+| Multi-repo: `rover task --source-branch feature/X` | Root from feature branch, children from their `ref` |
+| Multi-repo: child repos cloned inside container | Backend/frontend cloned from bare repos |
+| Multi-repo: cache hit after build | `Using cached setup image` confirmed |
+| Multi-repo: `/workspace/` repository paths | Resolved to host paths, mounted into container |

--- a/docs/branch-targeting-guide.md
+++ b/docs/branch-targeting-guide.md
@@ -195,7 +195,29 @@ These scenarios were tested and confirmed working:
 | Single-repo: `rover task --source-branch feature/X` | Worktree created from feature branch |
 | Single-repo: `rover iterate <id>` (no branch flag) | Inherits source branch, runs in same worktree |
 | Single-repo: `rover diff <id> --base` | Shows base commit = feature branch HEAD |
+| Single-repo: `rover push <id> -m "..."` | Pushes task branch to remote (not source branch) |
+| Single-repo: `rover rebase <id> --base main -f` | Rebases task branch onto main |
+| Single-repo: `rover merge <id>` | Merges task branch into current branch |
 | Multi-repo: `rover task --source-branch feature/X` | Root from feature branch, children from their `ref` |
 | Multi-repo: child repos cloned inside container | Backend/frontend cloned from bare repos |
+| Multi-repo: `rover push <id>` | Root workspace pushed; child repos fail (see known issue) |
+| Multi-repo: `rover rebase <id> --base main -f` | All repos (root + children) rebased onto main |
+| Multi-repo: `rover merge <id>` | Merges root task branch into current branch |
 | Multi-repo: cache hit after build | `Using cached setup image` confirmed |
 | Multi-repo: `/workspace/` repository paths | Resolved to host paths, mounted into container |
+
+## Known issues
+
+### Multi-repo push fails for child repos with local bare repos
+
+When child repos are cloned from local bare repos (via `/workspace/sources/*.git`), their git remote inside the worktree points to `/workspace-repos/N` (the container mount path). After the container exits, this path doesn't exist on the host, so `rover push` fails for child repos.
+
+**Workaround**: Manually set the remote URL in each child repo worktree before pushing:
+
+```bash
+WORKSPACE=$(rover inspect <id> 2>&1 | grep "Git Workspace" | awk '{print $NF}')
+cd "$WORKSPACE/backend"
+git remote set-url origin /path/to/real/backend-remote.git
+```
+
+This only affects local bare repo setups. When child repos point to real remote URLs (GitHub, GitLab, etc.), push works correctly.

--- a/docs/demo-project-guide.md
+++ b/docs/demo-project-guide.md
@@ -1,0 +1,315 @@
+# Demo Project Guide
+
+How to create, build, and run the multi-environment demo that validates the `swe-tdd` workflow across Python, Go, Flutter, and a PostgreSQL sidecar.
+
+## Prerequisites
+
+- Docker (or Podman)
+- Rover CLI built and on PATH (`pnpm build && pnpm link --global` from repo root)
+- A locally built agent image **or** the published `ghcr.io/endorhq/rover/agent-dev:latest`
+- Claude API key configured (`~/.claude/` credentials present)
+
+### Building a local agent image
+
+If you are working from an unreleased branch (e.g. `feat/multi-env-demo-validation`), the published agent image may not contain the latest workflow/runtime changes. Build a local image instead:
+
+```bash
+# From the rover repo root
+docker build -t rover-agent-local:latest -f packages/agent/Dockerfile .
+```
+
+The generated demo pins `sandbox.agentImage` to `rover-agent-local:latest`. To use the published image instead, edit the generated `rover.json` and remove (or change) the `sandbox.agentImage` field.
+
+## Step 1 — Generate the demo workspace
+
+```bash
+bash demos/create-multi-env-demo.sh          # default: /tmp/rover-multi-env-demo
+bash demos/create-multi-env-demo.sh ~/my-demo # or pick your own path
+```
+
+This creates a self-contained workspace with three sub-projects and a database sidecar:
+
+| Component  | Language     | Package Manager | What it does                              |
+| ---------- | ------------ | --------------- | ----------------------------------------- |
+| `frontend` | Dart/Flutter | `pub`           | Web UI with a "get joke" button           |
+| `backend`  | Go           | `gomod`         | HTTP API that stores/retrieves jokes in PG |
+| `e2e`      | Python       | `uv`            | Browser tests via `nodriver`/Chromium     |
+| `postgres` | —            | —               | PostgreSQL 15 sidecar (managed by Rover)  |
+
+### How the Postgres sidecar works
+
+The `rover.json` declares a service container in `sandbox.services[]`. When Rover starts a task:
+
+1. Rover creates an isolated Docker network for the task
+2. Rover starts the `postgres:15-alpine` container on that network
+3. Rover waits for `pg_isready` healthcheck to pass
+4. The task container joins the same network — Postgres is reachable at `postgres:5432`
+5. The Go backend connects via `DATABASE_URL` (default: `postgres://postgres:postgres@postgres:5432/jokes?sslmode=disable`)
+6. On task completion, Rover tears down the sidecar and network
+
+Unit tests (`make test`) run **without** Postgres — the backend falls back to an in-memory seed list when `db` is nil.
+
+### Generated layout
+
+```
+<workspace>/
+├── rover.json              # Multi-project config + Postgres sidecar
+├── Makefile                # Root orchestration (setup / test / test-e2e / validate)
+├── AGENTS.md / CLAUDE.md   # Agent instructions
+├── README.md
+├── scripts/
+│   └── system-init.sh      # OS-level setup (Chromium, curl, postgresql-client)
+└── sources/                # Bare git repos (cloned at task time)
+    ├── frontend.git
+    ├── backend.git
+    └── e2e.git
+```
+
+Sub-projects are **not** checked out yet — `make setup` (or Rover at task time) clones them from the bare repos in `sources/`.
+
+## Step 2 — Verify the workspace manually (optional)
+
+Before involving Rover, confirm the demo projects work on their own:
+
+```bash
+cd /tmp/rover-multi-env-demo
+
+make setup      # clone sub-repos + install deps
+make test       # run frontend + backend unit tests (no DB needed)
+make test-e2e   # full browser flow (backend → frontend → Python e2e)
+make validate   # all of the above in sequence
+```
+
+`make validate` is the single command that proves the entire workspace is healthy.
+
+Note: `make test` works without Postgres (in-memory fallback). `make test-e2e` needs a running Postgres if the backend is configured to use one. Under Rover, the sidecar handles this automatically.
+
+## Step 3 — Build the Rover cache image
+
+```bash
+cd /tmp/rover-multi-env-demo
+rover build -a claude:haiku
+```
+
+This creates a Docker image (`rover-cache:<hash>`) with:
+
+- Go, Dart/Flutter, and Python installed
+- All package manager dependencies resolved
+- Chromium and postgresql-client installed (via `scripts/system-init.sh`)
+
+The cache hash is derived from languages, package managers, init scripts, repo revisions, and agent image ID. Rebuilds only when inputs change.
+
+To verify the cache was created:
+
+```bash
+docker images 'rover-cache:*'
+```
+
+### Troubleshooting cache builds
+
+| Symptom | Fix |
+| ------- | --- |
+| Build fails during Go install | Ensure the agent image has enough disk. Go installs under `/opt/go`. |
+| Chromium not found at task time | Confirm `scripts/system-init.sh` installs `chromium` and runs during build. |
+| Stale cache after code changes | Delete old images: `docker rmi $(docker images -q 'rover-cache:*')` and rebuild. |
+| Per-project init fails during build | Expected — project repos are only cloned at task time, not build time. Per-project init scripts run inside the task container. |
+| Postgres sidecar not starting | Check `docker ps` for `rover-svc-*-postgres` containers. Verify the image `postgres:15-alpine` is pullable. |
+
+## Step 4 — Run a demo task with `swe-tdd`
+
+### Simple task (recommended for demos)
+
+Use `-a claude:haiku` for fast, cheap runs:
+
+```bash
+cd /tmp/rover-multi-env-demo
+
+rover task -a claude:haiku -w swe-tdd \
+  "Add a /api/joke/random endpoint to the backend that returns a single random joke without requiring query parameters. It should read from the database. Add a corresponding unit test."
+```
+
+This is a simple, self-contained Go task. The agent will:
+
+1. Analyze the codebase (context step)
+2. Plan a TDD approach
+3. Write a failing test first
+4. Implement the endpoint
+5. Loop until tests pass
+6. Review and summarize
+
+### Database-focused task
+
+```bash
+rover task -a claude:haiku -w swe-tdd \
+  "Add a /api/joke POST endpoint that accepts a JSON body with a 'template' field and inserts a new joke into the database. Return 201 on success. Add a unit test."
+```
+
+### Cross-project task
+
+```bash
+rover task -a claude:haiku -w swe-tdd \
+  "Add a 'joke count' display to the frontend that calls /api/joke/count on the backend and shows the total number of jokes stored in the database. Add unit tests for both the frontend widget and the backend endpoint."
+```
+
+### Full validation task
+
+Use `test_command` override to run the full workspace validation:
+
+```bash
+rover task -a claude:haiku -w swe-tdd \
+  --test-command "make validate" \
+  "Add input validation to the /api/joke endpoint: return 400 if the 'name' parameter is empty. Add a unit test."
+```
+
+### Monitoring a running task
+
+```bash
+rover logs <task-id>       # stream logs
+rover inspect <task-id>    # show task metadata and status
+rover list                 # list all tasks
+```
+
+## Step 5 — Iterate, merge, or clean up
+
+```bash
+# Refine the task with a follow-up instruction
+rover iterate <task-id> "Also add a timestamp field to the /healthz response"
+
+# View the diff
+rover diff <task-id>
+
+# Merge the task branch into main
+rover merge <task-id>
+
+# Or clean up
+rover delete <task-id>
+```
+
+## Example task ideas for demos
+
+These are intentionally simple tasks suitable for `claude:haiku`:
+
+### Backend only (Go + Postgres)
+
+- "Add a `/api/joke/random` endpoint that returns a single random joke without requiring query parameters. Add a unit test."
+- "Add input validation to the `/api/joke` endpoint: return 400 if the `name` parameter is empty. Add a test."
+- "Add a `DELETE /api/joke/:id` endpoint that removes a joke from the database. Add a test."
+- "Add a `GET /api/jokes` endpoint that returns all jokes from the database as a JSON array. Add a test."
+
+### Frontend only (Flutter)
+
+- "Add a loading spinner that shows while the joke API request is in flight. Add a widget test."
+- "Add a character counter below the name input field. Add a widget test."
+
+### Cross-project (Go + Flutter)
+
+- "Add a `/api/jokes` endpoint to the backend that returns all jokes as a JSON array. Update the frontend to show a 'View All' button that fetches and displays the list. Add tests for both."
+
+### E2E (Python)
+
+- "Update the e2e test to also verify that the joke text is non-empty after fetching."
+
+## Configuration reference
+
+The generated `rover.json`:
+
+```json
+{
+  "version": "1.5",
+  "languages": [],
+  "mcps": [],
+  "packageManagers": [],
+  "taskManagers": ["make"],
+  "attribution": true,
+  "sandbox": {
+    "agentImage": "rover-agent-local:latest",
+    "initScript": "scripts/system-init.sh",
+    "services": [
+      {
+        "name": "postgres",
+        "image": "postgres:15-alpine",
+        "ports": [5432],
+        "env": [
+          "POSTGRES_USER=postgres",
+          "POSTGRES_PASSWORD=postgres",
+          "POSTGRES_DB=jokes"
+        ],
+        "healthcheck": {
+          "cmd": "pg_isready -U postgres",
+          "interval": 5,
+          "timeout": 5,
+          "retries": 3,
+          "startPeriod": 10
+        },
+        "readyTimeout": 30
+      }
+    ]
+  },
+  "projects": [
+    {
+      "name": "frontend",
+      "path": "frontend",
+      "repository": "/workspace/sources/frontend.git",
+      "languages": ["dart"],
+      "packageManagers": ["pub"],
+      "initScript": "scripts/init.sh"
+    },
+    {
+      "name": "backend",
+      "path": "backend",
+      "repository": "/workspace/sources/backend.git",
+      "languages": ["go"],
+      "packageManagers": ["gomod"],
+      "initScript": "scripts/init.sh"
+    },
+    {
+      "name": "e2e",
+      "path": "e2e",
+      "repository": "/workspace/sources/e2e.git",
+      "languages": ["python"],
+      "packageManagers": ["uv"],
+      "initScript": "scripts/init.sh"
+    }
+  ]
+}
+```
+
+Key fields:
+
+| Field | Purpose |
+| ----- | ------- |
+| `taskManagers: ["make"]` | Installs `make` in the container |
+| `sandbox.agentImage` | Docker image for the agent runtime (remove to use published default) |
+| `sandbox.initScript` | Runs during `rover build` — use for OS packages like Chromium |
+| `sandbox.services[]` | Sidecar containers started before each task (Postgres in this demo) |
+| `sandbox.services[].healthcheck` | Rover polls this before starting the task container |
+| `projects[].repository` | Path to bare git repo (resolved inside the container as `/workspace/sources/...`) |
+| `projects[].initScript` | Runs at task time after the project repo is cloned (e.g. `flutter pub get`, `go mod download`) |
+
+### Service container fields
+
+| Field | Required | Purpose |
+| ----- | -------- | ------- |
+| `name` | yes | Hostname on the task network (e.g. `postgres`) |
+| `image` | yes | Docker image (e.g. `postgres:15-alpine`) |
+| `ports` | no | Informational — all ports are reachable on the task network |
+| `env` | no | Environment variables for the container |
+| `volumes` | no | Volume mounts (`name:/path` or `/host:/container`) |
+| `healthcheck.cmd` | no | Command to check readiness |
+| `healthcheck.interval` | no | Seconds between checks (default: 5) |
+| `healthcheck.timeout` | no | Timeout per check (default: 5) |
+| `healthcheck.retries` | no | Retries before unhealthy (default: 3) |
+| `healthcheck.startPeriod` | no | Delay before first check (default: 0) |
+| `readyTimeout` | no | Max seconds to wait for healthy (default: 60) |
+| `command` | no | Override container command (string or array) |
+
+## Tips
+
+- **Use `claude:haiku` for demos.** It's fast and cheap. Save `claude:sonnet` or `claude:opus` for real work.
+- **Keep tasks small and focused.** One endpoint + one test is ideal for a demo.
+- **`make validate` is the gold standard.** If it passes, the whole workspace is healthy.
+- **Cache builds are slow the first time** (installs Go, Flutter, Python, Chromium). Subsequent runs reuse the cached image.
+- **The agent cannot install OS packages at task time.** Everything that needs `apt-get` must go in `scripts/system-init.sh` and be baked into the cache image via `rover build`.
+- **Per-project init scripts run at task time**, not build time, because the project repos are cloned fresh for each task.
+- **The Postgres sidecar starts automatically** when Rover creates a task. No manual setup needed. The backend's `DATABASE_URL` defaults to the sidecar hostname.
+- **Unit tests don't need Postgres.** The Go backend falls back to in-memory jokes when `db` is nil, so `make test` works anywhere.

--- a/docs/multi-env-workspaces.md
+++ b/docs/multi-env-workspaces.md
@@ -257,7 +257,7 @@ Do not rely on in-task OS package installation for these runs. Task containers i
 
 The reproducible demo generator lives at:
 
-- [demos/create-multi-env-demo.sh](/home/dev/rover/demos/create-multi-env-demo.sh)
+- [demos/create-multi-env-demo.sh](../demos/create-multi-env-demo.sh)
 
 It generates:
 

--- a/docs/multi-env-workspaces.md
+++ b/docs/multi-env-workspaces.md
@@ -1,0 +1,277 @@
+# Multi-Repo Multi-Env Workspaces
+
+This document describes the Rover workspace shape for a single task that spans multiple repositories and multiple language/runtime environments.
+
+Status:
+
+- Config and setup support are implemented.
+- `push` support for workspace repos is implemented.
+- `rebase` support for workspace repos is implemented in Rover.
+- The generated Flutter + Go + Python demo now validates from a clean workspace, from a fresh clone, and from a fresh-clone Rover task running `swe-tdd` with `make validate`.
+
+## Use case
+
+One Rover task works across:
+
+- a Flutter/Dart web frontend
+- a Go backend
+- a Python `nodriver` E2E test project
+
+Each project can live in its own git repository and keep its own install and test requirements.
+
+## Configuration model
+
+Use `rover.json` at the workspace root.
+
+Root-level fields still apply as usual:
+
+- `languages`
+- `packageManagers`
+- `taskManagers`
+- `sandbox.initScript`
+
+Add `projects[]` entries for each repo in the task workspace.
+
+Example:
+
+```json
+{
+  "version": "1.4",
+  "languages": [],
+  "mcps": [],
+  "packageManagers": [],
+  "taskManagers": ["make"],
+  "attribution": true,
+  "sandbox": {
+    "initScript": "scripts/system-init.sh"
+  },
+  "projects": [
+    {
+      "name": "frontend",
+      "path": "frontend",
+      "repository": "/workspace/sources/frontend.git",
+      "languages": ["dart"],
+      "packageManagers": ["pub"],
+      "initScript": "scripts/init.sh"
+    },
+    {
+      "name": "backend",
+      "path": "backend",
+      "repository": "/workspace/sources/backend.git",
+      "languages": ["go"],
+      "packageManagers": ["gomod"],
+      "initScript": "scripts/init.sh"
+    },
+    {
+      "name": "e2e",
+      "path": "e2e",
+      "repository": "/workspace/sources/e2e.git",
+      "languages": ["python"],
+      "packageManagers": ["uv"],
+      "initScript": "scripts/init.sh"
+    }
+  ]
+}
+```
+
+## How Rover handles it
+
+At task startup Rover now:
+
+- installs the union of all languages, package managers, and task managers
+- clones each configured project repository into its configured `path`
+- creates or reuses the task branch in each cloned repository
+- resolves dependencies for the root workspace and each configured project
+- runs the root init script and each project init script
+
+During follow-up commands:
+
+- `rover push` walks the root workspace plus configured project repos
+- `rover rebase` walks the root workspace plus configured project repos
+
+## Practical guidance
+
+- Put shared system package installation in the root `sandbox.initScript`.
+- Put repo-specific setup in each project `initScript`.
+- Put project-specific dependency managers on the project entry, not only at the root.
+- Keep a root `Makefile`, `justfile`, or `Taskfile` that drives the combined test workflow.
+- Prefer a landing-repo pattern: root repo contains orchestration, docs, and task entrypoints; child repos contain the actual app/test code.
+- Put minimal root guidance in `AGENTS.md` and `CLAUDE.md` at the workspace root because Rover tasks start at `/workspace`.
+- Use local bare repos or reachable remotes for `projects[].repository`.
+
+## Recommended usage
+
+Use one root landing repo as the task entrypoint.
+
+- Put `rover.json`, `Makefile`, `AGENTS.md`, `CLAUDE.md`, and shared docs at the workspace root.
+- Put each app/test project in its own git repo under a stable child path such as `frontend`, `backend`, and `e2e`.
+- Keep the root repo lightweight. It should orchestrate the workspace, not duplicate child project logic.
+
+Use root `make` targets as the stable Rover interface.
+
+- `make setup` prepares all child repos for humans and for explicit validation runs outside Rover.
+- `make test` runs the default fast test pass Rover should prefer for normal TDD loops.
+- `make test-e2e` runs the cross-project flow.
+- `make validate` runs `make setup`, `make test`, and `make test-e2e` as one explicit full-workspace check.
+
+Use per-project `Makefile`s to keep ownership local.
+
+- `frontend/Makefile` owns Flutter setup, test, build, and run targets.
+- `backend/Makefile` owns Go setup, test, and run targets.
+- `e2e/Makefile` owns Python setup and browser-test targets.
+
+Use Rover commands this way.
+
+- Run `rover build` after changing shared image/setup inputs such as languages, package managers, `sandbox.initScript`, or child-project dependency manifests that should be baked into the cache image.
+- Run `rover task -a claude:haiku -w swe-tdd` from the root landing repo for normal work.
+- For explicit whole-workspace validation, pass or confirm the root command override `make validate`.
+- Use `rover push` and `rover rebase` from the landing repo; Rover now walks the root repo plus configured child repos.
+
+Keep cache expectations clear.
+
+- Shared tools and OS packages should be baked into the Rover cache image.
+- Child repos are still materialized into a fresh task workspace for isolation.
+- Repo-specific setup commands may still run per task, but multi-repo `rover build` now materializes child repos during build so dependency-heavy setup can be cached when the relevant manifests are part of the cache key.
+
+Recommended command shape:
+
+- Root `make setup`: clone local child repos when needed and run each child project's setup command.
+- Root `make test`: run the unit/integration tests Rover should prefer by default.
+- Root `make test-e2e`: run the full cross-project browser flow.
+- Root `make validate`: optional but recommended for explicit workspace verification runs that must execute setup, unit tests, and e2e in one command.
+- Child project `Makefile`s may still expose `setup`, `test`, `build`, or `run` for local use.
+- Keep identical minimal `AGENTS.md` and `CLAUDE.md` files at the workspace root, because Rover tasks enter at `/workspace`.
+
+Example root `Makefile` shape:
+
+```make
+ROOT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+BACKEND_PORT ?= 18080
+FRONTEND_PORT ?= 13000
+
+setup:
+	@if [ ! -d frontend/.git ]; then git clone sources/frontend.git frontend; fi
+	@if [ ! -d backend/.git ]; then git clone sources/backend.git backend; fi
+	@if [ ! -d e2e/.git ]; then git clone sources/e2e.git e2e; fi
+	$(MAKE) -C frontend setup
+	$(MAKE) -C backend setup
+	$(MAKE) -C e2e setup
+
+test:
+	$(MAKE) -C frontend test
+	$(MAKE) -C backend test
+
+test-e2e:
+	bash -euo pipefail -c '\
+	$(MAKE) -C $(ROOT_DIR)/backend run PORT=$(BACKEND_PORT) > /tmp/demo-backend.log 2>&1 & BACKEND_PID=$$!; \
+	trap "kill $$BACKEND_PID $$FRONTEND_PID 2>/dev/null || true" EXIT; \
+	until curl -sf http://127.0.0.1:$(BACKEND_PORT)/healthz >/dev/null; do sleep 1; done; \
+	$(MAKE) -C $(ROOT_DIR)/frontend build API_BASE_URL=http://127.0.0.1:$(BACKEND_PORT) > /tmp/demo-frontend-build.log 2>&1; \
+	python3 -m http.server $(FRONTEND_PORT) --directory $(ROOT_DIR)/frontend/build/web > /tmp/demo-frontend.log 2>&1 & FRONTEND_PID=$$!; \
+	sleep 2; \
+	$(MAKE) -C $(ROOT_DIR)/e2e test FRONTEND_URL=http://127.0.0.1:$(FRONTEND_PORT) BROWSER_BIN=/usr/bin/chromium'
+
+validate: setup test test-e2e
+```
+
+Example child `Makefile`s:
+
+```make
+# frontend/Makefile
+.PHONY: setup test build
+
+API_BASE_URL ?= http://127.0.0.1:8080
+
+setup:
+	flutter pub get
+
+test:
+	flutter test
+
+build:
+	flutter build web --dart-define=API_BASE_URL=$(API_BASE_URL)
+```
+
+```make
+# backend/Makefile
+.PHONY: setup test run
+
+PORT ?= 8080
+
+setup:
+	go mod download
+
+test:
+	go test ./...
+
+run:
+	PORT=$(PORT) go run .
+```
+
+```make
+# e2e/Makefile
+FRONTEND_URL ?= http://127.0.0.1:3000
+BROWSER_BIN ?= /usr/bin/chromium
+
+.PHONY: setup test
+
+setup:
+	uv sync --all-extras || uv sync
+
+test:
+	FRONTEND_URL='$(FRONTEND_URL)' BROWSER_BIN='$(BROWSER_BIN)' uv run pytest -q
+```
+
+For this demo, the Python test uses `nodriver` against the built Flutter web app and a small browser-side test hook. That hook exists because raw headless interaction with Flutter web semantics was materially less reliable than the rest of the stack.
+
+## About `make setup`
+
+Rover still clones and prepares the configured child repositories during normal task setup.
+
+Use root `make setup` for:
+
+- local development outside Rover
+- rebuilding a landing repo workspace by hand
+- giving the workflow and humans one obvious bootstrap command
+
+Do not treat `make setup` as a replacement for Rover's internal multi-project clone/setup logic.
+
+## Workflow guidance
+
+For normal coding tasks, Rover should prefer the root `make test` command when the workspace is `make`-driven.
+
+For explicit workspace verification tasks, prefer one root command that covers the whole flow:
+
+- `make validate`, if the workspace defines it
+- otherwise a workflow `test_command` override such as `make setup && make test && make test-e2e`
+
+The validated live path for this demo is:
+
+- `rover task -a claude:haiku -w swe-tdd`
+- workflow test override: `make validate`
+- result: successful fresh-clone Rover task on cached image with Flutter, Go, and Python tests all passing
+
+Do not rely on in-task OS package installation for these runs. Task containers intentionally drop broad sudo after setup, so OS packages belong in `sandbox.initScript`, image config, or `rover build`.
+
+## Demo workspace
+
+The reproducible demo generator lives at:
+
+- [demos/create-multi-env-demo.sh](/home/dev/rover/demos/create-multi-env-demo.sh)
+
+It generates:
+
+- one root Rover workspace
+- three project repositories
+- a Flutter frontend
+- a Go backend
+- a Python `nodriver` E2E suite
+- root `AGENTS.md` and `CLAUDE.md`
+- a root `Makefile` with `setup`, `test`, and `test-e2e`
+- a root `make validate` target for one-shot Rover validation
+
+## Current caveats
+
+- First-time container/image setup is expensive because Flutter and Chromium installation are heavy.
+- `nodriver` currently emits teardown warnings after the e2e test passes. They did not fail the validated runs, but the warnings are real.
+- Live Rover workflow execution still depends on valid agent auth in the local environment. The multi-env workspace path itself is now validated with Claude auth present.

--- a/docs/multi-env-workspaces.md
+++ b/docs/multi-env-workspaces.md
@@ -270,6 +270,131 @@ It generates:
 - a root `Makefile` with `setup`, `test`, and `test-e2e`
 - a root `make validate` target for one-shot Rover validation
 
+## Service dependencies (sidecars)
+
+Rover supports per-task service containers for infrastructure dependencies like databases, caches, and message brokers. Each task gets its own isolated set of services on a dedicated Docker network — no cross-task conflicts.
+
+### Configuration
+
+Add `sandbox.services` to your `rover.json`:
+
+```json
+{
+  "version": "1.5",
+  "languages": ["python"],
+  "packageManagers": ["uv"],
+  "sandbox": {
+    "services": [
+      {
+        "name": "postgres",
+        "image": "postgres:16",
+        "env": ["POSTGRES_PASSWORD=test", "POSTGRES_DB=myapp"],
+        "ports": [5432],
+        "healthcheck": {
+          "cmd": "pg_isready -U postgres",
+          "interval": 5,
+          "retries": 5,
+          "startPeriod": 10
+        },
+        "readyTimeout": 60
+      },
+      {
+        "name": "redis",
+        "image": "redis:7-alpine",
+        "ports": [6379],
+        "healthcheck": {
+          "cmd": "redis-cli ping"
+        }
+      }
+    ]
+  }
+}
+```
+
+### How it works
+
+When a task starts, Rover:
+
+1. Creates a Docker network named `rover-services-{taskId}-{iteration}`
+2. Starts each service container on that network with the service `name` as hostname
+3. Waits for services with healthchecks to become healthy (up to `readyTimeout` seconds)
+4. Attaches the task container to the same network
+5. Tears down all service containers and the network when the task stops
+
+The task container reaches services by name: `postgres:5432`, `redis:6379`.
+
+### Service fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Hostname on the task network |
+| `image` | yes | Docker image |
+| `ports` | no | Informational — all ports are reachable on the task network |
+| `env` | no | Environment variables (`KEY=VALUE` strings) |
+| `volumes` | no | Volume mounts (same syntax as Docker `-v`) |
+| `healthcheck` | no | Health check config — services without one are assumed ready immediately |
+| `command` | no | Override the image entrypoint command |
+| `readyTimeout` | no | Max seconds to wait for healthy (default: 60) |
+
+### Healthcheck fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `cmd` | (required) | Command to run inside the container |
+| `interval` | 5 | Seconds between checks |
+| `timeout` | 5 | Seconds before a check times out |
+| `retries` | 3 | Failures before unhealthy |
+| `startPeriod` | 0 | Grace period before first check |
+
+### Important notes
+
+- Services are **runtime-only** — `rover build` does not start them. They don't affect the cache image.
+- Services work with both Docker and Podman backends.
+- Network filtering (`sandbox.network`) applies to external traffic only. Containers on the same task network always reach each other.
+- Service names must be unique within a workspace.
+
+### Multi-repo workspaces with services
+
+For the multi-repo pattern, services are shared across all sub-projects. Define them once at `sandbox.services` — the backend, frontend, and e2e projects all connect to the same `postgres` and `redis` on the task network.
+
+Example combined config:
+
+```json
+{
+  "version": "1.5",
+  "taskManagers": ["make"],
+  "sandbox": {
+    "initScript": "scripts/system-init.sh",
+    "services": [
+      {
+        "name": "postgres",
+        "image": "postgres:16",
+        "env": ["POSTGRES_PASSWORD=test", "POSTGRES_DB=app"],
+        "healthcheck": { "cmd": "pg_isready -U postgres" }
+      }
+    ]
+  },
+  "projects": [
+    {
+      "name": "backend",
+      "path": "backend",
+      "repository": "/workspace/sources/backend.git",
+      "languages": ["go"],
+      "packageManagers": ["gomod"]
+    },
+    {
+      "name": "frontend",
+      "path": "frontend",
+      "repository": "/workspace/sources/frontend.git",
+      "languages": ["dart"],
+      "packageManagers": ["pub"]
+    }
+  ]
+}
+```
+
+The backend connects to `postgres:5432` during tests, and the same database is available to e2e tests.
+
 ## Current caveats
 
 - First-time container/image setup is expensive because Flutter and Chromium installation are heavy.

--- a/docs/multi-env-workspaces.md
+++ b/docs/multi-env-workspaces.md
@@ -81,8 +81,8 @@ At task startup Rover now:
 - installs the union of all languages, package managers, and task managers
 - clones each configured project repository into its configured `path`
 - creates or reuses the task branch in each cloned repository
-- resolves dependencies for the root workspace and each configured project
 - runs the root init script and each project init script
+- resolves dependencies for the root workspace and each configured project
 
 During follow-up commands:
 

--- a/docs/tracking/multi-env-demo-validation.md
+++ b/docs/tracking/multi-env-demo-validation.md
@@ -5,8 +5,9 @@
 Validate that Rover can run a single task against a multi-repo workspace with:
 
 - Flutter/Dart web frontend
-- Go backend
+- Go backend (backed by PostgreSQL)
 - Python `nodriver` E2E tests
+- PostgreSQL sidecar container
 
 Each part should have its own git repository, its own install requirements, and tests that fit the `swe-tdd` workflow.
 
@@ -36,13 +37,14 @@ Each part should have its own git repository, its own install requirements, and 
 ## Demo shape
 
 - `demo/frontend`: Flutter web app
-- `demo/backend`: Go API
+- `demo/backend`: Go API (stores jokes in PostgreSQL)
 - `demo/e2e`: Python `nodriver` tests
+- `postgres` sidecar: PostgreSQL 15 (auto-started by Rover via `sandbox.services[]`)
 
 Shared demo behavior:
 
 - Frontend renders a simple form/button.
-- Backend returns one random joke from a list of 10.
+- Backend stores seed jokes in PostgreSQL on startup and reads from the DB for each request. Falls back to in-memory seed list when no DB is available (unit tests).
 - E2E test opens the frontend, triggers the same Dart fetch path from the browser, and asserts a joke is shown.
 
 ## Resolved questions
@@ -95,6 +97,11 @@ Shared demo behavior:
 - [x] Validate `rover task -a claude:haiku -w swe-tdd` against a fresh clone using `test_command=make validate`
 - [x] Validate `rover rebase` against the demo workspace
 - [x] Draft user-facing setup/configuration doc after command validation
+- [ ] Add PostgreSQL sidecar to demo (`sandbox.services[]` in `rover.json`)
+- [ ] Update Go backend to store/retrieve jokes from Postgres
+- [ ] Validate sidecar lifecycle (start, healthcheck, teardown)
+- [ ] Validate `rover task -a claude:haiku -w swe-tdd` with Postgres sidecar
+- [ ] Write user-facing demo guide: `docs/demo-project-guide.md`
 
 ## Validated commands
 

--- a/docs/tracking/multi-env-demo-validation.md
+++ b/docs/tracking/multi-env-demo-validation.md
@@ -1,0 +1,130 @@
+# Multi-Env Demo Validation
+
+## Goal
+
+Validate that Rover can run a single task against a multi-repo workspace with:
+
+- Flutter/Dart web frontend
+- Go backend
+- Python `nodriver` E2E tests
+
+Each part should have its own git repository, its own install requirements, and tests that fit the `swe-tdd` workflow.
+
+## Working branch
+
+- `feat/multi-env-demo-validation`
+
+## Desired end state
+
+- One Rover workspace can define multiple sub-projects.
+- Sandbox/container setup installs everything needed for all sub-projects.
+- A task can work across frontend, backend, and tests in one run.
+- `rebase` and `push` behave correctly for the resulting workspace layout.
+- Demo project exists locally and is usable for validation.
+
+## Audit checklist
+
+- [x] Confirm current `rover.json` schema for multi-project support.
+- [x] Confirm task setup scripts install root and per-project requirements.
+- [x] Confirm container image cache hash includes project-specific setup.
+- [x] Confirm project cloning/setup works for multiple repositories.
+- [x] Confirm `task` works against a multi-project workspace.
+- [x] Confirm `rebase` behavior with nested repos/submodules or sibling repos.
+- [x] Confirm `push` behavior with nested repos/submodules or sibling repos.
+- [x] Confirm `swe-tdd`-style root commands can build/test the demo.
+
+## Demo shape
+
+- `demo/frontend`: Flutter web app
+- `demo/backend`: Go API
+- `demo/e2e`: Python `nodriver` tests
+
+Shared demo behavior:
+
+- Frontend renders a simple form/button.
+- Backend returns one random joke from a list of 10.
+- E2E test opens the frontend, triggers the same Dart fetch path from the browser, and asserts a joke is shown.
+
+## Open questions
+
+- [ ] Best repo layout for "3 separate gits" inside one Rover workspace:
+  placeholder choice is nested independent repos under one parent workspace.
+- [ ] Whether Rover should treat these as cloned sub-project repos, git submodules, or local repos attached by path.
+- [ ] Exact `nodriver` companion packages/models to preinstall for a realistic baseline.
+
+## Findings
+
+- Multi-project schema support already existed via `projects[]` with per-project language, package manager, task manager, repository, ref, and init script fields.
+- Runtime dependency resolution was still root-only. Fixed by iterating root plus per-project package managers during sandbox startup.
+- External repositories were being cloned onto base branches only. Fixed by creating or reusing the task branch inside each cloned project repo.
+- `projects[].initScript` for cloned repos was effectively broken because Rover tried to mount the script from the host before the repo existed. Fixed by executing project init scripts from the cloned workspace path.
+- `push` was still single-repo. Fixed by iterating the root workspace plus configured workspace repositories and pushing each repo branch.
+- The default `ghcr.io/endorhq/rover/agent-dev:latest` image is currently stale for this branch's workflow/runtime changes. It still bundles an older `@endorhq/agent` runtime that only validates `agent` and `command` steps, so `swe-tdd` fails in-container even though the workflow is valid in the repo.
+- Validation for unreleased Rover workflow/runtime changes therefore needs a locally built agent image from the current checkout. The demo is pinned to `rover-agent-local:latest` for that purpose.
+- The demo root `Makefile` had a real `test-e2e` orchestration bug: backgrounding `go run` inside a chained `cd` sequence left later `cd` commands in the wrong directory under Rover's shell, and failed retries could leave port `8080` occupied. Fixed by using absolute workspace paths, explicit bash orchestration, and pre-run cleanup of stale demo processes.
+- The backend demo repo shipped an incomplete `go.sum`, so `go test ./...` failed on a clean workspace before any application logic ran. The reproducible demo needs the fully resolved module hashes committed up front.
+- Cache-image builds were not executing the root workspace init script, so shared OS-level setup like installing Chromium never made it into the cached image. Fixed in Rover by running root init scripts during `rover build`.
+- Attempting to run per-project init scripts during cache builds exposed a second Rover gap: build containers do not clone external project repos first. The pragmatic fix was to keep cache builds to root init scripts only and let per-project init scripts continue to run at normal task startup in the writable cloned workspace.
+- Cache-image commits were failing after Go installation because the image diff/export path broke on `/usr/local/go`. Fixed in Rover by installing Go under `/opt/go` instead of `/usr/local/go` for sandbox setup.
+- The demo `test-e2e` recipe still had a process-management bug after the first orchestration fix: the leading `pkill -f ...` pre-cleanup commands could match the shell running the recipe itself and terminate the job before backend/frontend logs were even written. Fixed by removing that brittle pre-cleanup from the demo Makefile and generator.
+- Clean live validation in task `16` reached a green `make test` inside a real Rover task container after setup completed.
+- The child demo `Makefile`s originally omitted `.PHONY`, so `frontend/test` and `frontend/build` could be treated as existing paths and skipped. Fixed by marking root and child task targets as phony.
+- The original e2e child `Makefile` used shell-invalid `?=` lines inside a recipe. Fixed by moving those to actual Make variables.
+- `flutter config --enable-web` and in-place `flutter create . --platforms web` both proved too brittle as runtime setup steps inside live Rover tasks. The demo now ships a minimal Flutter web scaffold (`.metadata`, `web/index.html`, `web/manifest.json`) up front instead of generating it at task runtime.
+- The backend demo now accepts `PORT`, and the root demo Makefile now parameterizes `BACKEND_PORT` and `FRONTEND_PORT`, so repeated runs do not depend on fixed `8080`/`3000` ports.
+- The Flutter frontend now accepts `API_BASE_URL` via `--dart-define`, allowing the root orchestration layer to point the built web app at the selected backend port.
+- The Python `nodriver` harness needed container-safe browser flags in `conftest.py` to get past initial browser startup failures. That patch is now part of the generated demo.
+- In a clean task after the web-scaffold fix, root `make test` passed fully in-container again.
+- The root demo `Makefile` originally hardcoded `/workspace` paths, which made isolated/manual reruns harder. It now resolves paths relative to the root Makefile itself.
+- The Flutter web e2e path needed an explicit browser-side hook because headless `nodriver` interaction with Flutter semantics was not reliable enough by itself. The generated frontend now exposes a ready signal and fetch event hook for the Python browser test.
+- After that hook was added, full root `make setup`, `make test`, and `make test-e2e` passed on a clean generated workspace and again on a separate fresh clone.
+- `nodriver` still emits teardown warnings after the passing e2e run. Those warnings did not fail the validated runs, but they are real cleanup noise in the current dependency stack.
+- A fresh Rover task has now been validated end to end with Claude auth present. On a fresh clone, Rover created a task from the cached multi-repo image, carried `test_command=make validate`, ran the full `swe-tdd` test loop in-container, and completed successfully.
+- Rover task containers intentionally do not keep full sudo after setup. Missing OS packages must be handled in image/build configuration, not installed by the agent during task execution.
+- The `swe` and `swe-tdd` workflow prompts are now updated to reflect that boundary and to allow an explicit multi-command root validation sequence when a task is about validating the whole workspace.
+- The demo root `Makefile` now also exposes `make validate` as the explicit one-shot validation entrypoint for `make setup`, `make test`, and `make test-e2e`.
+- The `swe` and `swe-tdd` workflows no longer rely on agent-created sidecar files for core step handoff. Core markdown now flows through string outputs and is persisted explicitly, which removes the false `context.md` / `plan.md` / `changes.md` missing-file warnings from otherwise successful runs.
+
+## Demo status
+
+- [x] Added reproducible generator script: `demos/create-multi-env-demo.sh`
+- [x] Generated local demo workspace at `/tmp/rover-multi-env-demo`
+- [x] Build local agent image from current checkout
+- [x] Validate `rover build` enough to confirm a fresh cache image is produced with Chromium available
+- [x] Validate root `make setup && make test && make test-e2e` on a clean generated workspace
+- [x] Validate the same flow on a separate fresh clone
+- [x] Validate `rover task -a claude:haiku -w swe-tdd` against a fresh clone using `test_command=make validate`
+- [x] Validate `rover rebase` against the demo workspace
+- [x] Draft user-facing setup/configuration doc after command validation
+
+## Validated paths
+
+- Clean generated workspace: `/tmp/rover-multi-env-demo-run-5`
+- Fresh clone from that workspace root repo: `/tmp/rover-multi-env-demo-fresh-final-2`
+- Fresh clone used for final in-Rover validation: `/tmp/rover-multi-env-demo-run-6`
+
+Validated commands in both:
+
+- `make setup`
+- `make test`
+- `make test-e2e`
+- `make validate`
+
+Validated in prepared Rover task image:
+
+- `rover-fresh-prepared:latest`
+- `rover-cache:618a24cafbe9b09e`
+
+Validated in a real Rover task:
+
+- Project data root: `/home/dev/.rover/data/projects/tmp-rover-multi-env-demo-run-6-c39daf38`
+- Task: `3`
+- Workflow: `swe-tdd`
+- Agent: `claude:haiku`
+- Explicit test command override: `make validate`
+- Result: `Run Tests (exit code: 0)` and final workflow status `completed`
+- End-to-end proof point: the Python browser step finished with `1 passed`
+
+## Notes
+
+- Per request, if new questions come up during implementation, they go here and work continues with the most pragmatic placeholder.

--- a/docs/tracking/multi-env-demo-validation.md
+++ b/docs/tracking/multi-env-demo-validation.md
@@ -45,12 +45,11 @@ Shared demo behavior:
 - Backend returns one random joke from a list of 10.
 - E2E test opens the frontend, triggers the same Dart fetch path from the browser, and asserts a joke is shown.
 
-## Open questions
+## Resolved questions
 
-- [ ] Best repo layout for "3 separate gits" inside one Rover workspace:
-  placeholder choice is nested independent repos under one parent workspace.
-- [ ] Whether Rover should treat these as cloned sub-project repos, git submodules, or local repos attached by path.
-- [ ] Exact `nodriver` companion packages/models to preinstall for a realistic baseline.
+- [x] Best repo layout: nested independent repos cloned under one parent workspace via `projects[]` in `rover.json`.
+- [x] Rover treats these as cloned sub-project repos (not git submodules). Each is cloned from its `repository` field at task setup.
+- [x] `nodriver` works with Chromium and container-safe browser flags in `conftest.py`. No extra companion packages needed beyond Chromium in `sandbox.initScript`.
 
 ## Findings
 

--- a/docs/tracking/multi-env-demo-validation.md
+++ b/docs/tracking/multi-env-demo-validation.md
@@ -97,28 +97,15 @@ Shared demo behavior:
 - [x] Validate `rover rebase` against the demo workspace
 - [x] Draft user-facing setup/configuration doc after command validation
 
-## Validated paths
-
-- Clean generated workspace: `/tmp/rover-multi-env-demo-run-5`
-- Fresh clone from that workspace root repo: `/tmp/rover-multi-env-demo-fresh-final-2`
-- Fresh clone used for final in-Rover validation: `/tmp/rover-multi-env-demo-run-6`
-
-Validated commands in both:
+## Validated commands
 
 - `make setup`
 - `make test`
 - `make test-e2e`
 - `make validate`
 
-Validated in prepared Rover task image:
+## Validated Rover task
 
-- `rover-fresh-prepared:latest`
-- `rover-cache:618a24cafbe9b09e`
-
-Validated in a real Rover task:
-
-- Project data root: `/home/dev/.rover/data/projects/tmp-rover-multi-env-demo-run-6-c39daf38`
-- Task: `3`
 - Workflow: `swe-tdd`
 - Agent: `claude:haiku`
 - Explicit test command override: `make validate`

--- a/packages/agent/src/commands/__tests__/run-checkpoint.test.ts
+++ b/packages/agent/src/commands/__tests__/run-checkpoint.test.ts
@@ -596,9 +596,7 @@ describe('isTransientError', () => {
   });
 
   it('should detect provider 500 status as transient', () => {
-    expect(isTransientError('API Error: 500 Internal server error')).toBe(
-      true
-    );
+    expect(isTransientError('API Error: 500 Internal server error')).toBe(true);
   });
 
   it('should detect service unavailable as transient', () => {
@@ -721,9 +719,7 @@ describe('isRetryableError', () => {
   });
 
   it('should detect provider 500 status as retryable', () => {
-    expect(isRetryableError('API Error: 500 Internal server error')).toBe(
-      true
-    );
+    expect(isRetryableError('API Error: 500 Internal server error')).toBe(true);
   });
 
   it('should NOT match 429 embedded in a larger number', () => {

--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -80,16 +80,27 @@ function workflowReasonCode(error?: string): string {
   if (text.includes('rate limit') || text.includes('too many requests')) {
     return 'rate_limit';
   }
-  if (text.includes('auth') || text.includes('login') || text.includes('sign in')) {
+  if (
+    text.includes('auth') ||
+    text.includes('login') ||
+    text.includes('sign in')
+  ) {
     return 'auth_required';
   }
-  if (text.includes('timeout') || text.includes('timed out') || text.includes('network')) {
+  if (
+    text.includes('timeout') ||
+    text.includes('timed out') ||
+    text.includes('network')
+  ) {
     return 'network_timeout';
   }
   if (text.includes('step failure') || text.includes('step failed')) {
     return 'workflow_step_failed';
   }
-  if (text.includes('container') && (text.includes('exit') || text.includes('crash'))) {
+  if (
+    text.includes('container') &&
+    (text.includes('exit') || text.includes('crash'))
+  ) {
     return 'container_crashed';
   }
   if (text.includes('signal')) {
@@ -927,7 +938,8 @@ export const runCommand = async (
 
       // ACP usage decision: use ACP mode only for tools with ACP support.
       // Set ROVER_NO_ACP=1 to force direct runner mode (bypasses ACP auth issues).
-      const acpDisabled = process.env.ROVER_NO_ACP === '1' || process.env.ROVER_NO_ACP === 'true';
+      const acpDisabled =
+        process.env.ROVER_NO_ACP === '1' || process.env.ROVER_NO_ACP === 'true';
       const acpEnabledTools = [
         'claude',
         'gemini',
@@ -935,7 +947,8 @@ export const runCommand = async (
         'opencode',
         'qwen',
       ];
-      const useACPMode = !acpDisabled && acpEnabledTools.includes(tool.toLowerCase());
+      const useACPMode =
+        !acpDisabled && acpEnabledTools.includes(tool.toLowerCase());
 
       // Build the agent step executor based on mode
       if (useACPMode) {
@@ -992,7 +1005,10 @@ export const runCommand = async (
         if (existsSync(pauseRequestFile)) {
           const reason = (() => {
             try {
-              return readFileSync(pauseRequestFile, 'utf-8').trim() || 'Paused by external request';
+              return (
+                readFileSync(pauseRequestFile, 'utf-8').trim() ||
+                'Paused by external request'
+              );
             } catch {
               return 'Paused by external request';
             }

--- a/packages/agent/src/lib/__tests__/step-executor.test.ts
+++ b/packages/agent/src/lib/__tests__/step-executor.test.ts
@@ -1752,9 +1752,7 @@ describe('isTransientError', () => {
   });
 
   it('matches provider outage codes', () => {
-    expect(isTransientError('API Error: 500 Internal server error')).toBe(
-      true
-    );
+    expect(isTransientError('API Error: 500 Internal server error')).toBe(true);
     expect(isTransientError('Service unavailable')).toBe(true);
   });
 

--- a/packages/agent/src/lib/command-runner.ts
+++ b/packages/agent/src/lib/command-runner.ts
@@ -102,7 +102,11 @@ export async function runCommandStep(
   // Guard: if placeholder resolution produced a failure sentinel (e.g. a
   // prior step failed to extract the command), fail immediately with a
   // clear message instead of running a broken command that returns 127.
-  if (/\[Could not extract from response\]|\[Not found in response\]/.test(resolvedCommand)) {
+  if (
+    /\[Could not extract from response\]|\[Not found in response\]/.test(
+      resolvedCommand
+    )
+  ) {
     const duration = (performance.now() - start) / 1000;
     const errMsg = `Command contains unresolved output placeholder: ${resolvedCommand}`;
     console.log(`✗ ${step.name || step.id}: ${errMsg}`);

--- a/packages/agent/src/lib/runner.ts
+++ b/packages/agent/src/lib/runner.ts
@@ -587,12 +587,12 @@ export class Runner {
       '[Not found in response]',
     ];
     const missingRequired = stringOutputs.filter(
-      (o) =>
+      o =>
         o.required === true &&
         FAILURE_SENTINELS.includes(outputs.get(o.name) ?? '')
     );
     if (missingRequired.length > 0) {
-      const names = missingRequired.map((o) => o.name).join(', ');
+      const names = missingRequired.map(o => o.name).join(', ');
       throw new Error(
         `Required output(s) could not be extracted: ${names}. ` +
           `The agent's response did not include valid values for these fields.`

--- a/packages/agent/src/test-support/rover-telemetry.ts
+++ b/packages/agent/src/test-support/rover-telemetry.ts
@@ -1,0 +1,24 @@
+export enum TELEMETRY_FROM {
+  CLI = 'cli',
+  EXTENSION = 'extension',
+}
+
+export default class Telemetry {
+  static load(_from: TELEMETRY_FROM): Telemetry {
+    return new Telemetry();
+  }
+
+  static disableTelemetry(): void {}
+
+  static enableTelemetry(): void {}
+
+  async shutdown(): Promise<void> {}
+
+  getUserId(): string {
+    return 'test-user';
+  }
+
+  isDisabled(): boolean {
+    return false;
+  }
+}

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
       'rover-schemas': fileURLToPath(
         new URL('../schemas/src/index.ts', import.meta.url)
       ),
+      'rover-telemetry': fileURLToPath(
+        new URL('./src/test-support/rover-telemetry.ts', import.meta.url)
+      ),
     },
   },
   test: {

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -38,10 +38,15 @@ describe('generateBuildEntrypoint', () => {
       "Missing child repository 'backend' at '/workspace/backend' in the staged build workspace"
     );
     expect(script).toContain(
+      "Skipping project-specific cache setup for 'frontend'."
+    );
+    expect(script).toContain(
+      "Skipping project-specific cache setup for 'backend'."
+    );
+    expect(script).toContain(
       'rover build does not clone child repositories from project.repository.'
     );
-    expect(script).not.toContain('git clone');
-    expect(script).not.toContain('git fetch');
+    expect(script).not.toContain('safe_exit 1');
     expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
     expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
     expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -48,9 +48,11 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain(
       "git clone 'https://github.com/dataforxyz/frontend.git' '/workspace/frontend'"
     );
+    expect(script).toContain("rm -rf '/workspace/frontend'");
     expect(script).toContain(
       "git clone 'https://github.com/dataforxyz/backend.git' '/workspace/backend'"
     );
+    expect(script).toContain("rm -rf '/workspace/backend'");
     expect(script).toContain(
       "git -C '/workspace/frontend' fetch --all --tags --prune"
     );
@@ -74,6 +76,30 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain('bash "$workspace_script_2"');
   });
 
+  it('keeps a cloned default checkout when origin head is not advertised during cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [],
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+        },
+      ],
+      mcps: [],
+    } as any);
+
+    expect(script).toContain(
+      'echo "🔀 Remote HEAD not advertised for \'frontend\'; using cloned default checkout"'
+    );
+    expect(script).not.toContain(
+      'echo "❌ Could not determine default remote branch for \'frontend\'"'
+    );
+  });
+
   it('copies credentials before syncing child repositories for cache builds', () => {
     const script = generateBuildEntrypoint('claude', {
       allLanguages: [],
@@ -92,7 +118,7 @@ describe('generateBuildEntrypoint', () => {
     } as any);
 
     const credentialInstallIndex = script.indexOf(
-      'run_as_root rover-agent-install $AGENT || true'
+      'run_as_root rover-agent-install $AGENT_NAME || true'
     );
     const repoSyncIndex = script.indexOf(
       'Syncing external repositories for cache build'
@@ -139,9 +165,30 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain('run_as_root() {');
     expect(script).toContain('run_as_root_with_env() {');
     expect(script).toContain(
-      'run_as_root_with_env rover-agent install $AGENT || echo "Agent install failed (non-fatal for build)"'
+      'run_as_root_with_env rover-agent install $AGENT_NAME || echo "Agent install failed (non-fatal for build)"'
     );
-    expect(script).not.toContain('$_SUDO -E rover-agent install $AGENT');
+    expect(script).not.toContain('$_SUDO -E rover-agent install $AGENT_NAME');
+  });
+
+  it('strips model suffix from agent string for install and credential commands', () => {
+    const script = generateBuildEntrypoint('claude:haiku', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [],
+      projects: [],
+      mcps: [],
+    } as any);
+
+    // Full agent:model stored in AGENT variable
+    expect(script).toContain("AGENT='claude:haiku'");
+    // Stripped to agent name only in AGENT_NAME
+    expect(script).toContain('AGENT_NAME="${AGENT%%:*}"');
+    // Install commands use AGENT_NAME, not AGENT
+    expect(script).toContain('rover-agent install $AGENT_NAME');
+    expect(script).toContain('rover-agent-install $AGENT_NAME');
+    // MCP config uses agent name (from JS-side stripping)
+    expect(script).toContain("rover-agent config mcp 'claude' package-manager");
   });
 
   it('syncs child repositories before installing languages for cache builds', () => {
@@ -446,6 +493,84 @@ describe('generateBuildEntrypoint', () => {
     expect(repositoryMounts).toEqual([
       {
         hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace-repos/0'
+    );
+  });
+
+  it('rewrites file URL repositories during build config preparation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    const hostRepo = mkdtempSync(join(tmpdir(), 'rover-build-host-repo-'));
+    testDirs.push(root, hostRepo);
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      root,
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: [],
+          taskManagers: [],
+          attribution: true,
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: `file://${hostRepo}`,
+            },
+          ],
+        } as any,
+        root
+      )
+    );
+
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace-repos/0'
+    );
+  });
+
+  it('resolves relative local repositories against projectRoot during build config preparation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    const invocationDir = join(root, 'nested');
+    testDirs.push(root);
+    mkdirSync(invocationDir, { recursive: true });
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      invocationDir,
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: [],
+          taskManagers: [],
+          attribution: true,
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: './repos/frontend.git',
+            },
+          ],
+        } as any,
+        root
+      )
+    );
+
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
         containerPath: '/workspace-repos/0',
       },
     ]);

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -38,15 +38,10 @@ describe('generateBuildEntrypoint', () => {
       "Missing child repository 'backend' at '/workspace/backend' in the staged build workspace"
     );
     expect(script).toContain(
-      "Skipping project-specific cache setup for 'frontend'."
-    );
-    expect(script).toContain(
-      "Skipping project-specific cache setup for 'backend'."
-    );
-    expect(script).toContain(
       'rover build does not clone child repositories from project.repository.'
     );
-    expect(script).not.toContain('safe_exit 1');
+    expect(script).not.toContain('git clone');
+    expect(script).not.toContain('git fetch');
     expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
     expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
     expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -585,6 +585,46 @@ describe('generateBuildEntrypoint', () => {
     );
   });
 
+  it('rewrites file URL repositories under /workspace during build config preparation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    const hostRepoRoot = join(root, 'sources');
+    const hostRepo = join(hostRepoRoot, 'frontend.git');
+    mkdirSync(hostRepo, { recursive: true });
+    testDirs.push(root);
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      root,
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: [],
+          taskManagers: [],
+          attribution: true,
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: 'file:///workspace/sources/frontend.git',
+            },
+          ],
+        } as any,
+        root
+      )
+    );
+
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace-repos/0'
+    );
+  });
+
   it('resolves relative local repositories against projectRoot during build config preparation', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
     const invocationDir = join(root, 'nested');

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -45,4 +45,36 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
     expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');
   });
+
+  it('copies credentials before syncing child repositories for cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [],
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'git@github.com:dataforxyz/frontend.git',
+          packageManagers: ['npm'],
+        },
+      ],
+      mcps: [],
+    } as any);
+
+    const credentialInstallIndex = script.indexOf(
+      'sudo rover-agent-install $AGENT || true'
+    );
+    const repoSyncIndex = script.indexOf(
+      'Syncing external repositories for cache build'
+    );
+    const dependencyResolutionIndex = script.indexOf(
+      "cd '/workspace/frontend' && npm install 2>/dev/null || true"
+    );
+
+    expect(credentialInstallIndex).toBeGreaterThanOrEqual(0);
+    expect(repoSyncIndex).toBeGreaterThan(credentialInstallIndex);
+    expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
+  });
 });

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -79,4 +79,35 @@ describe('generateBuildEntrypoint', () => {
     expect(repoSyncIndex).toBeGreaterThan(credentialInstallIndex);
     expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
   });
+
+  it('filters unsafe project and init-script paths from cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [
+        { script: 'scripts/system-init.sh' },
+        { path: '../../escape', script: 'scripts/bad.sh' },
+        { path: 'frontend', script: 'scripts/init.sh' },
+      ],
+      projects: [
+        {
+          name: 'unsafe',
+          path: '../../escape',
+          repository: 'https://github.com/dataforxyz/unsafe.git',
+        },
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+        },
+      ],
+      mcps: [],
+      projectRoot: '/repo',
+    } as any);
+
+    expect(script).toContain('/workspace/frontend');
+    expect(script).not.toContain('/workspace/../../escape');
+    expect(script).not.toContain('scripts/bad.sh');
+  });
 });

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { generateBuildEntrypoint } from '../build.js';
 
 describe('generateBuildEntrypoint', () => {
-  it('uses staged child repos and runs root plus project init scripts during cache builds', () => {
+  it('clones child repos and runs root plus project init scripts during cache builds', () => {
     const script = generateBuildEntrypoint('claude', {
       allLanguages: [],
       allPackageManagers: [],
@@ -28,20 +28,19 @@ describe('generateBuildEntrypoint', () => {
     } as any);
 
     expect(script).toContain('cp -a /workspace-src/. "$BUILD_WORKSPACE/"');
+    expect(script).toContain('Syncing external repositories for cache build');
     expect(script).toContain(
-      'Validating external repositories for cache build'
+      "git clone 'https://github.com/dataforxyz/frontend.git' '/workspace/frontend'"
     );
     expect(script).toContain(
-      "Missing child repository 'frontend' at '/workspace/frontend' in the staged build workspace"
+      "git clone 'https://github.com/dataforxyz/backend.git' '/workspace/backend'"
     );
     expect(script).toContain(
-      "Missing child repository 'backend' at '/workspace/backend' in the staged build workspace"
+      "git -C '/workspace/frontend' fetch --all --tags --prune"
     );
     expect(script).toContain(
-      'rover build does not clone child repositories from project.repository.'
+      "git -C '/workspace/backend' fetch --all --tags --prune"
     );
-    expect(script).not.toContain('git clone');
-    expect(script).not.toContain('git fetch');
     expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
     expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
     expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -41,6 +41,8 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain(
       "git -C '/workspace/backend' fetch --all --tags --prune"
     );
+    expect(script).toContain("git -C '/workspace/frontend' clean -fdx");
+    expect(script).toContain("git -C '/workspace/backend' clean -fdx");
     expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
     expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
     expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -1,7 +1,22 @@
-import { describe, expect, it } from 'vitest';
-import { generateBuildEntrypoint } from '../build.js';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  generateBuildEntrypoint,
+  prepareBuildProjectConfig,
+} from '../build.js';
 
 describe('generateBuildEntrypoint', () => {
+  const testDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of testDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    testDirs.length = 0;
+  });
+
   it('clones child repos and runs root plus project init scripts during cache builds', () => {
     const script = generateBuildEntrypoint('claude', {
       allLanguages: [],
@@ -72,7 +87,7 @@ describe('generateBuildEntrypoint', () => {
     } as any);
 
     const credentialInstallIndex = script.indexOf(
-      'sudo rover-agent-install $AGENT || true'
+      'run_as_root rover-agent-install $AGENT || true'
     );
     const repoSyncIndex = script.indexOf(
       'Syncing external repositories for cache build'
@@ -84,6 +99,85 @@ describe('generateBuildEntrypoint', () => {
     expect(credentialInstallIndex).toBeGreaterThanOrEqual(0);
     expect(repoSyncIndex).toBeGreaterThan(credentialInstallIndex);
     expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
+  });
+
+  it('uses helper wrappers so cache builds still work when sudo is unavailable', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [],
+      projects: [],
+      mcps: [],
+    } as any);
+
+    expect(script).toContain('run_as_root() {');
+    expect(script).toContain('run_as_root_with_env() {');
+    expect(script).toContain(
+      'run_as_root_with_env rover-agent install $AGENT || echo "Agent install failed (non-fatal for build)"'
+    );
+    expect(script).not.toContain('$_SUDO -E rover-agent install $AGENT');
+  });
+
+  it('syncs child repositories before installing languages for cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: ['go'],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [],
+      projects: [
+        {
+          name: 'backend',
+          path: 'backend',
+          repository: 'https://github.com/dataforxyz/backend.git',
+          languages: ['go'],
+        },
+      ],
+      mcps: [],
+    } as any);
+
+    const repoSyncIndex = script.indexOf(
+      'Syncing external repositories for cache build'
+    );
+    const installGoIndex = script.indexOf('Installing go...');
+    const goVersionProbeIndex = script.indexOf(
+      'if [ -f /workspace/go.mod ]; then'
+    );
+
+    expect(repoSyncIndex).toBeGreaterThanOrEqual(0);
+    expect(installGoIndex).toBeGreaterThan(repoSyncIndex);
+    expect(goVersionProbeIndex).toBeGreaterThan(repoSyncIndex);
+  });
+
+  it('runs init scripts before resolving dependencies during cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [{ script: 'scripts/system-init.sh' }],
+      packageManagers: ['uv'],
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+          packageManagers: ['pnpm'],
+        },
+      ],
+      mcps: [],
+    } as any);
+
+    const initScriptIndex = script.indexOf(
+      'bash "/workspace/scripts/system-init.sh"'
+    );
+    const rootDependencyIndex = script.indexOf("cd '/workspace' && uv sync");
+    const projectDependencyIndex = script.indexOf(
+      "cd '/workspace/frontend' && pnpm install"
+    );
+
+    expect(initScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(rootDependencyIndex).toBeGreaterThan(initScriptIndex);
+    expect(projectDependencyIndex).toBeGreaterThan(initScriptIndex);
   });
 
   it('filters unsafe project and init-script paths from cache builds', () => {
@@ -143,5 +237,51 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain("workspace_dir_0='/workspace/frontend'");
     expect(script).toContain('if [ -f "$workspace_project_script_0" ]; then');
     expect(script).toContain('bash "$workspace_script_0"');
+  });
+
+  it('rewrites local child repositories to mounted container paths for cache builds', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      root,
+      {
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: './repos/frontend.git',
+          },
+        ],
+      } as any
+    );
+
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace-repos/0'
+    );
+  });
+
+  it('fails early when a configured local child repository is missing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    testDirs.push(root);
+
+    expect(() =>
+      prepareBuildProjectConfig(root, {
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: './repos/frontend.git',
+          },
+        ],
+      } as any)
+    ).toThrow(/Local workspace repository for frontend not found/);
   });
 });

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -117,7 +117,7 @@ describe('generateBuildEntrypoint', () => {
     expect(script).not.toContain('scripts/bad.sh');
   });
 
-  it('prefers root-relative project init scripts during cache builds', () => {
+  it('prefers project-relative init scripts during cache builds', () => {
     const script = generateBuildEntrypoint('claude', {
       allLanguages: [],
       allPackageManagers: [],
@@ -140,8 +140,8 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain(
       "workspace_project_script_0='/workspace/frontend/scripts/init.sh'"
     );
-    expect(script).toContain("workspace_dir_0='/workspace'");
     expect(script).toContain("workspace_dir_0='/workspace/frontend'");
+    expect(script).toContain('if [ -f "$workspace_project_script_0" ]; then');
     expect(script).toContain('bash "$workspace_script_0"');
   });
 });

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -469,9 +469,12 @@ describe('generateBuildEntrypoint', () => {
     ).toThrow(/Local workspace repository for frontend not found/);
   });
 
-  it('does not rewrite absolute container repository paths during build config preparation', () => {
+  it('rewrites absolute repository paths under /workspace during build config preparation', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
-    testDirs.push(root);
+    const hostRepoRoot = mkdtempSync(join(tmpdir(), 'rover-build-host-'));
+    const hostRepo = join(hostRepoRoot, 'sources', 'frontend.git');
+    mkdirSync(hostRepo, { recursive: true });
+    testDirs.push(root, hostRepoRoot);
 
     const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
       root,
@@ -487,7 +490,7 @@ describe('generateBuildEntrypoint', () => {
             {
               name: 'frontend',
               path: 'frontend',
-              repository: '/workspace/sources/frontend.git',
+              repository: hostRepo,
             },
           ],
         } as any,
@@ -495,9 +498,14 @@ describe('generateBuildEntrypoint', () => {
       )
     );
 
-    expect(repositoryMounts).toEqual([]);
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
     expect(buildProjectConfig.projects?.[0]?.repository).toBe(
-      '/workspace/sources/frontend.git'
+      '/workspace-repos/0'
     );
   });
 

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { ProjectConfigManager } from 'rover-core';
 import {
   generateBuildEntrypoint,
   prepareBuildProjectConfig,
@@ -141,7 +142,7 @@ describe('generateBuildEntrypoint', () => {
     );
     const installGoIndex = script.indexOf('Installing go...');
     const goVersionProbeIndex = script.indexOf(
-      'if [ -f /workspace/go.mod ]; then'
+      "for go_mod_path in '/workspace/go.mod' '/workspace/src/go.mod' '/workspace/backend/go.mod' '/workspace/backend/src/go.mod'; do"
     );
 
     expect(repoSyncIndex).toBeGreaterThanOrEqual(0);
@@ -229,14 +230,17 @@ describe('generateBuildEntrypoint', () => {
     } as any);
 
     expect(script).toContain(
-      "workspace_root_script_0='/workspace/scripts/init.sh'"
-    );
-    expect(script).toContain(
       "workspace_project_script_0='/workspace/frontend/scripts/init.sh'"
     );
     expect(script).toContain("workspace_dir_0='/workspace/frontend'");
     expect(script).toContain('if [ -f "$workspace_project_script_0" ]; then');
+    expect(script).toContain(
+      'echo "❌ Initialization script (frontend) not found at $workspace_project_script_0"'
+    );
     expect(script).toContain('bash "$workspace_script_0"');
+    expect(script).not.toContain(
+      "workspace_root_script_0='/workspace/scripts/init.sh'"
+    );
   });
 
   it('rewrites local child repositories to mounted container paths for cache builds', () => {
@@ -246,15 +250,29 @@ describe('generateBuildEntrypoint', () => {
 
     const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
       root,
-      {
-        projects: [
-          {
-            name: 'frontend',
-            path: 'frontend',
-            repository: './repos/frontend.git',
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: ['uv'],
+          taskManagers: [],
+          attribution: true,
+          sandbox: {
+            initScript: 'scripts/system-init.sh',
           },
-        ],
-      } as any
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: './repos/frontend.git',
+              packageManagers: ['pnpm'],
+              initScript: 'scripts/init.sh',
+            },
+          ],
+        } as any,
+        root
+      )
     );
 
     expect(repositoryMounts).toEqual([
@@ -266,6 +284,13 @@ describe('generateBuildEntrypoint', () => {
     expect(buildProjectConfig.projects?.[0]?.repository).toBe(
       '/workspace-repos/0'
     );
+    expect(buildProjectConfig).toBeInstanceOf(ProjectConfigManager);
+    expect(buildProjectConfig.packageManagers).toEqual(['uv']);
+    expect(buildProjectConfig.allPackageManagers).toEqual(['uv', 'pnpm']);
+    expect(buildProjectConfig.allInitScripts).toEqual([
+      { script: 'scripts/system-init.sh' },
+      { path: 'frontend', script: 'scripts/init.sh' },
+    ]);
   });
 
   it('fails early when a configured local child repository is missing', () => {
@@ -273,15 +298,73 @@ describe('generateBuildEntrypoint', () => {
     testDirs.push(root);
 
     expect(() =>
-      prepareBuildProjectConfig(root, {
-        projects: [
+      prepareBuildProjectConfig(
+        root,
+        new ProjectConfigManager(
           {
-            name: 'frontend',
-            path: 'frontend',
-            repository: './repos/frontend.git',
-          },
-        ],
-      } as any)
+            version: '1.2',
+            languages: [],
+            mcps: [],
+            packageManagers: [],
+            taskManagers: [],
+            attribution: true,
+            projects: [
+              {
+                name: 'frontend',
+                path: 'frontend',
+                repository: './repos/frontend.git',
+              },
+            ],
+          } as any,
+          root
+        )
+      )
     ).toThrow(/Local workspace repository for frontend not found/);
+  });
+
+  it('excludes unsafe-path projects during build config preparation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      root,
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: [],
+          taskManagers: [],
+          attribution: true,
+          projects: [
+            {
+              name: 'unsafe',
+              path: '../../escape',
+              repository: './repos/missing.git',
+            },
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: './repos/frontend.git',
+            },
+          ],
+        } as any,
+        root
+      )
+    );
+
+    // Unsafe project is filtered out entirely, only safe project remains
+    expect(buildProjectConfig.projects).toHaveLength(1);
+    expect(buildProjectConfig.projects?.[0]?.name).toBe('frontend');
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace-repos/1'
+    );
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/1',
+      },
+    ]);
   });
 });

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { generateBuildEntrypoint } from '../build.js';
+
+describe('generateBuildEntrypoint', () => {
+  it('materializes project repos and runs root plus project init scripts during cache builds', () => {
+    const script = generateBuildEntrypoint(
+      'claude',
+      {
+        allLanguages: [],
+        allPackageManagers: [],
+        allTaskManagers: [],
+        allInitScripts: [
+          { script: 'scripts/system-init.sh' },
+          { path: 'frontend', script: 'scripts/init.sh' },
+          { path: 'backend', script: 'scripts/init.sh' },
+        ],
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'https://github.com/dataforxyz/frontend.git',
+          },
+          {
+            name: 'backend',
+            path: 'backend',
+            repository: 'https://github.com/dataforxyz/backend.git',
+          },
+        ],
+        mcps: [],
+      } as any
+    );
+
+    expect(script).toContain('cp -a /workspace-src/. "$BUILD_WORKSPACE/"');
+    expect(script).toContain('Syncing external repositories for cache build');
+    expect(script).toContain(
+      "git clone 'https://github.com/dataforxyz/frontend.git' '/workspace/frontend'"
+    );
+    expect(script).toContain(
+      "git clone 'https://github.com/dataforxyz/backend.git' '/workspace/backend'"
+    );
+    expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
+    expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
+    expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');
+  });
+});

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -44,8 +44,14 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain("git -C '/workspace/frontend' clean -fdx");
     expect(script).toContain("git -C '/workspace/backend' clean -fdx");
     expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
-    expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
-    expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');
+    expect(script).toContain(
+      "workspace_project_script_1='/workspace/frontend/scripts/init.sh'"
+    );
+    expect(script).toContain(
+      "workspace_project_script_2='/workspace/backend/scripts/init.sh'"
+    );
+    expect(script).toContain('bash "$workspace_script_1"');
+    expect(script).toContain('bash "$workspace_script_2"');
   });
 
   it('copies credentials before syncing child repositories for cache builds', () => {
@@ -109,5 +115,33 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain('/workspace/frontend');
     expect(script).not.toContain('/workspace/../../escape');
     expect(script).not.toContain('scripts/bad.sh');
+  });
+
+  it('prefers root-relative project init scripts during cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [{ path: 'frontend', script: 'scripts/init.sh' }],
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+        },
+      ],
+      mcps: [],
+      projectRoot: '/repo',
+    } as any);
+
+    expect(script).toContain(
+      "workspace_root_script_0='/workspace/scripts/init.sh'"
+    );
+    expect(script).toContain(
+      "workspace_project_script_0='/workspace/frontend/scripts/init.sh'"
+    );
+    expect(script).toContain("workspace_dir_0='/workspace'");
+    expect(script).toContain("workspace_dir_0='/workspace/frontend'");
+    expect(script).toContain('bash "$workspace_script_0"');
   });
 });

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -2,42 +2,46 @@ import { describe, expect, it } from 'vitest';
 import { generateBuildEntrypoint } from '../build.js';
 
 describe('generateBuildEntrypoint', () => {
-  it('materializes project repos and runs root plus project init scripts during cache builds', () => {
-    const script = generateBuildEntrypoint(
-      'claude',
-      {
-        allLanguages: [],
-        allPackageManagers: [],
-        allTaskManagers: [],
-        allInitScripts: [
-          { script: 'scripts/system-init.sh' },
-          { path: 'frontend', script: 'scripts/init.sh' },
-          { path: 'backend', script: 'scripts/init.sh' },
-        ],
-        projects: [
-          {
-            name: 'frontend',
-            path: 'frontend',
-            repository: 'https://github.com/dataforxyz/frontend.git',
-          },
-          {
-            name: 'backend',
-            path: 'backend',
-            repository: 'https://github.com/dataforxyz/backend.git',
-          },
-        ],
-        mcps: [],
-      } as any
-    );
+  it('uses staged child repos and runs root plus project init scripts during cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [
+        { script: 'scripts/system-init.sh' },
+        { path: 'frontend', script: 'scripts/init.sh' },
+        { path: 'backend', script: 'scripts/init.sh' },
+      ],
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+        },
+        {
+          name: 'backend',
+          path: 'backend',
+          repository: 'https://github.com/dataforxyz/backend.git',
+        },
+      ],
+      mcps: [],
+    } as any);
 
     expect(script).toContain('cp -a /workspace-src/. "$BUILD_WORKSPACE/"');
-    expect(script).toContain('Syncing external repositories for cache build');
     expect(script).toContain(
-      "git clone 'https://github.com/dataforxyz/frontend.git' '/workspace/frontend'"
+      'Validating external repositories for cache build'
     );
     expect(script).toContain(
-      "git clone 'https://github.com/dataforxyz/backend.git' '/workspace/backend'"
+      "Missing child repository 'frontend' at '/workspace/frontend' in the staged build workspace"
     );
+    expect(script).toContain(
+      "Missing child repository 'backend' at '/workspace/backend' in the staged build workspace"
+    );
+    expect(script).toContain(
+      'rover build does not clone child repositories from project.repository.'
+    );
+    expect(script).not.toContain('git clone');
+    expect(script).not.toContain('git fetch');
     expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
     expect(script).toContain('bash "/workspace/frontend/scripts/init.sh"');
     expect(script).toContain('bash "/workspace/backend/scripts/init.sh"');

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -59,7 +59,11 @@ describe('generateBuildEntrypoint', () => {
     );
     expect(script).toContain("git -C '/workspace/frontend' clean -fdx");
     expect(script).toContain("git -C '/workspace/backend' clean -fdx");
-    expect(script).toContain('bash "/workspace/scripts/system-init.sh"');
+    expect(script).toContain("mounted_script_0='/init-script-0.sh'");
+    expect(script).toContain(
+      "workspace_script_0='/workspace/scripts/system-init.sh'"
+    );
+    expect(script).toContain('bash "$root_script_0"');
     expect(script).toContain(
       "workspace_project_script_1='/workspace/frontend/scripts/init.sh'"
     );
@@ -102,6 +106,26 @@ describe('generateBuildEntrypoint', () => {
     expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
   });
 
+  it('falls back to root init scripts for project-scoped entries during cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [{ path: 'frontend', script: 'scripts/init.sh' }],
+      projects: [],
+      mcps: [],
+    } as any);
+
+    expect(script).toContain(
+      "workspace_project_script_0='/workspace/frontend/scripts/init.sh'"
+    );
+    expect(script).toContain(
+      "workspace_root_script_0='/workspace/scripts/init.sh'"
+    );
+    expect(script).toContain('elif [ -f "$workspace_root_script_0" ]; then');
+    expect(script).toContain("workspace_dir_0='/workspace'");
+  });
+
   it('uses helper wrappers so cache builds still work when sudo is unavailable', () => {
     const script = generateBuildEntrypoint('claude', {
       allLanguages: [],
@@ -140,7 +164,9 @@ describe('generateBuildEntrypoint', () => {
     const repoSyncIndex = script.indexOf(
       'Syncing external repositories for cache build'
     );
-    const installGoIndex = script.indexOf('Installing go...');
+    const installGoIndex = script.indexOf(
+      'echo "Installing Go $GO_VERSION_DL ($GOARCH)..."'
+    );
     const goVersionProbeIndex = script.indexOf(
       "for go_mod_path in '/workspace/go.mod' '/workspace/src/go.mod' '/workspace/backend/go.mod' '/workspace/backend/src/go.mod'; do"
     );
@@ -168,9 +194,7 @@ describe('generateBuildEntrypoint', () => {
       mcps: [],
     } as any);
 
-    const initScriptIndex = script.indexOf(
-      'bash "/workspace/scripts/system-init.sh"'
-    );
+    const initScriptIndex = script.indexOf('bash "$root_script_0"');
     const rootDependencyIndex = script.indexOf("cd '/workspace' && uv sync");
     const projectDependencyIndex = script.indexOf(
       "cd '/workspace/frontend' && pnpm install"
@@ -179,6 +203,24 @@ describe('generateBuildEntrypoint', () => {
     expect(initScriptIndex).toBeGreaterThanOrEqual(0);
     expect(rootDependencyIndex).toBeGreaterThan(initScriptIndex);
     expect(projectDependencyIndex).toBeGreaterThan(initScriptIndex);
+  });
+
+  it('runs root init scripts from mounted host paths during cache builds', () => {
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [{ script: '../shared/system-init.sh' }],
+      projects: [],
+      mcps: [],
+    } as any);
+
+    expect(script).toContain("mounted_script_0='/init-script.sh'");
+    expect(script).toContain(
+      "workspace_script_0='/workspace/../shared/system-init.sh'"
+    );
+    expect(script).toContain('if [ -f "$mounted_script_0" ]; then');
+    expect(script).toContain('bash "$root_script_0"');
   });
 
   it('filters unsafe project and init-script paths from cache builds', () => {
@@ -212,6 +254,26 @@ describe('generateBuildEntrypoint', () => {
     expect(script).not.toContain('scripts/bad.sh');
   });
 
+  it('filters project-scoped init scripts whose path escapes through a symlink', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    const outside = mkdtempSync(join(tmpdir(), 'rover-build-outside-'));
+    testDirs.push(root);
+    testDirs.push(outside);
+    symlinkSync(outside, join(root, 'services'));
+
+    const script = generateBuildEntrypoint('claude', {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      allInitScripts: [{ path: 'services/api', script: 'scripts/init.sh' }],
+      projects: [],
+      mcps: [],
+      projectRoot: root,
+    } as any);
+
+    expect(script).not.toContain('/workspace/services/api/scripts/init.sh');
+  });
+
   it('prefers project-relative init scripts during cache builds', () => {
     const script = generateBuildEntrypoint('claude', {
       allLanguages: [],
@@ -235,10 +297,10 @@ describe('generateBuildEntrypoint', () => {
     expect(script).toContain("workspace_dir_0='/workspace/frontend'");
     expect(script).toContain('if [ -f "$workspace_project_script_0" ]; then');
     expect(script).toContain(
-      'echo "❌ Initialization script (frontend) not found at $workspace_project_script_0"'
+      'echo "❌ Initialization script (frontend) not found at $workspace_project_script_0 or $workspace_root_script_0"'
     );
     expect(script).toContain('bash "$workspace_script_0"');
-    expect(script).not.toContain(
+    expect(script).toContain(
       "workspace_root_script_0='/workspace/scripts/init.sh'"
     );
   });
@@ -320,6 +382,76 @@ describe('generateBuildEntrypoint', () => {
         )
       )
     ).toThrow(/Local workspace repository for frontend not found/);
+  });
+
+  it('does not rewrite absolute container repository paths during build config preparation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    testDirs.push(root);
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      root,
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: [],
+          taskManagers: [],
+          attribution: true,
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: '/workspace/sources/frontend.git',
+            },
+          ],
+        } as any,
+        root
+      )
+    );
+
+    expect(repositoryMounts).toEqual([]);
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace/sources/frontend.git'
+    );
+  });
+
+  it('rewrites absolute host repository paths during build config preparation', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    const hostRepo = mkdtempSync(join(tmpdir(), 'rover-build-host-repo-'));
+    testDirs.push(root, hostRepo);
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      root,
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: [],
+          taskManagers: [],
+          attribution: true,
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: hostRepo,
+            },
+          ],
+        } as any,
+        root
+      )
+    );
+
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace-repos/0'
+    );
   });
 
   it('excludes unsafe-path projects during build config preparation', () => {

--- a/packages/cli/src/commands/__tests__/build.test.ts
+++ b/packages/cli/src/commands/__tests__/build.test.ts
@@ -402,6 +402,44 @@ describe('generateBuildEntrypoint', () => {
     ]);
   });
 
+  it('rewrites plain relative child repositories to mounted container paths for cache builds', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      root,
+      new ProjectConfigManager(
+        {
+          version: '1.2',
+          languages: [],
+          mcps: [],
+          packageManagers: [],
+          taskManagers: [],
+          attribution: true,
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: 'repos/frontend.git',
+            },
+          ],
+        } as any,
+        root
+      )
+    );
+
+    expect(repositoryMounts).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(buildProjectConfig.projects?.[0]?.repository).toBe(
+      '/workspace-repos/0'
+    );
+  });
+
   it('fails early when a configured local child repository is missing', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-build-test-'));
     testDirs.push(root);

--- a/packages/cli/src/commands/__tests__/delete.test.ts
+++ b/packages/cli/src/commands/__tests__/delete.test.ts
@@ -74,6 +74,13 @@ vi.mock('../../lib/sandbox/index.js', () => ({
     stopAndRemove: vi.fn().mockResolvedValue(undefined),
     teardownServices: vi.fn().mockResolvedValue(undefined),
   }),
+  isSandboxBackendUnavailableError: vi.fn((error: unknown) => {
+    return (
+      error instanceof Error &&
+      error.message ===
+        'Neither Docker nor Podman are available. Please install Docker or Podman to run tasks.'
+    );
+  }),
 }));
 
 describe('delete command', () => {
@@ -374,6 +381,42 @@ describe('delete command', () => {
       expect(
         TaskDescriptionManager.exists(join(testDir, '.rover', 'tasks', '21'))
       ).toBe(false);
+    });
+
+    it('preserves the task when metadata-only cleanup cannot run without a backend', async () => {
+      const { createSandbox } = await import('../../lib/sandbox/index.js');
+      const { exitWithErrors, exitWithWarn } = await import(
+        '../../utils/exit.js'
+      );
+      vi.mocked(createSandbox).mockRejectedValueOnce(
+        new Error(
+          'Neither Docker nor Podman are available. Please install Docker or Podman to run tasks.'
+        )
+      );
+
+      const task = createTestTask(27, 'Paused Task Without Backend');
+      task.markPaused('paused');
+      task.setContainerInfo('', '', {
+        dockerHost: 'tcp://remote:2375',
+      });
+
+      await deleteCommand(['27'], { json: true });
+
+      expect(exitWithWarn).not.toHaveBeenCalled();
+      expect(exitWithErrors).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          errors: expect.arrayContaining([
+            'Task 27: sandbox service cleanup could not run because no container backend is available; task metadata was preserved so cleanup can be retried later',
+          ]),
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
+      );
+      expect(
+        TaskDescriptionManager.exists(join(testDir, '.rover', 'tasks', '27'))
+      ).toBe(true);
     });
   });
 

--- a/packages/cli/src/commands/__tests__/delete.test.ts
+++ b/packages/cli/src/commands/__tests__/delete.test.ts
@@ -69,6 +69,13 @@ vi.mock('../../utils/display.js', () => ({
   showRoverChat: vi.fn(),
 }));
 
+vi.mock('../../lib/sandbox/index.js', () => ({
+  createSandbox: vi.fn().mockResolvedValue({
+    stopAndRemove: vi.fn().mockResolvedValue(undefined),
+    teardownServices: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 describe('delete command', () => {
   let originalCwd: string;
 
@@ -302,6 +309,50 @@ describe('delete command', () => {
         })
       );
       expect(existsSync('.rover/tasks/4')).toBe(false);
+    });
+
+    it('cleans up persisted sidecars before deleting a paused task without a container id', async () => {
+      const { createSandbox } = await import('../../lib/sandbox/index.js');
+      const sandbox = {
+        stopAndRemove: vi.fn().mockResolvedValue(undefined),
+        teardownServices: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(createSandbox).mockResolvedValueOnce(sandbox as any);
+
+      const task = createTestTask(21, 'Paused Task');
+      task.markPaused('paused');
+      task.setContainerInfo('', '', {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-21-1',
+          containerNames: ['rover-svc-21-1-postgres'],
+          taskId: 21,
+          iteration: 1,
+        },
+      });
+
+      await deleteCommand(['21'], { json: true });
+
+      expect(createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 21 }),
+        undefined,
+        {
+          projectPath: testDir,
+          sandboxMetadata: {
+            dockerHost: 'tcp://remote:2375',
+            serviceContext: {
+              networkName: 'rover-services-21-1',
+              containerNames: ['rover-svc-21-1-postgres'],
+              taskId: 21,
+              iteration: 1,
+            },
+          },
+        }
+      );
+      expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
+      expect(
+        TaskDescriptionManager.exists(join(testDir, '.rover', 'tasks', '21'))
+      ).toBe(false);
     });
   });
 

--- a/packages/cli/src/commands/__tests__/delete.test.ts
+++ b/packages/cli/src/commands/__tests__/delete.test.ts
@@ -184,12 +184,31 @@ describe('delete command', () => {
 
       await deleteCommand(['1.5']);
 
-      // parseInt('1.5') = 1, so this should try to delete task 1
       expect(exitWithErrors).toHaveBeenCalledWith(
-        {
-          errors: ['Task with ID 1 was not found'],
+        expect.objectContaining({
+          errors: expect.arrayContaining([
+            "Invalid task ID '1.5' - must be a number",
+          ]),
           success: false,
-        },
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
+      );
+    });
+
+    it('should reject malformed numeric task IDs with trailing characters', async () => {
+      const { exitWithErrors } = await import('../../utils/exit.js');
+
+      await deleteCommand(['12abc']);
+
+      expect(exitWithErrors).toHaveBeenCalledWith(
+        expect.objectContaining({
+          errors: expect.arrayContaining([
+            "Invalid task ID '12abc' - must be a number",
+          ]),
+          success: false,
+        }),
         expect.objectContaining({
           telemetry: expect.anything(),
         })
@@ -220,10 +239,12 @@ describe('delete command', () => {
       await deleteCommand(['-1']);
 
       expect(exitWithErrors).toHaveBeenCalledWith(
-        {
-          errors: ['Task with ID -1 was not found'],
+        expect.objectContaining({
+          errors: expect.arrayContaining([
+            "Invalid task ID '-1' - must be a number",
+          ]),
           success: false,
-        },
+        }),
         expect.objectContaining({
           telemetry: expect.anything(),
         })

--- a/packages/cli/src/commands/__tests__/diff.test.ts
+++ b/packages/cli/src/commands/__tests__/diff.test.ts
@@ -154,6 +154,14 @@ describe('diff command', () => {
       );
     });
 
+    it('should reject malformed numeric task IDs with trailing characters', async () => {
+      await diffCommand('12abc');
+
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        expect.stringContaining("✗ Invalid task ID '12abc' - must be a number")
+      );
+    });
+
     it('should handle non-existent task', async () => {
       await diffCommand('999');
 

--- a/packages/cli/src/commands/__tests__/inspect.test.ts
+++ b/packages/cli/src/commands/__tests__/inspect.test.ts
@@ -168,6 +168,13 @@ describe('inspect command', () => {
       expect(output).toContain("Invalid task ID 'invalid' - must be a number");
     });
 
+    it('should reject malformed numeric task IDs with trailing characters', async () => {
+      await inspectCommand('12abc');
+
+      const output = capturedOutput.join('\n');
+      expect(output).toContain("Invalid task ID '12abc' - must be a number");
+    });
+
     it('should handle non-existent task', async () => {
       await inspectCommand('999');
 
@@ -264,6 +271,25 @@ describe('inspect command', () => {
       // Error output has 'errors' array from exitWithError
       expect(parsed.errors).toBeDefined();
       expect(parsed.errors[0]).toContain('Invalid task ID');
+    });
+
+    it('should output error as single JSON object for malformed numeric task ID', async () => {
+      await inspectCommand('12abc', undefined, { json: true });
+
+      const jsonOutputs = capturedOutput.filter(line => {
+        try {
+          JSON.parse(line);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(jsonOutputs.length).toBe(1);
+
+      const parsed = JSON.parse(jsonOutputs[0]);
+      expect(parsed.success).toBe(false);
+      expect(parsed.errors[0]).toContain("Invalid task ID '12abc'");
     });
 
     it('should output error as single JSON object for non-existent task', async () => {

--- a/packages/cli/src/commands/__tests__/list.test.ts
+++ b/packages/cli/src/commands/__tests__/list.test.ts
@@ -428,6 +428,7 @@ describe('list command', () => {
       expect(mockedDetectOrphanedTasks).toHaveBeenCalledTimes(1);
       const detectArgs = mockedDetectOrphanedTasks.mock.calls[0]?.[0];
       expect(detectArgs?.[0]?.task.status).toBe('COMPLETED');
+      expect(detectArgs?.[0]?.forceInspect).toBe(true);
       const detectOptions = mockedDetectOrphanedTasks.mock.calls[0]?.[1];
       expect(detectOptions).toEqual({ suppressWarnings: true });
     });

--- a/packages/cli/src/commands/__tests__/logs.test.ts
+++ b/packages/cli/src/commands/__tests__/logs.test.ts
@@ -198,10 +198,9 @@ describe('logs command', () => {
 
       await logsCommand('1.5');
 
-      // parseInt('1.5') = 1, so this should try to load task 1
       expect(exitWithError).toHaveBeenCalledWith(
         expect.objectContaining({
-          error: 'The task with ID 1 was not found',
+          error: "Invalid task ID '1.5' - must be a number",
         }),
         expect.objectContaining({
           telemetry: expect.anything(),
@@ -233,7 +232,22 @@ describe('logs command', () => {
 
       expect(exitWithError).toHaveBeenCalledWith(
         expect.objectContaining({
-          error: 'The task with ID -1 was not found',
+          error: "Invalid task ID '-1' - must be a number",
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
+      );
+    });
+
+    it('should reject malformed numeric task IDs with trailing characters', async () => {
+      const { exitWithError } = await import('../../utils/exit.js');
+
+      await logsCommand('12abc');
+
+      expect(exitWithError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: "Invalid task ID '12abc' - must be a number",
         }),
         expect.objectContaining({
           telemetry: expect.anything(),
@@ -254,6 +268,24 @@ describe('logs command', () => {
       expect(exitWithError).toHaveBeenCalledWith(
         expect.objectContaining({
           error: "Invalid iteration number: 'invalid'",
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
+      );
+    });
+
+    it('should reject malformed numeric iteration values with trailing characters', async () => {
+      await createTestTaskWithContainer(1, 'Test Task', 'container123');
+      createIterations(1, [1, 2]);
+
+      const { exitWithError } = await import('../../utils/exit.js');
+
+      await logsCommand('1', '2abc');
+
+      expect(exitWithError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: "Invalid iteration number: '2abc'",
         }),
         expect.objectContaining({
           telemetry: expect.anything(),

--- a/packages/cli/src/commands/__tests__/logs.test.ts
+++ b/packages/cli/src/commands/__tests__/logs.test.ts
@@ -835,13 +835,16 @@ Last line`;
 
       await logsCommand('14', '2', { follow: true });
 
-      expect(launch).toHaveBeenCalledWith(
-        'docker',
-        ['logs', '-f', 'follow456'],
+      const { exitWithWarn } = await import('../../utils/exit.js');
+      expect(launch).not.toHaveBeenCalled();
+      expect(exitWithWarn).toHaveBeenCalledWith(
+        "Logs for iteration 2 are no longer available for task '14'. Rover can only read logs for the latest iteration's container.",
         expect.objectContaining({
-          stdout: ['inherit'],
-          stderr: ['inherit'],
-          cancelSignal: expect.any(AbortSignal),
+          logs: '',
+          success: false,
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
         })
       );
     });
@@ -905,7 +908,7 @@ Last line`;
       );
     });
 
-    it('should use specific iteration when provided', async () => {
+    it('should only read logs for the latest iteration when explicitly requested', async () => {
       await createTestTaskWithContainer(
         17,
         'Specific Iteration Task',
@@ -923,12 +926,34 @@ Last line`;
         pid: 1234,
       } as any);
 
-      await logsCommand('17', '2');
+      await logsCommand('17', '3');
 
       expect(launchSync).toHaveBeenCalledWith(
         'docker',
         ['logs', 'specific123'],
         expect.objectContaining({ env: process.env })
+      );
+    });
+
+    it('should warn instead of reading the current container for older iterations', async () => {
+      await createTestTaskWithContainer(24, 'Older Iteration Task', 'older123');
+      createIterations(24, [1, 2, 3]);
+
+      const { launchSync } = await import('rover-core');
+      const { exitWithWarn } = await import('../../utils/exit.js');
+
+      await logsCommand('24', '2');
+
+      expect(launchSync).not.toHaveBeenCalled();
+      expect(exitWithWarn).toHaveBeenCalledWith(
+        "Logs for iteration 2 are no longer available for task '24'. Rover can only read logs for the latest iteration's container.",
+        expect.objectContaining({
+          logs: '',
+          success: false,
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
       );
     });
   });
@@ -966,6 +991,7 @@ Last line`;
       createIterations(19, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
       const { launchSync } = await import('rover-core');
+      const { exitWithWarn } = await import('../../utils/exit.js');
       vi.mocked(launchSync).mockReturnValue({
         stdout: 'Many iterations logs',
         stderr: '',
@@ -977,10 +1003,16 @@ Last line`;
 
       await logsCommand('19', '5');
 
-      expect(launchSync).toHaveBeenCalledWith(
-        'docker',
-        ['logs', 'many123'],
-        expect.objectContaining({ env: process.env })
+      expect(launchSync).not.toHaveBeenCalled();
+      expect(exitWithWarn).toHaveBeenCalledWith(
+        "Logs for iteration 5 are no longer available for task '19'. Rover can only read logs for the latest iteration's container.",
+        expect.objectContaining({
+          logs: '',
+          success: false,
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
       );
     });
   });

--- a/packages/cli/src/commands/__tests__/merge.test.ts
+++ b/packages/cli/src/commands/__tests__/merge.test.ts
@@ -193,4 +193,21 @@ describe('merge command', () => {
       expect.anything()
     );
   });
+
+  it('fails with a clear error when the current checkout is detached', async () => {
+    mockGitInstance.getCurrentBranch.mockReturnValue('unknown');
+
+    await mergeCommandModule.action('1', { json: true, force: true });
+
+    expect(mockGitInstance.hasUnmergedCommits).not.toHaveBeenCalled();
+    expect(mockExitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        currentBranch: 'unknown',
+        error:
+          'Current checkout is detached. Check out a branch before merging.',
+      }),
+      expect.objectContaining({ telemetry: expect.anything() })
+    );
+  });
 });

--- a/packages/cli/src/commands/__tests__/pause.test.ts
+++ b/packages/cli/src/commands/__tests__/pause.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearProjectRootCache, TaskDescriptionManager } from 'rover-core';
+import { pauseCommand } from '../pause.js';
+
+let testDir: string;
+
+vi.mock('../../lib/context.js', () => ({
+  requireProjectContext: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      path: testDir,
+      getTask: (taskId: number) => {
+        const taskPath = join(testDir, '.rover', 'tasks', taskId.toString());
+        if (TaskDescriptionManager.exists(taskPath)) {
+          return TaskDescriptionManager.load(taskPath, taskId);
+        }
+        return undefined;
+      },
+      getTaskIterationLogsPath: (taskId: number, iteration: number) =>
+        join(
+          testDir,
+          '.rover',
+          'tasks',
+          taskId.toString(),
+          'iterations',
+          iteration.toString(),
+          'logs'
+        ),
+    })
+  ),
+  isJsonMode: vi.fn().mockReturnValue(false),
+  setJsonMode: vi.fn(),
+}));
+
+vi.mock('../../lib/telemetry.js', () => ({
+  getTelemetry: vi.fn().mockReturnValue({
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('../../utils/exit.js', () => ({
+  exitWithError: vi.fn().mockImplementation(() => {}),
+  exitWithSuccess: vi.fn().mockImplementation(() => {}),
+}));
+
+vi.mock('../../lib/sandbox/index.js', () => ({
+  createSandbox: vi.fn(),
+}));
+
+describe('pause command', () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'rover-pause-test-'));
+    mkdirSync(join(testDir, '.rover', 'tasks'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'rover.json'),
+      JSON.stringify({ name: 'test-project' })
+    );
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    clearProjectRootCache();
+    vi.clearAllMocks();
+  });
+
+  function createTestTask(id: number): TaskDescriptionManager {
+    const taskPath = join(testDir, '.rover', 'tasks', id.toString());
+    const task = TaskDescriptionManager.create(taskPath, {
+      id,
+      title: `Task ${id}`,
+      description: 'Pause test task',
+      inputs: new Map(),
+      workflowName: 'swe',
+    });
+    task.markInProgress();
+    return task;
+  }
+
+  it('tears down sidecars after a graceful pause and preserves resumable sandbox metadata', async () => {
+    const { createSandbox } = await import('../../lib/sandbox/index.js');
+    const { exitWithSuccess } = await import('../../utils/exit.js');
+
+    const task = createTestTask(1);
+    const iterationPath = join(
+      testDir,
+      '.rover',
+      'tasks',
+      '1',
+      'iterations',
+      '1'
+    );
+    mkdirSync(iterationPath, { recursive: true });
+    writeFileSync(join(iterationPath, 'checkpoint.json'), '{"ok":true}');
+
+    task.setContainerInfo('container-1', 'running', {
+      dockerHost: 'tcp://remote:2375',
+      serviceContext: {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
+    });
+
+    const sandbox = {
+      inspect: vi
+        .fn()
+        .mockResolvedValueOnce({ status: 'running' })
+        .mockResolvedValueOnce({ status: 'exited' }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+      stopGracefully: vi.fn().mockResolvedValue(undefined),
+      getSandboxMetadata: vi.fn().mockReturnValue({
+        dockerHost: 'tcp://remote:2375',
+      }),
+    };
+    vi.mocked(createSandbox).mockResolvedValue(sandbox as any);
+
+    await pauseCommand('1', { json: true, reason: 'Paused for maintenance' });
+
+    const reloadedTask = TaskDescriptionManager.load(
+      join(testDir, '.rover', 'tasks', '1'),
+      1
+    );
+
+    const createSandboxCall = vi.mocked(createSandbox).mock.calls[0];
+    expect(createSandboxCall?.[0]).toEqual(expect.objectContaining({ id: 1 }));
+    expect(createSandboxCall?.[2]).toEqual({
+      projectPath: testDir,
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
+    expect(sandbox.stopGracefully).not.toHaveBeenCalled();
+    expect(reloadedTask.status).toBe('PAUSED');
+    expect(reloadedTask.containerId).toBe('');
+    expect(reloadedTask.sandboxMetadata).toEqual({
+      dockerHost: 'tcp://remote:2375',
+    });
+    expect(exitWithSuccess).toHaveBeenCalledWith(
+      'Task paused successfully!',
+      expect.objectContaining({
+        success: true,
+        taskId: 1,
+        status: 'PAUSED',
+        hasCheckpoint: true,
+        reason: 'Paused for maintenance',
+      }),
+      expect.objectContaining({
+        telemetry: expect.anything(),
+      })
+    );
+  });
+});

--- a/packages/cli/src/commands/__tests__/pause.test.ts
+++ b/packages/cli/src/commands/__tests__/pause.test.ts
@@ -94,7 +94,7 @@ describe('pause command', () => {
     );
   });
 
-  it('tears down sidecars after a graceful pause and preserves resumable sandbox metadata', async () => {
+  it('preserves sidecars after a graceful pause so resume can reuse them', async () => {
     const { createSandbox } = await import('../../lib/sandbox/index.js');
     const { exitWithSuccess } = await import('../../utils/exit.js');
 
@@ -125,10 +125,15 @@ describe('pause command', () => {
         .fn()
         .mockResolvedValueOnce({ status: 'running' })
         .mockResolvedValueOnce({ status: 'exited' }),
-      teardownServices: vi.fn().mockResolvedValue(undefined),
       stopGracefully: vi.fn().mockResolvedValue(undefined),
       getSandboxMetadata: vi.fn().mockReturnValue({
         dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
       }),
     };
     vi.mocked(createSandbox).mockResolvedValue(sandbox as any);
@@ -154,12 +159,23 @@ describe('pause command', () => {
         },
       },
     });
-    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(sandbox.stopGracefully).not.toHaveBeenCalled();
+    expect(sandbox.inspect).toHaveBeenNthCalledWith(1, {
+      teardownServices: false,
+    });
+    expect(sandbox.inspect).toHaveBeenNthCalledWith(2, {
+      teardownServices: false,
+    });
     expect(reloadedTask.status).toBe('PAUSED');
     expect(reloadedTask.containerId).toBe('');
     expect(reloadedTask.sandboxMetadata).toEqual({
       dockerHost: 'tcp://remote:2375',
+      serviceContext: {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
     });
     expect(exitWithSuccess).toHaveBeenCalledWith(
       'Task paused successfully!',

--- a/packages/cli/src/commands/__tests__/pause.test.ts
+++ b/packages/cli/src/commands/__tests__/pause.test.ts
@@ -191,4 +191,22 @@ describe('pause command', () => {
       })
     );
   });
+
+  it('returns an already-paused error for paused tasks', async () => {
+    const { exitWithError } = await import('../../utils/exit.js');
+
+    const task = createTestTask(2);
+    task.markPaused('Paused earlier');
+
+    await pauseCommand('2', { json: true });
+
+    expect(exitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: 'Task 2 is already paused',
+      }),
+      expect.objectContaining({
+        telemetry: expect.anything(),
+      })
+    );
+  });
 });

--- a/packages/cli/src/commands/__tests__/pause.test.ts
+++ b/packages/cli/src/commands/__tests__/pause.test.ts
@@ -79,6 +79,21 @@ describe('pause command', () => {
     return task;
   }
 
+  it('rejects malformed task IDs with trailing characters', async () => {
+    const { exitWithError } = await import('../../utils/exit.js');
+
+    await pauseCommand('12abc', { json: true });
+
+    expect(exitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: "Invalid task ID '12abc' - must be a number",
+      }),
+      expect.objectContaining({
+        telemetry: expect.anything(),
+      })
+    );
+  });
+
   it('tears down sidecars after a graceful pause and preserves resumable sandbox metadata', async () => {
     const { createSandbox } = await import('../../lib/sandbox/index.js');
     const { exitWithSuccess } = await import('../../utils/exit.js');

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -17,6 +17,7 @@ const {
   mockExecuteHooks,
   mockCollapseTaskCommits,
   mockShowRoverChat,
+  mockGetWorkspaceRepositories,
 } = vi.hoisted(() => ({
   mockRequireProjectContext: vi.fn(),
   mockSetJsonMode: vi.fn(),
@@ -26,6 +27,7 @@ const {
   mockExecuteHooks: vi.fn(),
   mockCollapseTaskCommits: vi.fn(),
   mockShowRoverChat: vi.fn(),
+  mockGetWorkspaceRepositories: vi.fn(),
 }));
 
 const mockGitInstance = vi.hoisted(() => ({
@@ -71,6 +73,10 @@ vi.mock('../../lib/squash.js', () => ({
   collapseTaskCommits: mockCollapseTaskCommits,
 }));
 
+vi.mock('../../lib/workspace-repositories.js', () => ({
+  getWorkspaceRepositories: mockGetWorkspaceRepositories,
+}));
+
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual('node:fs');
   return {
@@ -91,7 +97,10 @@ vi.mock('enquirer', () => ({
 
 vi.mock('rover-core', () => ({
   ProjectConfigManager: {
-    load: vi.fn().mockReturnValue(null),
+    load: vi.fn().mockReturnValue({
+      hooks: undefined,
+      projects: [],
+    }),
   },
   Git: vi.fn(() => mockGitInstance),
   showTitle: vi.fn(),
@@ -115,6 +124,8 @@ describe('push command', () => {
     mockGitInstance.addAndCommit.mockReturnValue(undefined);
     mockGitInstance.push.mockReturnValue(undefined);
     mockGitInstance.remoteUrl.mockReturnValue('');
+    mockGitInstance.getCurrentBranch = vi.fn().mockReturnValue('task/1');
+    mockGetWorkspaceRepositories.mockReturnValue([]);
 
     const task = {
       id: 1,
@@ -151,5 +162,25 @@ describe('push command', () => {
       }),
       expect.anything()
     );
+  });
+
+  it('pushes configured workspace repositories alongside the root workspace', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+      },
+    ]);
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1',
+    });
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
   });
 });

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -33,6 +33,7 @@ const {
 const mockGitInstance = vi.hoisted(() => ({
   uncommittedChanges: vi.fn(),
   hasUnmergedCommits: vi.fn(),
+  branchExists: vi.fn(),
   addAndCommit: vi.fn(),
   push: vi.fn(),
   remoteUrl: vi.fn(),
@@ -122,6 +123,7 @@ describe('push command', () => {
     mockExistsSync.mockReturnValue(true);
     mockGitInstance.uncommittedChanges.mockReturnValue([]);
     mockGitInstance.hasUnmergedCommits.mockReturnValue(true);
+    mockGitInstance.branchExists.mockReturnValue(true);
     mockGitInstance.addAndCommit.mockReturnValue(undefined);
     mockGitInstance.push.mockReturnValue(undefined);
     mockGitInstance.remoteUrl.mockReturnValue('');
@@ -176,6 +178,20 @@ describe('push command', () => {
         repository: 'https://example.com/frontend.git',
       },
     ]);
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      ({ worktreePath } = {}) =>
+        worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+    );
+    mockGitInstance.uncommittedChanges.mockImplementation(
+      ({ worktreePath } = {}) =>
+        worktreePath === '/tmp/task-1/frontend' ? [' M src/app.ts'] : []
+    );
+    mockGitInstance.hasUnmergedCommits.mockImplementation(
+      (_branchName, { worktreePath } = {}) => worktreePath !== '/tmp/task-1/frontend'
+    );
+    mockGitInstance.branchExists.mockImplementation(
+      (_branchName, { worktreePath } = {}) => worktreePath !== '/tmp/task-1/frontend'
+    );
 
     await pushCommandModule.action('1', { json: true });
 
@@ -188,6 +204,41 @@ describe('push command', () => {
     });
     expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
       worktreePath: '/tmp/task-1/frontend',
+    });
+  });
+
+  it('does not create or push task branches for untouched workspace repositories', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+      },
+    ]);
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      ({ worktreePath } = {}) =>
+        worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+    );
+    mockGitInstance.uncommittedChanges.mockReturnValue([]);
+    mockGitInstance.hasUnmergedCommits.mockImplementation(
+      (_branchName, { worktreePath } = {}) => worktreePath === '/tmp/task-1'
+    );
+    mockGitInstance.branchExists.mockImplementation(
+      (_branchName, { worktreePath } = {}) => worktreePath === '/tmp/task-1'
+    );
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.checkoutBranch).not.toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+      createIfMissing: true,
+    });
+    expect(mockGitInstance.push).not.toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1',
     });
   });
 });

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -416,6 +416,56 @@ describe('push command', () => {
     });
   });
 
+  it('pushes workspace repositories from detached HEAD without diffing against an invalid current branch', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? '' : 'task/1'
+    );
+    mockGitInstance.uncommittedChanges.mockReturnValue([]);
+    mockGitInstance.branchExists.mockImplementation(
+      (_branchName, options?: { worktreePath?: string }) => true
+    );
+    mockGitInstance.remoteBranchExists.mockImplementation(
+      (_branchName, _remoteName, options?: { worktreePath?: string }) =>
+        options?.worktreePath !== '/tmp/task-1/frontend'
+    );
+    mockGitInstance.hasUnmergedCommits.mockImplementation(
+      (
+        _branchName,
+        options?: { targetBranch?: string; worktreePath?: string }
+      ) => options?.worktreePath === '/tmp/task-1'
+    );
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.hasUnmergedCommits).not.toHaveBeenCalledWith(
+      'task/1',
+      expect.objectContaining({
+        targetBranch: 'unknown',
+        worktreePath: '/tmp/task-1/frontend',
+      })
+    );
+    expect(mockGitInstance.checkoutBranch).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+      createIfMissing: true,
+    });
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+  });
+
   it('skips configured workspace repositories that have not been cloned yet', async () => {
     mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
       foundPersistedState: false,

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -218,6 +218,54 @@ describe('push command', () => {
     });
   });
 
+  it('refreshes missing remote-tracking refs before deciding a workspace repo has no upstream task branch', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+      },
+    ]);
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+    );
+    mockGitInstance.uncommittedChanges.mockReturnValue([]);
+    mockGitInstance.branchExists.mockImplementation(
+      (_branchName, options?: { worktreePath?: string }) => true
+    );
+    mockGitInstance.remoteBranchExists.mockImplementation(
+      (
+        _branchName,
+        _remoteName,
+        options?: { worktreePath?: string; refreshIfMissing?: boolean }
+      ) => options?.worktreePath === '/tmp/task-1/frontend'
+    );
+    mockGitInstance.hasUnmergedCommits.mockImplementation(
+      (
+        _branchName,
+        options?: { targetBranch?: string; worktreePath?: string }
+      ) =>
+        options?.worktreePath === '/tmp/task-1/frontend' &&
+        options?.targetBranch === 'origin/task/1'
+    );
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.remoteBranchExists).toHaveBeenCalledWith(
+      'task/1',
+      'origin',
+      expect.objectContaining({
+        worktreePath: '/tmp/task-1/frontend',
+        refreshIfMissing: true,
+      })
+    );
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+  });
+
   it('does not create or push task branches for untouched workspace repositories without upstream branches', async () => {
     mockGetWorkspaceRepositories.mockReturnValue([
       {

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -34,6 +34,7 @@ const mockGitInstance = vi.hoisted(() => ({
   uncommittedChanges: vi.fn(),
   hasUnmergedCommits: vi.fn(),
   branchExists: vi.fn(),
+  remoteBranchExists: vi.fn(),
   addAndCommit: vi.fn(),
   push: vi.fn(),
   remoteUrl: vi.fn(),
@@ -127,6 +128,7 @@ describe('push command', () => {
     mockGitInstance.uncommittedChanges.mockReturnValue([]);
     mockGitInstance.hasUnmergedCommits.mockReturnValue(true);
     mockGitInstance.branchExists.mockReturnValue(true);
+    mockGitInstance.remoteBranchExists.mockReturnValue(true);
     mockGitInstance.addAndCommit.mockReturnValue(undefined);
     mockGitInstance.push.mockReturnValue(undefined);
     mockGitInstance.remoteUrl.mockReturnValue('');
@@ -197,6 +199,10 @@ describe('push command', () => {
       (_branchName, options?: { worktreePath?: string }) =>
         options?.worktreePath !== '/tmp/task-1/frontend'
     );
+    mockGitInstance.remoteBranchExists.mockImplementation(
+      (_branchName, _remoteName, options?: { worktreePath?: string }) =>
+        options?.worktreePath !== '/tmp/task-1/frontend'
+    );
 
     await pushCommandModule.action('1', { json: true });
 
@@ -212,7 +218,7 @@ describe('push command', () => {
     });
   });
 
-  it('does not create or push task branches for untouched workspace repositories', async () => {
+  it('does not create or push task branches for untouched workspace repositories without upstream branches', async () => {
     mockGetWorkspaceRepositories.mockReturnValue([
       {
         name: 'frontend',
@@ -227,11 +233,17 @@ describe('push command', () => {
     );
     mockGitInstance.uncommittedChanges.mockReturnValue([]);
     mockGitInstance.hasUnmergedCommits.mockImplementation(
-      (_branchName, options?: { worktreePath?: string }) =>
-        options?.worktreePath === '/tmp/task-1'
+      (
+        _branchName,
+        options?: { worktreePath?: string; targetBranch?: string }
+      ) => options?.worktreePath === '/tmp/task-1'
     );
     mockGitInstance.branchExists.mockImplementation(
       (_branchName, options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1'
+    );
+    mockGitInstance.remoteBranchExists.mockImplementation(
+      (_branchName, _remoteName, options?: { worktreePath?: string }) =>
         options?.worktreePath === '/tmp/task-1'
     );
 
@@ -247,5 +259,76 @@ describe('push command', () => {
     expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
       worktreePath: '/tmp/task-1',
     });
+  });
+
+  it('pushes workspace repositories with local task commits even when the upstream branch does not exist yet', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+      },
+    ]);
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+    );
+    mockGitInstance.uncommittedChanges.mockReturnValue([]);
+    mockGitInstance.branchExists.mockImplementation(
+      (_branchName, options?: { worktreePath?: string }) => true
+    );
+    mockGitInstance.remoteBranchExists.mockImplementation(
+      (_branchName, _remoteName, options?: { worktreePath?: string }) =>
+        options?.worktreePath !== '/tmp/task-1/frontend'
+    );
+    mockGitInstance.hasUnmergedCommits.mockImplementation(
+      (
+        _branchName,
+        options?: { targetBranch?: string; worktreePath?: string }
+      ) =>
+        options?.worktreePath === '/tmp/task-1/frontend' &&
+        options?.targetBranch === 'main'
+    );
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.checkoutBranch).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+      createIfMissing: true,
+    });
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+  });
+
+  it('fails when a configured workspace repository is missing from the task workspace', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+      },
+    ]);
+    mockExistsSync.mockImplementation((targetPath: string) => {
+      if (targetPath === '/tmp/task-1/frontend') {
+        return false;
+      }
+      return true;
+    });
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.push).not.toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+    expect(mockExitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error:
+          'Configured workspace repositories are missing or invalid: frontend (frontend)',
+      }),
+      expect.anything()
+    );
   });
 });

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -17,7 +17,7 @@ const {
   mockExecuteHooks,
   mockCollapseTaskCommits,
   mockShowRoverChat,
-  mockGetWorkspaceRepositories,
+  mockGetWorkspaceRepositoriesLookupResult,
 } = vi.hoisted(() => ({
   mockRequireProjectContext: vi.fn(),
   mockSetJsonMode: vi.fn(),
@@ -27,7 +27,7 @@ const {
   mockExecuteHooks: vi.fn(),
   mockCollapseTaskCommits: vi.fn(),
   mockShowRoverChat: vi.fn(),
-  mockGetWorkspaceRepositories: vi.fn(),
+  mockGetWorkspaceRepositoriesLookupResult: vi.fn(),
 }));
 
 const mockGitInstance = vi.hoisted(() => ({
@@ -80,7 +80,8 @@ vi.mock('../../lib/squash.js', () => ({
 }));
 
 vi.mock('../../lib/workspace-repositories.js', () => ({
-  getWorkspaceRepositories: mockGetWorkspaceRepositories,
+  getWorkspaceRepositoriesLookupResult:
+    mockGetWorkspaceRepositoriesLookupResult,
 }));
 
 vi.mock('node:fs', async () => {
@@ -132,7 +133,11 @@ describe('push command', () => {
     mockGitInstance.addAndCommit.mockReturnValue(undefined);
     mockGitInstance.push.mockReturnValue(undefined);
     mockGitInstance.remoteUrl.mockReturnValue('');
-    mockGetWorkspaceRepositories.mockReturnValue([]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [],
+    });
 
     const task = {
       id: 1,
@@ -173,14 +178,18 @@ describe('push command', () => {
   });
 
   it('pushes configured workspace repositories alongside the root workspace', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-      },
-    ]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
     mockGitInstance.getCurrentBranch.mockImplementation(
       (options?: { worktreePath?: string }) =>
         options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
@@ -218,15 +227,19 @@ describe('push command', () => {
     });
   });
 
-  it('refreshes missing remote-tracking refs before deciding a workspace repo has no upstream task branch', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-      },
-    ]);
+  it('refreshes remote-tracking refs before deciding a workspace repo has an upstream task branch', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
     mockGitInstance.getCurrentBranch.mockImplementation(
       (options?: { worktreePath?: string }) =>
         options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
@@ -239,7 +252,7 @@ describe('push command', () => {
       (
         _branchName,
         _remoteName,
-        options?: { worktreePath?: string; refreshIfMissing?: boolean }
+        options?: { worktreePath?: string; refresh?: boolean }
       ) => options?.worktreePath === '/tmp/task-1/frontend'
     );
     mockGitInstance.hasUnmergedCommits.mockImplementation(
@@ -258,7 +271,7 @@ describe('push command', () => {
       'origin',
       expect.objectContaining({
         worktreePath: '/tmp/task-1/frontend',
-        refreshIfMissing: true,
+        refresh: true,
       })
     );
     expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
@@ -266,15 +279,64 @@ describe('push command', () => {
     });
   });
 
+  it('treats a stale remote-tracking ref as missing when refresh shows the upstream branch was deleted', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+    );
+    mockGitInstance.uncommittedChanges.mockReturnValue([]);
+    mockGitInstance.branchExists.mockImplementation(
+      (_branchName, options?: { worktreePath?: string }) => true
+    );
+    mockGitInstance.remoteBranchExists.mockImplementation(
+      (_branchName, _remoteName, options?: { worktreePath?: string }) =>
+        options?.worktreePath !== '/tmp/task-1/frontend'
+    );
+    mockGitInstance.hasUnmergedCommits.mockImplementation(
+      (
+        _branchName,
+        options?: { targetBranch?: string; worktreePath?: string }
+      ) =>
+        options?.worktreePath === '/tmp/task-1/frontend' &&
+        options?.targetBranch === 'main'
+    );
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.hasUnmergedCommits).toHaveBeenCalledWith('task/1', {
+      targetBranch: 'main',
+      worktreePath: '/tmp/task-1/frontend',
+    });
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+  });
+
   it('does not create or push task branches for untouched workspace repositories without upstream branches', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-      },
-    ]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
     mockGitInstance.getCurrentBranch.mockImplementation(
       (options?: { worktreePath?: string }) =>
         options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
@@ -310,14 +372,18 @@ describe('push command', () => {
   });
 
   it('pushes workspace repositories with local task commits even when the upstream branch does not exist yet', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-      },
-    ]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
     mockGitInstance.getCurrentBranch.mockImplementation(
       (options?: { worktreePath?: string }) =>
         options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
@@ -350,15 +416,50 @@ describe('push command', () => {
     });
   });
 
-  it('fails when a configured workspace repository is missing from the task workspace', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-      },
-    ]);
+  it('skips configured workspace repositories that have not been cloned yet', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
+    mockExistsSync.mockImplementation((targetPath: string) => {
+      if (targetPath === '/tmp/task-1/frontend') {
+        return false;
+      }
+      return true;
+    });
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockExitWithError).not.toHaveBeenCalled();
+    expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1',
+    });
+    expect(mockGitInstance.push).not.toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+  });
+
+  it('fails when a persisted workspace repository is missing from the task workspace', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: true,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
     mockExistsSync.mockImplementation((targetPath: string) => {
       if (targetPath === '/tmp/task-1/frontend') {
         return false;
@@ -375,6 +476,25 @@ describe('push command', () => {
       expect.objectContaining({
         error:
           'Configured workspace repositories are missing or invalid: frontend (frontend)',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('fails closed when persisted workspace repository metadata is malformed', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: true,
+      hasPersistedParseErrors: true,
+      repositories: [],
+    });
+
+    await pushCommandModule.action('1', { json: true });
+
+    expect(mockGitInstance.push).not.toHaveBeenCalled();
+    expect(mockExitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error:
+          'Persisted workspace repository metadata is invalid. Fix or remove the task workspace description before pushing.',
       }),
       expect.anything()
     );

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -187,10 +187,12 @@ describe('push command', () => {
         worktreePath === '/tmp/task-1/frontend' ? [' M src/app.ts'] : []
     );
     mockGitInstance.hasUnmergedCommits.mockImplementation(
-      (_branchName, { worktreePath } = {}) => worktreePath !== '/tmp/task-1/frontend'
+      (_branchName, { worktreePath } = {}) =>
+        worktreePath !== '/tmp/task-1/frontend'
     );
     mockGitInstance.branchExists.mockImplementation(
-      (_branchName, { worktreePath } = {}) => worktreePath !== '/tmp/task-1/frontend'
+      (_branchName, { worktreePath } = {}) =>
+        worktreePath !== '/tmp/task-1/frontend'
     );
 
     await pushCommandModule.action('1', { json: true });

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -36,6 +36,7 @@ const mockGitInstance = vi.hoisted(() => ({
   addAndCommit: vi.fn(),
   push: vi.fn(),
   remoteUrl: vi.fn(),
+  checkoutBranch: vi.fn(),
 }));
 
 vi.mock('../../utils/exit.js', () => ({
@@ -124,7 +125,9 @@ describe('push command', () => {
     mockGitInstance.addAndCommit.mockReturnValue(undefined);
     mockGitInstance.push.mockReturnValue(undefined);
     mockGitInstance.remoteUrl.mockReturnValue('');
-    mockGitInstance.getCurrentBranch = vi.fn().mockReturnValue('task/1');
+    mockGitInstance.getCurrentBranch = vi.fn(({ worktreePath } = {}) =>
+      worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+    );
     mockGetWorkspaceRepositories.mockReturnValue([]);
 
     const task = {
@@ -178,6 +181,10 @@ describe('push command', () => {
 
     expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
       worktreePath: '/tmp/task-1',
+    });
+    expect(mockGitInstance.checkoutBranch).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+      createIfMissing: true,
     });
     expect(mockGitInstance.push).toHaveBeenCalledWith('task/1', {
       worktreePath: '/tmp/task-1/frontend',

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -38,6 +38,9 @@ const mockGitInstance = vi.hoisted(() => ({
   push: vi.fn(),
   remoteUrl: vi.fn(),
   checkoutBranch: vi.fn(),
+  getCurrentBranch: vi.fn((options?: { worktreePath?: string }) =>
+    options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+  ),
 }));
 
 vi.mock('../../utils/exit.js', () => ({
@@ -127,9 +130,6 @@ describe('push command', () => {
     mockGitInstance.addAndCommit.mockReturnValue(undefined);
     mockGitInstance.push.mockReturnValue(undefined);
     mockGitInstance.remoteUrl.mockReturnValue('');
-    mockGitInstance.getCurrentBranch = vi.fn(({ worktreePath } = {}) =>
-      worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
-    );
     mockGetWorkspaceRepositories.mockReturnValue([]);
 
     const task = {
@@ -179,20 +179,20 @@ describe('push command', () => {
       },
     ]);
     mockGitInstance.getCurrentBranch.mockImplementation(
-      ({ worktreePath } = {}) =>
-        worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
     );
     mockGitInstance.uncommittedChanges.mockImplementation(
-      ({ worktreePath } = {}) =>
-        worktreePath === '/tmp/task-1/frontend' ? [' M src/app.ts'] : []
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? [' M src/app.ts'] : []
     );
     mockGitInstance.hasUnmergedCommits.mockImplementation(
-      (_branchName, { worktreePath } = {}) =>
-        worktreePath !== '/tmp/task-1/frontend'
+      (_branchName, options?: { worktreePath?: string }) =>
+        options?.worktreePath !== '/tmp/task-1/frontend'
     );
     mockGitInstance.branchExists.mockImplementation(
-      (_branchName, { worktreePath } = {}) =>
-        worktreePath !== '/tmp/task-1/frontend'
+      (_branchName, options?: { worktreePath?: string }) =>
+        options?.worktreePath !== '/tmp/task-1/frontend'
     );
 
     await pushCommandModule.action('1', { json: true });
@@ -219,15 +219,17 @@ describe('push command', () => {
       },
     ]);
     mockGitInstance.getCurrentBranch.mockImplementation(
-      ({ worktreePath } = {}) =>
-        worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
     );
     mockGitInstance.uncommittedChanges.mockReturnValue([]);
     mockGitInstance.hasUnmergedCommits.mockImplementation(
-      (_branchName, { worktreePath } = {}) => worktreePath === '/tmp/task-1'
+      (_branchName, options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1'
     );
     mockGitInstance.branchExists.mockImplementation(
-      (_branchName, { worktreePath } = {}) => worktreePath === '/tmp/task-1'
+      (_branchName, options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1'
     );
 
     await pushCommandModule.action('1', { json: true });

--- a/packages/cli/src/commands/__tests__/push.test.ts
+++ b/packages/cli/src/commands/__tests__/push.test.ts
@@ -138,6 +138,7 @@ describe('push command', () => {
       branchName: 'task/1',
       baseCommit: 'abc123',
       worktreePath: '/tmp/task-1',
+      getBasePath: () => '/tmp/tasks/1',
       status: 'COMPLETED',
       isInProgress: () => false,
       isIterating: () => false,
@@ -184,7 +185,9 @@ describe('push command', () => {
     );
     mockGitInstance.uncommittedChanges.mockImplementation(
       (options?: { worktreePath?: string }) =>
-        options?.worktreePath === '/tmp/task-1/frontend' ? [' M src/app.ts'] : []
+        options?.worktreePath === '/tmp/task-1/frontend'
+          ? [' M src/app.ts']
+          : []
     );
     mockGitInstance.hasUnmergedCommits.mockImplementation(
       (_branchName, options?: { worktreePath?: string }) =>

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -275,10 +275,13 @@ describe('rebase command', () => {
       force: true,
     });
 
-    expect(mockLaunchSync).toHaveBeenCalledWith(
-      'git',
-      ['-C', '/tmp/task-1/frontend', 'fetch', 'origin', 'v1.2.3']
-    );
+    expect(mockLaunchSync).toHaveBeenCalledWith('git', [
+      '-C',
+      '/tmp/task-1/frontend',
+      'fetch',
+      'origin',
+      'v1.2.3',
+    ]);
     expect(mockLaunchSync).toHaveBeenCalledWith(
       'git',
       [

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -10,6 +10,7 @@ const {
   mockGetWorkspaceRepositories,
   mockGetAIAgentTool,
   mockRepoGitInstance,
+  mockLaunchSync,
 } = vi.hoisted(() => ({
   mockExitWithError: vi.fn(),
   mockExitWithSuccess: vi.fn(),
@@ -20,6 +21,7 @@ const {
   mockRepoGitInstance: {
     getMainBranch: vi.fn().mockReturnValue('develop'),
   },
+  mockLaunchSync: vi.fn(),
 }));
 
 const mockGitInstance = vi.hoisted(() => ({
@@ -81,6 +83,7 @@ vi.mock('rover-core', () => ({
   Git: vi.fn(({ cwd }: { cwd: string }) =>
     cwd === '/tmp/task-1/frontend' ? mockRepoGitInstance : mockGitInstance
   ),
+  launchSync: mockLaunchSync,
   ProjectConfigManager: {
     load: vi.fn().mockReturnValue({
       attribution: true,
@@ -129,6 +132,8 @@ describe('rebase command', () => {
     mockGetAIAgentTool.mockReturnValue({});
     mockRepoGitInstance.getMainBranch.mockClear();
     mockRepoGitInstance.getMainBranch.mockReturnValue('develop');
+    mockLaunchSync.mockReset();
+    mockLaunchSync.mockReturnValue({ exitCode: 0, stdout: '' });
     mockRequireProjectContext.mockResolvedValue({
       path: '/repo',
       getTask: vi.fn().mockReturnValue({
@@ -210,7 +215,14 @@ describe('rebase command', () => {
       worktreePath: '/tmp/task-1/frontend',
       createIfMissing: true,
     });
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/x', {
+    expect(mockLaunchSync).toHaveBeenCalledWith('git', [
+      '-C',
+      '/tmp/task-1/frontend',
+      'fetch',
+      'origin',
+      'release/x',
+    ]);
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('origin/release/x', {
       worktreePath: '/tmp/task-1/frontend',
     });
     expect(mockExitWithSuccess).toHaveBeenCalled();
@@ -239,9 +251,19 @@ describe('rebase command', () => {
     expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
       worktreePath: '/tmp/task-1',
     });
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/1.0', {
-      worktreePath: '/tmp/task-1/frontend',
-    });
+    expect(mockLaunchSync).toHaveBeenCalledWith('git', [
+      '-C',
+      '/tmp/task-1/frontend',
+      'fetch',
+      'origin',
+      'release/1.0',
+    ]);
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
+      'origin/release/1.0',
+      {
+        worktreePath: '/tmp/task-1/frontend',
+      }
+    );
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 
@@ -269,9 +291,19 @@ describe('rebase command', () => {
       worktreePath: '/tmp/task-1',
     });
     expect(mockRepoGitInstance.getMainBranch).toHaveBeenCalled();
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('develop', {
-      worktreePath: '/tmp/task-1/frontend',
-    });
+    expect(mockLaunchSync).toHaveBeenCalledWith('git', [
+      '-C',
+      '/tmp/task-1/frontend',
+      'fetch',
+      'origin',
+      'develop',
+    ]);
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
+      'origin/develop',
+      {
+        worktreePath: '/tmp/task-1/frontend',
+      }
+    );
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -2,14 +2,35 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
 import { resolvePathWithinRoot } from '../../utils/path-safety.js';
 
-const { mockExitWithError, mockGetTelemetry } = vi.hoisted(() => ({
+const {
+  mockExitWithError,
+  mockExitWithSuccess,
+  mockGetTelemetry,
+  mockRequireProjectContext,
+  mockGetWorkspaceRepositories,
+  mockGetAIAgentTool,
+} = vi.hoisted(() => ({
   mockExitWithError: vi.fn(),
+  mockExitWithSuccess: vi.fn(),
   mockGetTelemetry: vi.fn(),
+  mockRequireProjectContext: vi.fn(),
+  mockGetWorkspaceRepositories: vi.fn(),
+  mockGetAIAgentTool: vi.fn(),
+}));
+
+const mockGitInstance = vi.hoisted(() => ({
+  isGitRepo: vi.fn().mockReturnValue(true),
+  getCurrentBranch: vi.fn().mockReturnValue('main'),
+  hasUncommittedChanges: vi.fn().mockReturnValue(false),
+  getRecentCommits: vi.fn().mockReturnValue([]),
+  rebaseBranch: vi.fn().mockReturnValue({ success: true }),
+  getMergeConflicts: vi.fn().mockReturnValue([]),
+  getCommitHash: vi.fn().mockReturnValue('new-base'),
 }));
 
 vi.mock('../../utils/exit.js', () => ({
   exitWithError: mockExitWithError,
-  exitWithSuccess: vi.fn(),
+  exitWithSuccess: mockExitWithSuccess,
   exitWithWarn: vi.fn(),
 }));
 
@@ -20,7 +41,7 @@ vi.mock('../../lib/telemetry.js', () => ({
 vi.mock('../../lib/context.js', () => ({
   isJsonMode: vi.fn().mockReturnValue(true),
   setJsonMode: vi.fn(),
-  requireProjectContext: vi.fn(),
+  requireProjectContext: mockRequireProjectContext,
 }));
 
 vi.mock('../../utils/display.js', () => ({
@@ -37,13 +58,24 @@ vi.mock('yocto-spinner', () => ({
   default: vi.fn(),
 }));
 
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(true),
+  };
+});
+
 vi.mock('rover-core', () => ({
   AI_AGENT: {
     Claude: 'claude',
   },
-  Git: vi.fn(),
+  Git: vi.fn(() => mockGitInstance),
   ProjectConfigManager: {
-    load: vi.fn(),
+    load: vi.fn().mockReturnValue({
+      attribution: true,
+      projects: [],
+    }),
   },
   UserSettingsManager: {
     exists: vi.fn().mockReturnValue(false),
@@ -52,7 +84,7 @@ vi.mock('rover-core', () => ({
 }));
 
 vi.mock('../../lib/agents/index.js', () => ({
-  getAIAgentTool: vi.fn(),
+  getAIAgentTool: mockGetAIAgentTool,
   getUserDefaultModel: vi.fn(),
 }));
 
@@ -69,6 +101,10 @@ vi.mock('../../lib/context-optimizer.js', () => ({
   hasConflictMarkers: vi.fn(),
 }));
 
+vi.mock('../../lib/workspace-repositories.js', () => ({
+  getWorkspaceRepositories: mockGetWorkspaceRepositories,
+}));
+
 import { rebaseCommand } from '../rebase.js';
 
 describe('rebase command', () => {
@@ -78,6 +114,32 @@ describe('rebase command', () => {
       shutdown: vi.fn().mockResolvedValue(undefined),
     });
     mockExitWithError.mockResolvedValue(undefined);
+    mockExitWithSuccess.mockResolvedValue(undefined);
+    mockGetWorkspaceRepositories.mockReturnValue([]);
+    mockGetAIAgentTool.mockReturnValue({});
+    mockRequireProjectContext.mockResolvedValue({
+      path: '/repo',
+      getTask: vi.fn().mockReturnValue({
+        id: 1,
+        title: 'Test task',
+        description: 'test',
+        branchName: 'task/1',
+        baseCommit: 'base',
+        worktreePath: '/tmp/task-1',
+        status: 'COMPLETED',
+        iterations: 1,
+        isInProgress: () => false,
+        isIterating: () => false,
+        isPaused: () => false,
+        iterationsPath: () => '/tmp/task-1/.rover/iterations',
+        setBaseCommit: vi.fn(),
+      }),
+    });
+    Object.values(mockGitInstance).forEach(value => {
+      if (typeof value === 'function' && 'mockClear' in value) {
+        value.mockClear();
+      }
+    });
   });
 
   it('rejects malformed numeric task IDs with trailing characters', async () => {
@@ -110,5 +172,27 @@ describe('rebase command', () => {
         path.win32 as typeof path
       )
     ).toBeNull();
+  });
+
+  it('rebases configured workspace repositories after the root workspace', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+        ref: 'main',
+      },
+    ]);
+
+    await rebaseCommand('1', { json: true, force: true });
+
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
+      worktreePath: '/tmp/task-1',
+    });
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+    expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -143,6 +143,7 @@ describe('rebase command', () => {
         branchName: 'task/1',
         baseCommit: 'base',
         worktreePath: '/tmp/task-1',
+        getBasePath: () => '/tmp/tasks/1',
         status: 'COMPLETED',
         iterations: 1,
         isInProgress: () => false,
@@ -243,9 +244,7 @@ describe('rebase command', () => {
     ]);
     mockGitInstance.getCurrentBranch.mockImplementation(
       (options?: { worktreePath?: string }) =>
-        options?.worktreePath === '/tmp/task-1/frontend'
-          ? 'task/1'
-          : 'main'
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
     );
 
     await rebaseCommand('1', {

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetAIAgentTool,
   mockRepoGitInstance,
   mockLaunchSync,
+  mockExistsSync,
 } = vi.hoisted(() => ({
   mockExitWithError: vi.fn(),
   mockExitWithSuccess: vi.fn(),
@@ -22,6 +23,7 @@ const {
     getMainBranch: vi.fn().mockReturnValue('develop'),
   },
   mockLaunchSync: vi.fn(),
+  mockExistsSync: vi.fn(),
 }));
 
 const mockGitInstance = vi.hoisted(() => ({
@@ -72,7 +74,7 @@ vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
-    existsSync: vi.fn().mockReturnValue(true),
+    existsSync: mockExistsSync,
   };
 });
 
@@ -134,6 +136,7 @@ describe('rebase command', () => {
     mockRepoGitInstance.getMainBranch.mockReturnValue('develop');
     mockLaunchSync.mockReset();
     mockLaunchSync.mockReturnValue({ exitCode: 0, stdout: '' });
+    mockExistsSync.mockReturnValue(true);
     mockRequireProjectContext.mockResolvedValue({
       path: '/repo',
       getTask: vi.fn().mockReturnValue({
@@ -311,5 +314,41 @@ describe('rebase command', () => {
       }
     );
     expect(mockExitWithSuccess).toHaveBeenCalled();
+  });
+
+  it('fails when a configured workspace repository is missing from the task workspace', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+      },
+    ]);
+    mockExistsSync.mockImplementation((targetPath: string) => {
+      if (targetPath === '/tmp/task-1/frontend') {
+        return false;
+      }
+      return true;
+    });
+
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+    });
+
+    expect(mockGitInstance.rebaseBranch).not.toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        worktreePath: '/tmp/task-1/frontend',
+      }
+    );
+    expect(mockExitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error:
+          'Configured workspace repositories are missing or invalid: frontend (frontend)',
+      }),
+      expect.anything()
+    );
   });
 });

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -9,7 +9,7 @@ const {
   mockRequireProjectContext,
   mockGetWorkspaceRepositories,
   mockGetAIAgentTool,
-  mockLaunchSync,
+  mockRepoGitInstance,
 } = vi.hoisted(() => ({
   mockExitWithError: vi.fn(),
   mockExitWithSuccess: vi.fn(),
@@ -17,7 +17,9 @@ const {
   mockRequireProjectContext: vi.fn(),
   mockGetWorkspaceRepositories: vi.fn(),
   mockGetAIAgentTool: vi.fn(),
-  mockLaunchSync: vi.fn(),
+  mockRepoGitInstance: {
+    getMainBranch: vi.fn().mockReturnValue('develop'),
+  },
 }));
 
 const mockGitInstance = vi.hoisted(() => ({
@@ -25,6 +27,7 @@ const mockGitInstance = vi.hoisted(() => ({
   getCurrentBranch: vi.fn(({ worktreePath } = {}) =>
     worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
   ),
+  getMainBranch: vi.fn().mockReturnValue('main'),
   hasUncommittedChanges: vi.fn().mockReturnValue(false),
   getRecentCommits: vi.fn().mockReturnValue([]),
   rebaseBranch: vi.fn().mockReturnValue({ success: true }),
@@ -75,8 +78,9 @@ vi.mock('rover-core', () => ({
   AI_AGENT: {
     Claude: 'claude',
   },
-  Git: vi.fn(() => mockGitInstance),
-  launchSync: mockLaunchSync,
+  Git: vi.fn(({ cwd }: { cwd: string }) =>
+    cwd === '/tmp/task-1/frontend' ? mockRepoGitInstance : mockGitInstance
+  ),
   ProjectConfigManager: {
     load: vi.fn().mockReturnValue({
       attribution: true,
@@ -123,8 +127,8 @@ describe('rebase command', () => {
     mockExitWithSuccess.mockResolvedValue(undefined);
     mockGetWorkspaceRepositories.mockReturnValue([]);
     mockGetAIAgentTool.mockReturnValue({});
-    mockLaunchSync.mockReset();
-    mockLaunchSync.mockReturnValue({ exitCode: 0, stdout: '' });
+    mockRepoGitInstance.getMainBranch.mockClear();
+    mockRepoGitInstance.getMainBranch.mockReturnValue('develop');
     mockRequireProjectContext.mockResolvedValue({
       path: '/repo',
       getTask: vi.fn().mockReturnValue({
@@ -206,13 +210,9 @@ describe('rebase command', () => {
       worktreePath: '/tmp/task-1/frontend',
       createIfMissing: true,
     });
-    // Sub-project repos rebase onto origin/<base> after fetching
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
-      'origin/release/x',
-      {
-        worktreePath: '/tmp/task-1/frontend',
-      }
-    );
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/x', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 
@@ -239,62 +239,37 @@ describe('rebase command', () => {
     expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
       worktreePath: '/tmp/task-1',
     });
-    // Sub-project repos rebase onto origin/<ref> after fetching
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
-      'origin/release/1.0',
-      {
-        worktreePath: '/tmp/task-1/frontend',
-      }
-    );
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/1.0', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 
-  it('rebases detached workspace refs against the raw ref', async () => {
+  it('rebases workspace repositories without refs onto their own default branch', async () => {
     mockGetWorkspaceRepositories.mockReturnValue([
       {
         name: 'frontend',
         relativePath: 'frontend',
         worktreePath: '/tmp/task-1/frontend',
         repository: 'https://example.com/frontend.git',
-        ref: 'v1.2.3',
       },
     ]);
     mockGitInstance.getCurrentBranch.mockImplementation(
       ({ worktreePath } = {}) =>
-        worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
+        worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'release/root'
     );
-    mockLaunchSync.mockImplementation((_command, args) => {
-      if (Array.isArray(args) && args.includes('show-ref')) {
-        return { exitCode: 1, stdout: '' };
-      }
-      return { exitCode: 0, stdout: '' };
-    });
+    mockRepoGitInstance.getMainBranch.mockReturnValue('develop');
 
     await rebaseCommand('1', {
       json: true,
       force: true,
     });
 
-    expect(mockLaunchSync).toHaveBeenCalledWith('git', [
-      '-C',
-      '/tmp/task-1/frontend',
-      'fetch',
-      'origin',
-      'v1.2.3',
-    ]);
-    expect(mockLaunchSync).toHaveBeenCalledWith(
-      'git',
-      [
-        '-C',
-        '/tmp/task-1/frontend',
-        'show-ref',
-        '--verify',
-        '--quiet',
-        'refs/remotes/origin/v1.2.3',
-      ],
-      { reject: false }
-    );
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('v1.2.3', {
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/root', {
+      worktreePath: '/tmp/task-1',
+    });
+    expect(mockRepoGitInstance.getMainBranch).toHaveBeenCalled();
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('develop', {
       worktreePath: '/tmp/task-1/frontend',
     });
     expect(mockExitWithSuccess).toHaveBeenCalled();

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -26,8 +26,8 @@ const {
 
 const mockGitInstance = vi.hoisted(() => ({
   isGitRepo: vi.fn().mockReturnValue(true),
-  getCurrentBranch: vi.fn(({ worktreePath } = {}) =>
-    worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+  getCurrentBranch: vi.fn((options?: { worktreePath?: string }): string =>
+    options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
   ),
   getMainBranch: vi.fn().mockReturnValue('main'),
   hasUncommittedChanges: vi.fn().mockReturnValue(false),
@@ -242,8 +242,10 @@ describe('rebase command', () => {
       },
     ]);
     mockGitInstance.getCurrentBranch.mockImplementation(
-      ({ worktreePath } = {}) =>
-        worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend'
+          ? 'task/1'
+          : 'main'
     );
 
     await rebaseCommand('1', {
@@ -280,8 +282,10 @@ describe('rebase command', () => {
       },
     ]);
     mockGitInstance.getCurrentBranch.mockImplementation(
-      ({ worktreePath } = {}) =>
-        worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'release/root'
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend'
+          ? 'task/1'
+          : 'release/root'
     );
     mockRepoGitInstance.getMainBranch.mockReturnValue('develop');
 

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -194,6 +194,26 @@ describe('rebase command', () => {
     );
   });
 
+  it('fails with a clear error when rebasing from a detached checkout without --base', async () => {
+    mockGitInstance.getCurrentBranch.mockReturnValue('unknown');
+
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+    });
+
+    expect(mockGitInstance.rebaseBranch).not.toHaveBeenCalled();
+    expect(mockExitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        currentBranch: 'unknown',
+        error:
+          'Current checkout is detached. Pass `--base <branch>` or check out a branch before rebasing.',
+      }),
+      expect.objectContaining({ telemetry: expect.anything() })
+    );
+  });
+
   it('accepts paths under the root with Windows separators', () => {
     expect(
       resolvePathWithinRoot(

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -217,8 +217,9 @@ describe('rebase command', () => {
         ref: 'release/1.0',
       },
     ]);
-    mockGitInstance.getCurrentBranch.mockImplementation(({ worktreePath } = {}) =>
-      worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      ({ worktreePath } = {}) =>
+        worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
     );
 
     await rebaseCommand('1', {

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -7,7 +7,7 @@ const {
   mockExitWithSuccess,
   mockGetTelemetry,
   mockRequireProjectContext,
-  mockGetWorkspaceRepositories,
+  mockGetWorkspaceRepositoriesLookupResult,
   mockGetAIAgentTool,
   mockRepoGitInstance,
   mockLaunchSync,
@@ -17,10 +17,11 @@ const {
   mockExitWithSuccess: vi.fn(),
   mockGetTelemetry: vi.fn(),
   mockRequireProjectContext: vi.fn(),
-  mockGetWorkspaceRepositories: vi.fn(),
+  mockGetWorkspaceRepositoriesLookupResult: vi.fn(),
   mockGetAIAgentTool: vi.fn(),
   mockRepoGitInstance: {
     getMainBranch: vi.fn().mockReturnValue('develop'),
+    remoteBranchExists: vi.fn().mockReturnValue(true),
   },
   mockLaunchSync: vi.fn(),
   mockExistsSync: vi.fn(),
@@ -117,7 +118,8 @@ vi.mock('../../lib/context-optimizer.js', () => ({
 }));
 
 vi.mock('../../lib/workspace-repositories.js', () => ({
-  getWorkspaceRepositories: mockGetWorkspaceRepositories,
+  getWorkspaceRepositoriesLookupResult:
+    mockGetWorkspaceRepositoriesLookupResult,
 }));
 
 import { rebaseCommand } from '../rebase.js';
@@ -130,13 +132,30 @@ describe('rebase command', () => {
     });
     mockExitWithError.mockResolvedValue(undefined);
     mockExitWithSuccess.mockResolvedValue(undefined);
-    mockGetWorkspaceRepositories.mockReturnValue([]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [],
+    });
     mockGetAIAgentTool.mockReturnValue({});
     mockRepoGitInstance.getMainBranch.mockClear();
     mockRepoGitInstance.getMainBranch.mockReturnValue('develop');
+    mockRepoGitInstance.remoteBranchExists.mockClear();
+    mockRepoGitInstance.remoteBranchExists.mockReturnValue(true);
     mockLaunchSync.mockReset();
     mockLaunchSync.mockReturnValue({ exitCode: 0, stdout: '' });
     mockExistsSync.mockReturnValue(true);
+    mockGitInstance.isGitRepo.mockReturnValue(true);
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      (options?: { worktreePath?: string }): string =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+    );
+    mockGitInstance.getMainBranch.mockReturnValue('main');
+    mockGitInstance.hasUncommittedChanges.mockReturnValue(false);
+    mockGitInstance.getRecentCommits.mockReturnValue([]);
+    mockGitInstance.rebaseBranch.mockReturnValue({ success: true });
+    mockGitInstance.getMergeConflicts.mockReturnValue([]);
+    mockGitInstance.getCommitHash.mockReturnValue('new-base');
     mockRequireProjectContext.mockResolvedValue({
       path: '/repo',
       getTask: vi.fn().mockReturnValue({
@@ -196,15 +215,19 @@ describe('rebase command', () => {
   });
 
   it('rebases configured workspace repositories onto the requested base branch', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-        ref: 'main',
-      },
-    ]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+          ref: 'main',
+        },
+      ],
+    });
 
     await rebaseCommand('1', {
       json: true,
@@ -226,6 +249,13 @@ describe('rebase command', () => {
       'origin',
       'release/x',
     ]);
+    expect(mockRepoGitInstance.remoteBranchExists).toHaveBeenCalledWith(
+      'release/x',
+      'origin',
+      expect.objectContaining({
+        refresh: true,
+      })
+    );
     expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
       'origin/release/x',
       {
@@ -236,15 +266,19 @@ describe('rebase command', () => {
   });
 
   it('rebases each workspace repository onto its configured ref by default', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-        ref: 'release/1.0',
-      },
-    ]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+          ref: 'release/1.0',
+        },
+      ],
+    });
     mockGitInstance.getCurrentBranch.mockImplementation(
       (options?: { worktreePath?: string }) =>
         options?.worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
@@ -265,6 +299,13 @@ describe('rebase command', () => {
       'origin',
       'release/1.0',
     ]);
+    expect(mockRepoGitInstance.remoteBranchExists).toHaveBeenCalledWith(
+      'release/1.0',
+      'origin',
+      expect.objectContaining({
+        refresh: true,
+      })
+    );
     expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
       'origin/release/1.0',
       {
@@ -275,14 +316,18 @@ describe('rebase command', () => {
   });
 
   it('rebases workspace repositories without refs onto their own default branch', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
-      {
-        name: 'frontend',
-        relativePath: 'frontend',
-        worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-      },
-    ]);
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
     mockGitInstance.getCurrentBranch.mockImplementation(
       (options?: { worktreePath?: string }) =>
         options?.worktreePath === '/tmp/task-1/frontend'
@@ -307,6 +352,13 @@ describe('rebase command', () => {
       'origin',
       'develop',
     ]);
+    expect(mockRepoGitInstance.remoteBranchExists).toHaveBeenCalledWith(
+      'develop',
+      'origin',
+      expect.objectContaining({
+        refresh: true,
+      })
+    );
     expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
       'origin/develop',
       {
@@ -316,15 +368,110 @@ describe('rebase command', () => {
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 
-  it('fails when a configured workspace repository is missing from the task workspace', async () => {
-    mockGetWorkspaceRepositories.mockReturnValue([
+  it('falls back to the local base branch when refresh shows the remote base ref is stale', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+          ref: 'develop',
+        },
+      ],
+    });
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
+    );
+    mockRepoGitInstance.remoteBranchExists.mockImplementation(
+      (branchName, _remoteName, options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend'
+          ? branchName === 'task/1'
+          : false
+    );
+
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+    });
+
+    expect(mockRepoGitInstance.remoteBranchExists).toHaveBeenCalledWith(
+      'develop',
+      'origin',
+      expect.objectContaining({
+        refresh: true,
+      })
+    );
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('develop', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+    expect(mockGitInstance.rebaseBranch).not.toHaveBeenCalledWith(
+      'origin/develop',
       {
-        name: 'frontend',
-        relativePath: 'frontend',
         worktreePath: '/tmp/task-1/frontend',
-        repository: 'https://example.com/frontend.git',
-      },
-    ]);
+      }
+    );
+  });
+
+  it('skips configured workspace repositories that have not been cloned yet', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: false,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
+    mockExistsSync.mockImplementation((targetPath: string) => {
+      if (targetPath === '/tmp/task-1/frontend') {
+        return false;
+      }
+      return true;
+    });
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      (options?: { worktreePath?: string }) =>
+        options?.worktreePath === '/tmp/task-1/frontend'
+          ? 'task/1'
+          : 'release/root'
+    );
+
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+    });
+
+    expect(mockExitWithError).not.toHaveBeenCalled();
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/root', {
+      worktreePath: '/tmp/task-1',
+    });
+    expect(mockGitInstance.rebaseBranch).not.toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        worktreePath: '/tmp/task-1/frontend',
+      }
+    );
+  });
+
+  it('fails when a persisted workspace repository is missing from the task workspace', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: true,
+      hasPersistedParseErrors: false,
+      repositories: [
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: '/tmp/task-1/frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    });
     mockExistsSync.mockImplementation((targetPath: string) => {
       if (targetPath === '/tmp/task-1/frontend') {
         return false;
@@ -347,6 +494,28 @@ describe('rebase command', () => {
       expect.objectContaining({
         error:
           'Configured workspace repositories are missing or invalid: frontend (frontend)',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('fails closed when persisted workspace repository metadata is malformed', async () => {
+    mockGetWorkspaceRepositoriesLookupResult.mockReturnValue({
+      foundPersistedState: true,
+      hasPersistedParseErrors: true,
+      repositories: [],
+    });
+
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+    });
+
+    expect(mockGitInstance.rebaseBranch).not.toHaveBeenCalled();
+    expect(mockExitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error:
+          'Persisted workspace repository metadata is invalid. Fix or remove the task workspace description before rebasing.',
       }),
       expect.anything()
     );

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolvePathWithinRoot } from '../../utils/path-safety.js';
 
 const {
@@ -20,12 +20,15 @@ const {
 
 const mockGitInstance = vi.hoisted(() => ({
   isGitRepo: vi.fn().mockReturnValue(true),
-  getCurrentBranch: vi.fn().mockReturnValue('main'),
+  getCurrentBranch: vi.fn(({ worktreePath } = {}) =>
+    worktreePath === '/tmp/task-1/frontend' ? 'main' : 'task/1'
+  ),
   hasUncommittedChanges: vi.fn().mockReturnValue(false),
   getRecentCommits: vi.fn().mockReturnValue([]),
   rebaseBranch: vi.fn().mockReturnValue({ success: true }),
   getMergeConflicts: vi.fn().mockReturnValue([]),
   getCommitHash: vi.fn().mockReturnValue('new-base'),
+  checkoutBranch: vi.fn(),
 }));
 
 vi.mock('../../utils/exit.js', () => ({
@@ -174,7 +177,7 @@ describe('rebase command', () => {
     ).toBeNull();
   });
 
-  it('rebases configured workspace repositories after the root workspace', async () => {
+  it('rebases configured workspace repositories onto the requested base branch', async () => {
     mockGetWorkspaceRepositories.mockReturnValue([
       {
         name: 'frontend',
@@ -185,12 +188,20 @@ describe('rebase command', () => {
       },
     ]);
 
-    await rebaseCommand('1', { json: true, force: true });
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+      base: 'release/x',
+    });
 
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/x', {
       worktreePath: '/tmp/task-1',
     });
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
+    expect(mockGitInstance.checkoutBranch).toHaveBeenCalledWith('task/1', {
+      worktreePath: '/tmp/task-1/frontend',
+      createIfMissing: true,
+    });
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/x', {
       worktreePath: '/tmp/task-1/frontend',
     });
     expect(mockExitWithSuccess).toHaveBeenCalled();

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -222,9 +222,12 @@ describe('rebase command', () => {
       'origin',
       'release/x',
     ]);
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('origin/release/x', {
-      worktreePath: '/tmp/task-1/frontend',
-    });
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
+      'origin/release/x',
+      {
+        worktreePath: '/tmp/task-1/frontend',
+      }
+    );
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -206,4 +206,32 @@ describe('rebase command', () => {
     });
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
+
+  it('rebases each workspace repository onto its configured ref by default', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+        ref: 'release/1.0',
+      },
+    ]);
+    mockGitInstance.getCurrentBranch.mockImplementation(({ worktreePath } = {}) =>
+      worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
+    );
+
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+    });
+
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
+      worktreePath: '/tmp/task-1',
+    });
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/1.0', {
+      worktreePath: '/tmp/task-1/frontend',
+    });
+    expect(mockExitWithSuccess).toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/commands/__tests__/rebase.test.ts
+++ b/packages/cli/src/commands/__tests__/rebase.test.ts
@@ -9,6 +9,7 @@ const {
   mockRequireProjectContext,
   mockGetWorkspaceRepositories,
   mockGetAIAgentTool,
+  mockLaunchSync,
 } = vi.hoisted(() => ({
   mockExitWithError: vi.fn(),
   mockExitWithSuccess: vi.fn(),
@@ -16,6 +17,7 @@ const {
   mockRequireProjectContext: vi.fn(),
   mockGetWorkspaceRepositories: vi.fn(),
   mockGetAIAgentTool: vi.fn(),
+  mockLaunchSync: vi.fn(),
 }));
 
 const mockGitInstance = vi.hoisted(() => ({
@@ -74,6 +76,7 @@ vi.mock('rover-core', () => ({
     Claude: 'claude',
   },
   Git: vi.fn(() => mockGitInstance),
+  launchSync: mockLaunchSync,
   ProjectConfigManager: {
     load: vi.fn().mockReturnValue({
       attribution: true,
@@ -120,6 +123,8 @@ describe('rebase command', () => {
     mockExitWithSuccess.mockResolvedValue(undefined);
     mockGetWorkspaceRepositories.mockReturnValue([]);
     mockGetAIAgentTool.mockReturnValue({});
+    mockLaunchSync.mockReset();
+    mockLaunchSync.mockReturnValue({ exitCode: 0, stdout: '' });
     mockRequireProjectContext.mockResolvedValue({
       path: '/repo',
       getTask: vi.fn().mockReturnValue({
@@ -201,9 +206,13 @@ describe('rebase command', () => {
       worktreePath: '/tmp/task-1/frontend',
       createIfMissing: true,
     });
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/x', {
-      worktreePath: '/tmp/task-1/frontend',
-    });
+    // Sub-project repos rebase onto origin/<base> after fetching
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
+      'origin/release/x',
+      {
+        worktreePath: '/tmp/task-1/frontend',
+      }
+    );
     expect(mockExitWithSuccess).toHaveBeenCalled();
   });
 
@@ -230,7 +239,59 @@ describe('rebase command', () => {
     expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('main', {
       worktreePath: '/tmp/task-1',
     });
-    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('release/1.0', {
+    // Sub-project repos rebase onto origin/<ref> after fetching
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith(
+      'origin/release/1.0',
+      {
+        worktreePath: '/tmp/task-1/frontend',
+      }
+    );
+    expect(mockExitWithSuccess).toHaveBeenCalled();
+  });
+
+  it('rebases detached workspace refs against the raw ref', async () => {
+    mockGetWorkspaceRepositories.mockReturnValue([
+      {
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: '/tmp/task-1/frontend',
+        repository: 'https://example.com/frontend.git',
+        ref: 'v1.2.3',
+      },
+    ]);
+    mockGitInstance.getCurrentBranch.mockImplementation(
+      ({ worktreePath } = {}) =>
+        worktreePath === '/tmp/task-1/frontend' ? 'task/1' : 'main'
+    );
+    mockLaunchSync.mockImplementation((_command, args) => {
+      if (Array.isArray(args) && args.includes('show-ref')) {
+        return { exitCode: 1, stdout: '' };
+      }
+      return { exitCode: 0, stdout: '' };
+    });
+
+    await rebaseCommand('1', {
+      json: true,
+      force: true,
+    });
+
+    expect(mockLaunchSync).toHaveBeenCalledWith(
+      'git',
+      ['-C', '/tmp/task-1/frontend', 'fetch', 'origin', 'v1.2.3']
+    );
+    expect(mockLaunchSync).toHaveBeenCalledWith(
+      'git',
+      [
+        '-C',
+        '/tmp/task-1/frontend',
+        'show-ref',
+        '--verify',
+        '--quiet',
+        'refs/remotes/origin/v1.2.3',
+      ],
+      { reject: false }
+    );
+    expect(mockGitInstance.rebaseBranch).toHaveBeenCalledWith('v1.2.3', {
       worktreePath: '/tmp/task-1/frontend',
     });
     expect(mockExitWithSuccess).toHaveBeenCalled();

--- a/packages/cli/src/commands/__tests__/reset.test.ts
+++ b/packages/cli/src/commands/__tests__/reset.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { clearProjectRootCache, TaskDescriptionManager } from 'rover-core';
+import resetCommand from '../reset.js';
+
+let testDir: string;
+
+const { mockTelemetry } = vi.hoisted(() => ({
+  mockTelemetry: {
+    eventReset: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../lib/context.js', () => ({
+  requireProjectContext: vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      path: testDir,
+      getTask: (taskId: number) => {
+        const taskPath = join(testDir, '.rover', 'tasks', taskId.toString());
+        if (TaskDescriptionManager.exists(taskPath)) {
+          return TaskDescriptionManager.load(taskPath, taskId);
+        }
+        return undefined;
+      },
+      getTaskPath: (taskId: number) =>
+        join(testDir, '.rover', 'tasks', taskId.toString()),
+    })
+  ),
+}));
+
+vi.mock('../../lib/telemetry.js', () => ({
+  getTelemetry: vi.fn().mockReturnValue(mockTelemetry),
+}));
+
+vi.mock('../../utils/exit.js', () => ({
+  exitWithError: vi.fn().mockImplementation(() => {}),
+  exitWithWarn: vi.fn().mockImplementation(() => {}),
+  exitWithSuccess: vi.fn().mockImplementation(() => {}),
+}));
+
+vi.mock('enquirer', () => ({
+  default: {
+    prompt: vi.fn(),
+  },
+}));
+
+describe('reset command', () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'rover-reset-test-'));
+    mkdirSync(join(testDir, '.rover', 'tasks'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'rover.json'),
+      JSON.stringify({ name: 'test-project' })
+    );
+    vi.clearAllMocks();
+    mockTelemetry.shutdown.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+    clearProjectRootCache();
+    vi.clearAllMocks();
+  });
+
+  it('rejects malformed numeric task IDs with trailing characters', async () => {
+    const { exitWithError } = await import('../../utils/exit.js');
+
+    await resetCommand.action('12abc', { force: true });
+
+    expect(exitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "Invalid task ID '12abc' - must be a number",
+      }),
+      expect.objectContaining({
+        telemetry: expect.anything(),
+      })
+    );
+    expect(mockTelemetry.shutdown).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/__tests__/restart.test.ts
+++ b/packages/cli/src/commands/__tests__/restart.test.ts
@@ -9,6 +9,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { restartCommand } from '../restart.js';
+import { createSandbox } from '../../lib/sandbox/index.js';
 import {
   TaskDescriptionManager,
   clearProjectRootCache,
@@ -74,6 +75,7 @@ vi.mock('../../lib/sandbox/index.js', () => ({
 
 describe('restart command', async () => {
   let originalCwd: string;
+  const mockedCreateSandbox = vi.mocked(createSandbox);
 
   beforeEach(() => {
     // Clear project root cache to ensure tests use the correct directory
@@ -136,6 +138,41 @@ describe('restart command', async () => {
   });
 
   describe('basic functionality', () => {
+    it('passes stored sandboxMetadata when checking whether an active task container is still running', async () => {
+      const taskId = 901;
+      const taskDir = join(testDir, '.rover', 'tasks', taskId.toString());
+
+      const task = TaskDescriptionManager.create(taskDir, {
+        id: taskId,
+        title: 'Running Task',
+        description: 'A running task',
+        inputs: new Map(),
+        workflowName: 'swe',
+      });
+      task.markInProgress();
+      task.setContainerInfo('remote-container', 'running', {
+        dockerHost: 'tcp://remote:2375',
+      });
+
+      mockedCreateSandbox.mockResolvedValueOnce({
+        inspect: vi.fn().mockResolvedValue({ status: 'running' }),
+      } as any);
+
+      await restartCommand(taskId.toString(), { json: true });
+
+      const reloadedTask = TaskDescriptionManager.load(taskDir, taskId);
+      expect(mockedCreateSandbox).toHaveBeenCalledWith(
+        reloadedTask,
+        undefined,
+        {
+          projectPath: testDir,
+          sandboxMetadata: {
+            dockerHost: 'tcp://remote:2375',
+          },
+        }
+      );
+    });
+
     it('should restart a failed task successfully', async () => {
       // Create a failed task
       const taskId = 123;

--- a/packages/cli/src/commands/__tests__/restart.test.ts
+++ b/packages/cli/src/commands/__tests__/restart.test.ts
@@ -200,6 +200,47 @@ describe('restart command', async () => {
       expect(reloadedTask.lastRestartAt).toBeDefined();
     });
 
+    it('passes persisted sandboxMetadata when starting the replacement sandbox', async () => {
+      const taskId = 902;
+      const taskDir = join(testDir, '.rover', 'tasks', taskId.toString());
+
+      const task = TaskDescriptionManager.create(taskDir, {
+        id: taskId,
+        title: 'Failed Task With Sidecars',
+        description: 'A failed task',
+        inputs: new Map(),
+        workflowName: 'swe',
+      });
+      task.markFailed('failed');
+      task.setContainerInfo('', '', {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-902-1',
+          containerNames: ['rover-svc-902-1-postgres'],
+          taskId,
+          iteration: 1,
+        },
+      });
+
+      await restartCommand(taskId.toString(), { json: true });
+
+      const startupCall = mockedCreateSandbox.mock.calls.at(-1);
+      expect(startupCall?.[2]).toEqual(
+        expect.objectContaining({
+          projectPath: testDir,
+          sandboxMetadata: {
+            dockerHost: 'tcp://remote:2375',
+            serviceContext: {
+              networkName: 'rover-services-902-1',
+              containerNames: ['rover-svc-902-1-postgres'],
+              taskId: 902,
+              iteration: 1,
+            },
+          },
+        })
+      );
+    });
+
     it('should track multiple restart attempts', async () => {
       // Create a failed task
       const taskId = 456;

--- a/packages/cli/src/commands/__tests__/resume.test.ts
+++ b/packages/cli/src/commands/__tests__/resume.test.ts
@@ -48,7 +48,10 @@ describe('resume command', () => {
       eventResumeTaskFailed: vi.fn(),
       shutdown: vi.fn().mockResolvedValue(undefined),
     });
-    mockResumeTask.mockResolvedValue({ status: 'ok' });
+    mockResumeTask.mockResolvedValue({
+      status: 'ok',
+      resumedFromCheckpoint: false,
+    });
     mockExitWithError.mockResolvedValue(undefined);
     mockExitWithSuccess.mockResolvedValue(undefined);
   });
@@ -89,6 +92,88 @@ describe('resume command', () => {
     expect(mockResumeTask).toHaveBeenCalledWith(project, 7, { quiet: true });
     expect(mockExitWithError).not.toHaveBeenCalled();
     expect(mockExitWithSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports whether resume actually used the checkpoint', async () => {
+    const task = {
+      id: 9,
+      title: 'Paused task',
+      description: 'desc',
+      status: 'PAUSED',
+      iterations: 1,
+      branchName: 'rover/task-9',
+      worktreePath: '/tmp/worktree-9',
+      iterationsPath: () => '/tmp/task-9/iterations',
+      updateStatusFromIteration: vi.fn(),
+      isPaused: vi.fn(function (this: any) {
+        return this.status === 'PAUSED';
+      }),
+      isFailed: vi.fn(function (this: any) {
+        return this.status === 'FAILED';
+      }),
+    };
+    const project = {
+      getTask: vi.fn().mockReturnValue(task),
+    };
+
+    mockRequireProjectContext.mockResolvedValue(project);
+    mockResumeTask.mockResolvedValue({
+      status: 'ok',
+      resumedFromCheckpoint: true,
+    });
+
+    await resumeCommand('9', { json: true });
+
+    expect(mockExitWithSuccess).toHaveBeenCalledWith(
+      'Task resumed successfully!',
+      expect.objectContaining({
+        success: true,
+        taskId: 9,
+        hasCheckpoint: true,
+      }),
+      expect.anything()
+    );
+  });
+
+  it('does not report a checkpoint when resume falls back to a full rerun', async () => {
+    const task = {
+      id: 12,
+      title: 'Paused task',
+      description: 'desc',
+      status: 'PAUSED',
+      iterations: 1,
+      branchName: 'rover/task-12',
+      worktreePath: '/tmp/worktree-12',
+      iterationsPath: () => '/tmp/task-12/iterations',
+      updateStatusFromIteration: vi.fn(),
+      isPaused: vi.fn(function (this: any) {
+        return this.status === 'PAUSED';
+      }),
+      isFailed: vi.fn(function (this: any) {
+        return this.status === 'FAILED';
+      }),
+    };
+    const project = {
+      getTask: vi.fn().mockReturnValue(task),
+    };
+
+    mockRequireProjectContext.mockResolvedValue(project);
+    mockResumeTask.mockResolvedValue({
+      status: 'ok',
+      resumedFromCheckpoint: false,
+    });
+
+    await resumeCommand('12', { json: true });
+
+    expect(mockExitWithSuccess).toHaveBeenCalledWith(
+      'Task resumed successfully!',
+      expect.objectContaining({
+        success: true,
+        taskId: 12,
+        hasCheckpoint: false,
+      }),
+      expect.anything()
+    );
   });
 
   it('preserves FAILED status and skips iteration status refresh when resuming', async () => {
@@ -353,5 +438,38 @@ describe('resume command', () => {
     await resumeCommand('14');
 
     expect(mockResumeTask).toHaveBeenCalledWith(project, 14, { quiet: false });
+  });
+
+  it('describes checkpoint file presence without implying checkpoint validity', async () => {
+    const task = {
+      id: 15,
+      title: 'Paused task',
+      description: 'desc',
+      status: 'PAUSED',
+      iterations: 1,
+      branchName: 'rover/task-15',
+      worktreePath: '/tmp/worktree-15',
+      iterationsPath: () => '/tmp/task-15/iterations',
+      updateStatusFromIteration: vi.fn(),
+      isPaused: vi.fn(function (this: any) {
+        return this.status === 'PAUSED';
+      }),
+      isFailed: vi.fn(function (this: any) {
+        return this.status === 'FAILED';
+      }),
+    };
+    const project = {
+      getTask: vi.fn().mockReturnValue(task),
+    };
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mockRequireProjectContext.mockResolvedValue(project);
+
+    await resumeCommand('15');
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Checkpoint File: ')
+    );
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('absent'));
   });
 });

--- a/packages/cli/src/commands/__tests__/shell.test.ts
+++ b/packages/cli/src/commands/__tests__/shell.test.ts
@@ -129,7 +129,8 @@ describe('shell command', () => {
   it.each([
     ['COMPLETED', (task: TaskDescriptionManager) => task.markCompleted()],
     ['FAILED', (task: TaskDescriptionManager) => task.markFailed('boom')],
-  ])('omits persisted serviceContext for %s tasks in container shells', async (_status, setTerminalStatus) => {
+    ['PAUSED', (task: TaskDescriptionManager) => task.markPaused('paused')],
+  ])('preserves sandbox metadata for %s tasks in container shells', async (_status, setTerminalStatus) => {
     const task = createTestTask(1, 'Terminal task');
     setTerminalStatus(task);
     task.setContainerInfo('container-1', 'running', {
@@ -152,6 +153,12 @@ describe('shell command', () => {
       projectPath: testDir,
       sandboxMetadata: {
         dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
       },
     });
   });

--- a/packages/cli/src/commands/__tests__/shell.test.ts
+++ b/packages/cli/src/commands/__tests__/shell.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+  mkdirSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearProjectRootCache,
+  launchSync,
+  TaskDescriptionManager,
+} from 'rover-core';
+import { shellCommand } from '../shell.js';
+import {
+  createSandbox,
+  getAvailableSandboxBackend,
+} from '../../lib/sandbox/index.js';
+
+let testDir: string;
+
+vi.mock('../../lib/context.js', () => ({
+  requireProjectContext: vi.fn().mockImplementation(() => {
+    return Promise.resolve({
+      path: testDir,
+      getTask: (taskId: number) => {
+        const taskPath = join(testDir, '.rover', 'tasks', taskId.toString());
+        if (TaskDescriptionManager.exists(taskPath)) {
+          return TaskDescriptionManager.load(taskPath, taskId);
+        }
+        return undefined;
+      },
+    });
+  }),
+}));
+
+vi.mock('../../lib/telemetry.js', () => ({
+  getTelemetry: vi.fn().mockReturnValue({
+    eventShell: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('../../utils/exit.js', () => ({
+  exitWithError: vi.fn().mockImplementation(() => {}),
+  exitWithSuccess: vi.fn().mockImplementation(() => {}),
+  exitWithWarn: vi.fn().mockImplementation(() => {}),
+}));
+
+vi.mock('yocto-spinner', () => ({
+  default: vi.fn(() => ({
+    start() {
+      return this;
+    },
+    success: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock('../../lib/sandbox/index.js', () => ({
+  createSandbox: vi.fn(),
+  getAvailableSandboxBackend: vi.fn(),
+}));
+
+describe('shell command', () => {
+  let originalCwd: string;
+  const mockedCreateSandbox = vi.mocked(createSandbox);
+  const mockedGetAvailableSandboxBackend = vi.mocked(
+    getAvailableSandboxBackend
+  );
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'rover-shell-test-'));
+    originalCwd = process.cwd();
+    process.chdir(testDir);
+
+    launchSync('git', ['init']);
+    launchSync('git', ['config', 'user.email', 'test@test.com']);
+    launchSync('git', ['config', 'user.name', 'Test User']);
+    launchSync('git', ['config', 'commit.gpgsign', 'false']);
+
+    writeFileSync('README.md', '# Test');
+    launchSync('git', ['add', '.']);
+    launchSync('git', ['commit', '-m', 'Initial commit']);
+
+    mkdirSync('.rover/tasks', { recursive: true });
+    writeFileSync(
+      join(testDir, 'rover.json'),
+      JSON.stringify({ name: 'test-project' })
+    );
+
+    vi.clearAllMocks();
+    mockedGetAvailableSandboxBackend.mockResolvedValue('docker');
+    mockedCreateSandbox.mockResolvedValue({
+      openShellAtWorktree: vi.fn().mockResolvedValue(undefined),
+    } as any);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+    vi.clearAllMocks();
+    clearProjectRootCache();
+  });
+
+  const createTestTask = (id: number, title: string = 'Test Task') => {
+    const taskPath = join(testDir, '.rover', 'tasks', id.toString());
+    const task = TaskDescriptionManager.create(taskPath, {
+      id,
+      title,
+      description: 'Test task description',
+      inputs: new Map(),
+      workflowName: 'swe',
+    });
+
+    const worktreePath = join('.rover', 'tasks', id.toString(), 'workspace');
+    const branchName = `rover-task-${id}`;
+
+    launchSync('git', ['worktree', 'add', worktreePath, '-b', branchName]);
+    task.setWorkspace(join(testDir, worktreePath), branchName);
+
+    return task;
+  };
+
+  it.each([
+    ['COMPLETED', (task: TaskDescriptionManager) => task.markCompleted()],
+    ['FAILED', (task: TaskDescriptionManager) => task.markFailed('boom')],
+  ])('omits persisted serviceContext for %s tasks in container shells', async (_status, setTerminalStatus) => {
+    const task = createTestTask(1, 'Terminal task');
+    setTerminalStatus(task);
+    task.setContainerInfo('container-1', 'running', {
+      dockerHost: 'tcp://remote:2375',
+      serviceContext: {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
+    });
+
+    await shellCommand('1', { container: true });
+
+    const reloadedTask = TaskDescriptionManager.load(
+      join(testDir, '.rover', 'tasks', '1'),
+      1
+    );
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(reloadedTask, undefined, {
+      projectPath: testDir,
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+      },
+    });
+  });
+
+  it('preserves persisted serviceContext for active tasks in container shells', async () => {
+    const task = createTestTask(2, 'Running task');
+    task.markInProgress();
+    task.setContainerInfo('container-2', 'running', {
+      dockerHost: 'tcp://remote:2375',
+      serviceContext: {
+        networkName: 'rover-services-2-1',
+        containerNames: ['rover-svc-2-1-postgres'],
+        taskId: 2,
+        iteration: 1,
+      },
+    });
+
+    await shellCommand('2', { container: true });
+
+    const reloadedTask = TaskDescriptionManager.load(
+      join(testDir, '.rover', 'tasks', '2'),
+      2
+    );
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(reloadedTask, undefined, {
+      projectPath: testDir,
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-2-1',
+          containerNames: ['rover-svc-2-1-postgres'],
+          taskId: 2,
+          iteration: 1,
+        },
+      },
+    });
+  });
+
+  it('reports non-zero exit codes from container shells', async () => {
+    const { exitWithWarn, exitWithSuccess } = await import(
+      '../../utils/exit.js'
+    );
+    const task = createTestTask(3, 'Shell failure task');
+    task.markInProgress();
+
+    mockedCreateSandbox.mockResolvedValueOnce({
+      openShellAtWorktree: vi.fn().mockResolvedValue({ exitCode: 17 }),
+    } as any);
+
+    await shellCommand('3', { container: true });
+
+    expect(exitWithWarn).toHaveBeenCalledWith(
+      'Shell session ended with code 17',
+      expect.any(Object),
+      expect.objectContaining({ telemetry: expect.anything() })
+    );
+    expect(exitWithSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/__tests__/shell.test.ts
+++ b/packages/cli/src/commands/__tests__/shell.test.ts
@@ -126,6 +126,21 @@ describe('shell command', () => {
     return task;
   };
 
+  it('rejects malformed task IDs with trailing characters', async () => {
+    const { exitWithError } = await import('../../utils/exit.js');
+
+    await shellCommand('12abc', { container: false });
+
+    expect(exitWithError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: "Invalid task ID '12abc' - must be a number",
+      }),
+      expect.objectContaining({
+        telemetry: expect.anything(),
+      })
+    );
+  });
+
   it.each([
     ['COMPLETED', (task: TaskDescriptionManager) => task.markCompleted()],
     ['FAILED', (task: TaskDescriptionManager) => task.markFailed('boom')],

--- a/packages/cli/src/commands/__tests__/shell.test.ts
+++ b/packages/cli/src/commands/__tests__/shell.test.ts
@@ -231,4 +231,19 @@ describe('shell command', () => {
     );
     expect(exitWithSuccess).not.toHaveBeenCalled();
   });
+
+  it('does not block container shells on the global backend probe when task sandbox metadata is usable', async () => {
+    const task = createTestTask(4, 'Remote docker shell task');
+    task.markInProgress();
+    task.setContainerInfo('container-4', 'running', {
+      dockerHost: 'tcp://remote:2375',
+    });
+
+    mockedGetAvailableSandboxBackend.mockResolvedValueOnce(null);
+
+    await shellCommand('4', { container: true });
+
+    expect(mockedGetAvailableSandboxBackend).not.toHaveBeenCalled();
+    expect(mockedCreateSandbox).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/cli/src/commands/__tests__/stop.test.ts
+++ b/packages/cli/src/commands/__tests__/stop.test.ts
@@ -47,6 +47,7 @@ vi.mock('../../lib/telemetry.js', () => ({
 // Mock exit utilities to prevent process.exit
 vi.mock('../../utils/exit.js', () => ({
   exitWithError: vi.fn().mockImplementation(() => {}),
+  exitWithWarn: vi.fn().mockImplementation(() => {}),
   exitWithSuccess: vi.fn().mockImplementation(() => {}),
 }));
 
@@ -55,6 +56,13 @@ vi.mock('../../lib/sandbox/index.js', () => ({
   createSandbox: vi.fn().mockResolvedValue({
     stopAndRemove: vi.fn().mockResolvedValue(undefined),
     teardownServices: vi.fn().mockResolvedValue(undefined),
+  }),
+  isSandboxBackendUnavailableError: vi.fn((error: unknown) => {
+    return (
+      error instanceof Error &&
+      error.message ===
+        'Neither Docker nor Podman are available. Please install Docker or Podman to run tasks.'
+    );
   }),
 }));
 
@@ -337,6 +345,52 @@ describe('stop command', () => {
         })
       );
       expect(exitWithSuccess).not.toHaveBeenCalled();
+    });
+
+    it('should continue resetting the task when metadata-only cleanup cannot run without a backend', async () => {
+      const { createSandbox } = await import('../../lib/sandbox/index.js');
+      const { exitWithError, exitWithSuccess, exitWithWarn } = await import(
+        '../../utils/exit.js'
+      );
+      vi.mocked(createSandbox).mockRejectedValueOnce(
+        new Error(
+          'Neither Docker nor Podman are available. Please install Docker or Podman to run tasks.'
+        )
+      );
+
+      const task = createTestTask(18, 'Paused task without backend');
+      task.markPaused('paused');
+      task.setContainerInfo('', '', {
+        dockerHost: 'tcp://remote:2375',
+      });
+
+      await stopCommand('18', { json: true });
+
+      const reloadedTask = TaskDescriptionManager.load(
+        join(testDir, '.rover', 'tasks', '18'),
+        18
+      );
+      expect(reloadedTask.status).toBe('NEW');
+      expect(reloadedTask.containerId).toBe('');
+      expect(reloadedTask.sandboxMetadata).toEqual({
+        dockerHost: 'tcp://remote:2375',
+      });
+      expect(exitWithError).not.toHaveBeenCalled();
+      expect(exitWithSuccess).not.toHaveBeenCalled();
+      expect(exitWithWarn).toHaveBeenCalledWith(
+        'Task stopped with warnings',
+        expect.objectContaining({
+          success: false,
+          taskId: 18,
+          status: 'NEW',
+          error: expect.stringContaining(
+            'Task metadata was preserved so cleanup can be retried later'
+          ),
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
+      );
     });
   });
 

--- a/packages/cli/src/commands/__tests__/stop.test.ts
+++ b/packages/cli/src/commands/__tests__/stop.test.ts
@@ -135,6 +135,21 @@ describe('stop command', () => {
       );
     });
 
+    it('should reject malformed numeric task IDs with trailing characters', async () => {
+      const { exitWithError } = await import('../../utils/exit.js');
+
+      await stopCommand('12abc', { json: true });
+
+      expect(exitWithError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: "Invalid task ID '12abc' - must be a number",
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
+      );
+    });
+
     it('should handle non-existent task', async () => {
       const { exitWithError } = await import('../../utils/exit.js');
 

--- a/packages/cli/src/commands/__tests__/stop.test.ts
+++ b/packages/cli/src/commands/__tests__/stop.test.ts
@@ -54,6 +54,7 @@ vi.mock('../../utils/exit.js', () => ({
 vi.mock('../../lib/sandbox/index.js', () => ({
   createSandbox: vi.fn().mockResolvedValue({
     stopAndRemove: vi.fn().mockResolvedValue(undefined),
+    teardownServices: vi.fn().mockResolvedValue(undefined),
   }),
 }));
 
@@ -242,6 +243,85 @@ describe('stop command', () => {
 
       // Verify sandbox was not created since there's no container
       expect(createSandbox).not.toHaveBeenCalled();
+    });
+
+    it('should tear down persisted sidecars even when task has no container id', async () => {
+      const { createSandbox } = await import('../../lib/sandbox/index.js');
+      const sandbox = {
+        stopAndRemove: vi.fn().mockResolvedValue(undefined),
+        teardownServices: vi.fn().mockResolvedValue(undefined),
+      };
+      vi.mocked(createSandbox).mockResolvedValueOnce(sandbox as any);
+
+      const task = createTestTask(17, 'Paused task with sidecars');
+      task.markPaused('paused');
+      task.setContainerInfo('', '', {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-17-1',
+          containerNames: ['rover-svc-17-1-postgres'],
+          taskId: 17,
+          iteration: 1,
+        },
+      });
+
+      await stopCommand('17', { json: true });
+
+      expect(createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 17 }),
+        undefined,
+        {
+          projectPath: testDir,
+          sandboxMetadata: {
+            dockerHost: 'tcp://remote:2375',
+            serviceContext: {
+              networkName: 'rover-services-17-1',
+              containerNames: ['rover-svc-17-1-postgres'],
+              taskId: 17,
+              iteration: 1,
+            },
+          },
+        }
+      );
+      expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
+      expect(sandbox.stopAndRemove).not.toHaveBeenCalled();
+    });
+
+    it('should not clear task metadata when sandbox stopAndRemove fails', async () => {
+      const { createSandbox } = await import('../../lib/sandbox/index.js');
+      const { exitWithError, exitWithSuccess } = await import(
+        '../../utils/exit.js'
+      );
+      vi.mocked(createSandbox).mockResolvedValueOnce({
+        stopAndRemove: vi.fn().mockRejectedValue(new Error('remove failed')),
+      } as any);
+
+      const task = createTestTask(16, 'Task with failing stop');
+      task.setContainerInfo('container-16', 'running', {
+        dockerHost: 'tcp://remote:2375',
+      });
+      task.markInProgress();
+
+      await stopCommand('16', { json: true });
+
+      const reloadedTask = TaskDescriptionManager.load(
+        join(testDir, '.rover', 'tasks', '16'),
+        16
+      );
+      expect(reloadedTask.status).toBe('IN_PROGRESS');
+      expect(reloadedTask.containerId).toBe('container-16');
+      expect(reloadedTask.sandboxMetadata).toEqual({
+        dockerHost: 'tcp://remote:2375',
+      });
+      expect(exitWithError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.stringContaining('remove failed'),
+        }),
+        expect.objectContaining({
+          telemetry: expect.anything(),
+        })
+      );
+      expect(exitWithSuccess).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/commands/__tests__/stop.test.ts
+++ b/packages/cli/src/commands/__tests__/stop.test.ts
@@ -341,10 +341,10 @@ describe('stop command', () => {
   });
 
   describe('Workspace cleanup', () => {
-    it('should clear workspace information', async () => {
+    it('should preserve workspace information by default', async () => {
       const task = createTestTask(6, 'Task with Workspace');
-      expect(task.worktreePath).toBeTruthy();
-      expect(task.branchName).toBeTruthy();
+      const originalWorktreePath = task.worktreePath;
+      const originalBranchName = task.branchName;
 
       await stopCommand('6', { json: true });
 
@@ -352,8 +352,8 @@ describe('stop command', () => {
         join(testDir, '.rover', 'tasks', '6'),
         6
       );
-      expect(reloadedTask.worktreePath).toBe('');
-      expect(reloadedTask.branchName).toBe('');
+      expect(reloadedTask.worktreePath).toBe(originalWorktreePath);
+      expect(reloadedTask.branchName).toBe(originalBranchName);
     });
 
     it('should not remove git worktree and branch by default', async () => {
@@ -380,6 +380,12 @@ describe('stop command', () => {
       expect(existsSync(worktreePath)).toBe(false);
       const branches = launchSync('git', ['branch']).stdout;
       expect(branches).not.toContain(branchName);
+      const reloadedTask = TaskDescriptionManager.load(
+        join(testDir, '.rover', 'tasks', '8'),
+        8
+      );
+      expect(reloadedTask.worktreePath).toBe('');
+      expect(reloadedTask.branchName).toBe('');
     });
 
     it('should remove git worktree and branch with removeGitWorktreeAndBranch option', async () => {
@@ -396,11 +402,17 @@ describe('stop command', () => {
       expect(existsSync(worktreePath)).toBe(false);
       const branches = launchSync('git', ['branch']).stdout;
       expect(branches).not.toContain(branchName);
+      const reloadedTask = TaskDescriptionManager.load(
+        join(testDir, '.rover', 'tasks', '9'),
+        9
+      );
+      expect(reloadedTask.worktreePath).toBe('');
+      expect(reloadedTask.branchName).toBe('');
     });
   });
 
   describe('Iterations cleanup', () => {
-    it('should delete iterations directory', async () => {
+    it('should preserve iterations directory', async () => {
       const task = createTestTask(10, 'Task with Iterations');
 
       // Create iterations directory with content
@@ -413,9 +425,9 @@ describe('stop command', () => {
 
       await stopCommand('10', { json: true });
 
-      // Iterations directory should be deleted
+      // Iterations directory should remain for inspection/restart context
       const iterationsPath = join('.rover', 'tasks', '10', 'iterations');
-      expect(existsSync(iterationsPath)).toBe(false);
+      expect(existsSync(iterationsPath)).toBe(true);
     });
   });
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -146,15 +146,30 @@ function generateBuildEntrypoint(
   const rootInitScripts = projectConfig.allInitScripts ?? [];
   const initScriptBlocks = rootInitScripts
     .filter(entry => !entry.path || isSafeRelativePath(entry.path))
-    .map(entry => {
-      const workspaceScript = entry.path
-        ? `/workspace/${entry.path}/${entry.script}`
-        : `/workspace/${entry.script}`;
-      const workspaceDir = entry.path
-        ? `/workspace/${entry.path}`
-        : '/workspace';
+    .map((entry, index) => {
       const label = entry.path ? ` (${entry.path})` : '';
 
+      if (entry.path) {
+        return `echo "🔧 Running initialization script${label}"
+workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
+workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
+if [ -f "$workspace_root_script_${index}" ]; then
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
+elif [ -f "$workspace_project_script_${index}" ]; then
+  workspace_script_${index}="$workspace_project_script_${index}"
+  workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
+else
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
+fi
+cd "$workspace_dir_${index}"
+bash "$workspace_script_${index}"
+echo "✅ Initialization script${label} completed successfully"`;
+      }
+
+      const workspaceScript = `/workspace/${entry.script}`;
+      const workspaceDir = '/workspace';
       return `echo "🔧 Running initialization script${label}"
 cd ${JSON.stringify(workspaceDir)}
 bash ${JSON.stringify(workspaceScript)}
@@ -274,7 +289,8 @@ for _dlcache_dir in /var/cache/apt; do
   [ -d "$_dlcache_dir" ] && chmod -R a+rwX "$_dlcache_dir" 2>/dev/null || true
 done
 
-# Mark all directories as git-safe so they work with any UID
+# Mark all directories as git-safe so they work with any UID.
+# Safe inside build containers — ephemeral, single-user, no multi-tenant concerns.
 git config --system --add safe.directory '*' 2>/dev/null || true
 
 echo ""

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -153,12 +153,12 @@ function generateBuildEntrypoint(
         return `echo "🔧 Running initialization script${label}"
 workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
 workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
-if [ -f "$workspace_root_script_${index}" ]; then
-  workspace_script_${index}="$workspace_root_script_${index}"
-  workspace_dir_${index}='/workspace'
-elif [ -f "$workspace_project_script_${index}" ]; then
+if [ -f "$workspace_project_script_${index}" ]; then
   workspace_script_${index}="$workspace_project_script_${index}"
   workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
+elif [ -f "$workspace_root_script_${index}" ]; then
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
 else
   workspace_script_${index}="$workspace_root_script_${index}"
   workspace_dir_${index}='/workspace'

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -92,7 +92,9 @@ if ! git -C ${escapedPath} fetch --all --tags --prune; then
 fi
 ${checkoutRef}
 git -C ${escapedPath} reset --hard HEAD
-git -C ${escapedPath} clean -fd
+# Remove ignored files too so copied local checkouts cannot leak state into
+# dependency resolution or init scripts inside the cache build.
+git -C ${escapedPath} clean -fdx
 echo "✅ Repository ${escapedName} is ready for build caching"`;
   });
 
@@ -207,6 +209,10 @@ if [[ -f /etc/debian_version ]]; then
 fi
 
 # Create a writable build workspace from the read-only host project mount.
+# The host project is mounted read-only at /workspace-src. We copy it to a
+# writable location and symlink /workspace to it. If /workspace is a mount
+# point (cannot be removed), the symlink will fail and the build will error
+# out on subsequent steps that write to /workspace — this is intentional.
 export BUILD_WORKSPACE=/tmp/rover-build-workspace
 rm -rf "$BUILD_WORKSPACE"
 mkdir -p "$BUILD_WORKSPACE"

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -288,11 +288,6 @@ ln -s "$BUILD_WORKSPACE" /workspace
 # Install languages, package managers, task managers
 ${installScripts.join('\n')}
 
-${generateProjectRepositorySyncSection(projectConfig)}
-
-${dependencyResolutionSection}
-
-${initScriptSection}
 echo "Installing agent CLI ($AGENT)..."
 sudo -E rover-agent install $AGENT || echo "Agent install failed (non-fatal for build)"
 sudo chown -R $(id -u):$(id -g) $HOME
@@ -303,6 +298,12 @@ sudo rover-agent-install $AGENT || true
 for _cred_dir in $HOME/.codex $HOME/.claude $HOME/.config/github-copilot $HOME/.gemini $HOME/.qwen $HOME/.opencode; do
   [ -d "$_cred_dir" ] && sudo chown -R $(id -u):$(id -g) "$_cred_dir"
 done
+
+${generateProjectRepositorySyncSection(projectConfig)}
+
+${dependencyResolutionSection}
+
+${initScriptSection}
 
 ${mcpSection}
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -19,6 +19,8 @@ import { getProjectPath, isJsonMode } from '../lib/context.js';
 import { getAvailableSandboxBackend } from '../lib/sandbox/index.js';
 import {
   ContainerBackend,
+  getInitScriptMounts,
+  getRootInitScriptMountPath,
   normalizeExtraArgs,
   resolveAgentImage,
 } from '../lib/sandbox/container-common.js';
@@ -52,7 +54,7 @@ interface BuildRepositoryMount {
 function isLocalRepositoryReference(repository: string): boolean {
   return (
     repository.startsWith('file://') ||
-    isAbsolute(repository) ||
+    (isAbsolute(repository) && !repository.startsWith('/workspace/')) ||
     repository === '.' ||
     repository === '..' ||
     repository.startsWith('./') ||
@@ -213,36 +215,47 @@ function generateBuildEntrypoint(
   targetUid?: number,
   targetGid?: number
 ): string {
+  const isSafeProjectPath = (projectPath: string): boolean =>
+    typeof projectConfig.projectRoot !== 'string'
+      ? isSafeRelativePath(projectPath)
+      : resolvePathWithinRoot(projectConfig.projectRoot, projectPath) !== null;
+
   const allPackages = getPackagesFromConfig(projectConfig);
 
   const installScripts: string[] = [];
   for (const pkg of allPackages) {
     const install = pkg.installScript();
     if (install.trim()) {
-      installScripts.push(`echo "Installing ${pkg.name}..."`);
+      const safeName = pkg.name.replace(/["`$\\]/g, '');
+      installScripts.push(`echo "Installing ${safeName}..."`);
       installScripts.push(install);
     }
     const init = pkg.initScript();
     if (init.trim()) {
-      installScripts.push(`echo "Initializing ${pkg.name}..."`);
+      const safeName = pkg.name.replace(/["`$\\]/g, '');
+      installScripts.push(`echo "Initializing ${safeName}..."`);
       installScripts.push(init);
     }
   }
 
   const rootInitScripts = projectConfig.allInitScripts ?? [];
   const initScriptBlocks = rootInitScripts
-    .filter(entry => !entry.path || isSafeRelativePath(entry.path))
+    .filter(entry => !entry.path || isSafeProjectPath(entry.path))
     .map((entry, index) => {
       const label = entry.path ? ` (${entry.path})` : '';
 
       if (entry.path) {
         return `echo "🔧 Running initialization script${label}"
 workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
+workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
 if [ -f "$workspace_project_script_${index}" ]; then
   workspace_script_${index}="$workspace_project_script_${index}"
   workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
+elif [ -f "$workspace_root_script_${index}" ]; then
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
 else
-  echo "❌ Initialization script${label} not found at $workspace_project_script_${index}"
+  echo "❌ Initialization script${label} not found at $workspace_project_script_${index} or $workspace_root_script_${index}"
   safe_exit 1
 fi
 cd "$workspace_dir_${index}"
@@ -250,11 +263,22 @@ bash "$workspace_script_${index}"
 echo "✅ Initialization script${label} completed successfully"`;
       }
 
+      const mountedScript = getRootInitScriptMountPath(rootInitScripts, index);
       const workspaceScript = `/workspace/${entry.script}`;
       const workspaceDir = '/workspace';
       return `echo "🔧 Running initialization script${label}"
-cd ${JSON.stringify(workspaceDir)}
-bash ${JSON.stringify(workspaceScript)}
+mounted_script_${index}=${shellEscape(mountedScript)}
+workspace_script_${index}=${shellEscape(workspaceScript)}
+if [ -f "$mounted_script_${index}" ]; then
+  root_script_${index}="$mounted_script_${index}"
+elif [ -f "$workspace_script_${index}" ]; then
+  root_script_${index}="$workspace_script_${index}"
+else
+  echo "❌ Initialization script${label} not found at $mounted_script_${index} or $workspace_script_${index}"
+  safe_exit 1
+fi
+cd ${shellEscape(workspaceDir)}
+bash "$root_script_${index}"
 echo "✅ Initialization script${label} completed successfully"`;
     });
 
@@ -270,6 +294,7 @@ ${initScriptBlocks.join('\n')}
   const dependencyResolutionCommands = getDependencyResolutionCommands({
     rootPackageManagers: projectConfig.packageManagers ?? [],
     projects: projectConfig.projects,
+    workspaceRoot: projectConfig.projectRoot,
   });
   const dependencyResolutionSection =
     dependencyResolutionCommands.length > 0
@@ -529,6 +554,8 @@ const buildCommand = async (
         `${repositoryMount.hostPath}:${repositoryMount.containerPath}:Z,ro`
       );
     }
+
+    dockerArgs.push(...getInitScriptMounts(buildProjectConfig));
 
     // Add agent-specific mounts (credential files)
     try {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -29,80 +29,9 @@ import type { BuildOutput } from '../output-types.js';
 import { getTelemetry } from '../lib/telemetry.js';
 import { getUserAIAgent, getAIAgentTool } from '../lib/agents/index.js';
 
-// Language packages
-import { JavaScriptSandboxPackage } from '../lib/sandbox/languages/javascript.js';
-import { TypeScriptSandboxPackage } from '../lib/sandbox/languages/typescript.js';
-import { PHPSandboxPackage } from '../lib/sandbox/languages/php.js';
-import { RustSandboxPackage } from '../lib/sandbox/languages/rust.js';
-import { GoSandboxPackage } from '../lib/sandbox/languages/go.js';
-import { PythonSandboxPackage } from '../lib/sandbox/languages/python.js';
-import { RubySandboxPackage } from '../lib/sandbox/languages/ruby.js';
-import { DartSandboxPackage } from '../lib/sandbox/languages/dart.js';
-
-// Package manager packages
-import { NpmSandboxPackage } from '../lib/sandbox/package-managers/npm.js';
-import { PnpmSandboxPackage } from '../lib/sandbox/package-managers/pnpm.js';
-import { YarnSandboxPackage } from '../lib/sandbox/package-managers/yarn.js';
-import { ComposerSandboxPackage } from '../lib/sandbox/package-managers/composer.js';
-import { CargoSandboxPackage } from '../lib/sandbox/package-managers/cargo.js';
-import { GomodSandboxPackage } from '../lib/sandbox/package-managers/gomod.js';
-import { PipSandboxPackage } from '../lib/sandbox/package-managers/pip.js';
-import { PoetrySandboxPackage } from '../lib/sandbox/package-managers/poetry.js';
-import { UvSandboxPackage } from '../lib/sandbox/package-managers/uv.js';
-import { RubygemsSandboxPackage } from '../lib/sandbox/package-managers/rubygems.js';
-import { PubSandboxPackage } from '../lib/sandbox/package-managers/pub.js';
-
-// Task manager packages
-import { JustSandboxPackage } from '../lib/sandbox/task-managers/just.js';
-import { MakeSandboxPackage } from '../lib/sandbox/task-managers/make.js';
-import { TaskSandboxPackage } from '../lib/sandbox/task-managers/task.js';
-
-import type { SandboxPackage } from '../lib/sandbox/types.js';
+import { getPackagesFromConfig } from '../lib/sandbox/packages.js';
 import { getDependencyResolutionCommands } from '../lib/dependency-resolution.js';
 import { shellEscape } from '../utils/shell.js';
-
-function getPackages(projectConfig: ProjectConfigManager): SandboxPackage[] {
-  const packages: SandboxPackage[] = [];
-  const langMap: Record<string, () => SandboxPackage> = {
-    javascript: () => new JavaScriptSandboxPackage(),
-    typescript: () => new TypeScriptSandboxPackage(),
-    php: () => new PHPSandboxPackage(),
-    rust: () => new RustSandboxPackage(),
-    go: () => new GoSandboxPackage(),
-    python: () => new PythonSandboxPackage(),
-    ruby: () => new RubySandboxPackage(),
-    dart: () => new DartSandboxPackage(),
-  };
-  const pmMap: Record<string, () => SandboxPackage> = {
-    npm: () => new NpmSandboxPackage(),
-    pnpm: () => new PnpmSandboxPackage(),
-    yarn: () => new YarnSandboxPackage(),
-    composer: () => new ComposerSandboxPackage(),
-    cargo: () => new CargoSandboxPackage(),
-    gomod: () => new GomodSandboxPackage(),
-    pip: () => new PipSandboxPackage(),
-    poetry: () => new PoetrySandboxPackage(),
-    uv: () => new UvSandboxPackage(),
-    rubygems: () => new RubygemsSandboxPackage(),
-    pub: () => new PubSandboxPackage(),
-  };
-  const tmMap: Record<string, () => SandboxPackage> = {
-    just: () => new JustSandboxPackage(),
-    make: () => new MakeSandboxPackage(),
-    task: () => new TaskSandboxPackage(),
-  };
-
-  for (const lang of projectConfig.allLanguages ?? []) {
-    if (langMap[lang]) packages.push(langMap[lang]());
-  }
-  for (const pm of projectConfig.allPackageManagers ?? []) {
-    if (pmMap[pm]) packages.push(pmMap[pm]());
-  }
-  for (const tm of projectConfig.allTaskManagers ?? []) {
-    if (tmMap[tm]) packages.push(tmMap[tm]());
-  }
-  return packages;
-}
 
 function generateProjectRepositorySyncSection(
   projectConfig: ProjectConfigManager
@@ -183,7 +112,7 @@ function generateBuildEntrypoint(
   targetUid?: number,
   targetGid?: number
 ): string {
-  const allPackages = getPackages(projectConfig);
+  const allPackages = getPackagesFromConfig(projectConfig);
 
   const installScripts: string[] = [];
   for (const pkg of allPackages) {
@@ -491,7 +420,11 @@ const buildCommand = async (
       );
     }
 
-    await launch(backendName, ['start', '-a', containerName]);
+    // 6. Start container and stream build output. Don't throw on non-zero
+    //    exit — let waitForInitAndCommit handle cleanup and commit decisions.
+    await launch(backendName, ['start', '-a', containerName], {
+      reject: false,
+    });
 
     // 7. Wait for init to finish and commit as cache image
     const committed = await waitForInitAndCommit(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -119,23 +119,59 @@ function generateProjectRepositorySyncSection(
     const targetPath = `/workspace/${project.path}`;
     const escapedName = shellEscape(project.name);
     const escapedPath = shellEscape(targetPath);
+    const escapedRepository = shellEscape(project.repository!);
+    const escapedRef = project.ref ? shellEscape(project.ref) : '';
 
-    return `echo "📥 Validating local child repository ${escapedName} for build cache"
-if [ ! -d ${escapedPath} ]; then
-  echo "❌ Missing child repository ${escapedName} at ${escapedPath} in the staged build workspace"
-  echo "   rover build does not clone child repositories from project.repository."
-  echo "   Make sure ${escapedName} is already materialized under ${escapedPath} before building the cache image."
+    const checkoutRef = project.ref
+      ? `
+echo "🔀 Checking out ${escapedRef} for ${escapedName}"
+if git -C ${escapedPath} rev-parse --verify refs/remotes/origin/${escapedRef} >/dev/null 2>&1; then
+  git -C ${escapedPath} checkout -B ${escapedRef} refs/remotes/origin/${escapedRef}
+elif git -C ${escapedPath} rev-parse --verify ${escapedRef} >/dev/null 2>&1; then
+  git -C ${escapedPath} checkout --detach ${escapedRef}
+else
+  echo "❌ Could not resolve ref ${escapedRef} in ${escapedName}"
   safe_exit 1
 fi
-echo "✅ Local child repository ${escapedName} is present for build caching"`;
+`
+      : `
+default_remote_ref=$(git -C ${escapedPath} symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+if [ -z "$default_remote_ref" ]; then
+  echo "❌ Could not determine default remote branch for ${escapedName}"
+  safe_exit 1
+fi
+default_branch="\${default_remote_ref#origin/}"
+echo "🔀 Checking out default branch $default_branch for ${escapedName}"
+git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"
+`;
+
+    return `echo "📥 Syncing child repository ${escapedName} for build cache"
+mkdir -p "$(dirname ${escapedPath})"
+if [ ! -d ${escapedPath}/.git ]; then
+  rm -rf ${escapedPath}
+  git clone ${escapedRepository} ${escapedPath}
+else
+  current_origin=$(git -C ${escapedPath} remote get-url origin 2>/dev/null || true)
+  if [ "$current_origin" != ${escapedRepository} ]; then
+    echo "❌ Existing repository at ${escapedPath} points to a different origin"
+    safe_exit 1
+  fi
+fi
+if ! git -C ${escapedPath} fetch --all --tags --prune; then
+  echo "❌ Failed to fetch repository ${escapedName}"
+  safe_exit 1
+fi
+${checkoutRef}
+git -C ${escapedPath} reset --hard HEAD
+git -C ${escapedPath} clean -fd
+echo "✅ Repository ${escapedName} is ready for build caching"`;
   });
 
   return `
-# Validate external project repositories are already present in the staged
-# workspace so multi-repo dependency setup can be baked into the cache image
-# without requiring build-time Git credentials.
+# Materialize external project repositories into the staged workspace so
+# multi-repo dependency setup can be baked into the cache image.
 echo -e "\\n======================================="
-echo "📥 Validating external repositories for cache build"
+echo "📥 Syncing external repositories for cache build"
 echo "======================================="
 ${syncBlocks.join('\n')}
 `;

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -6,7 +6,7 @@ import {
   rmSync,
   existsSync,
 } from 'node:fs';
-import { join, isAbsolute, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir, userInfo } from 'node:os';
 import {
@@ -44,22 +44,12 @@ import {
   isSafeRelativePath,
   resolvePathWithinRoot,
 } from '../utils/path-safety.js';
+import { isLocalRepositoryReference } from '../utils/repository-reference.js';
 import { shellEscape } from '../utils/shell.js';
 
 interface BuildRepositoryMount {
   hostPath: string;
   containerPath: string;
-}
-
-function isLocalRepositoryReference(repository: string): boolean {
-  return (
-    repository.startsWith('file://') ||
-    (isAbsolute(repository) && !repository.startsWith('/workspace/')) ||
-    repository === '.' ||
-    repository === '..' ||
-    repository.startsWith('./') ||
-    repository.startsWith('../')
-  );
 }
 
 export function prepareBuildProjectConfig(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -7,7 +7,6 @@ import {
   existsSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { tmpdir, userInfo } from 'node:os';
 import {
   ProjectConfigManager,
@@ -46,7 +45,7 @@ import {
 } from '../utils/path-safety.js';
 import {
   isLocalRepositoryReference,
-  resolveRepositoryHostPath,
+  resolveLocalRepositoryReference,
 } from '../utils/repository-reference.js';
 import { shellEscape } from '../utils/shell.js';
 
@@ -85,12 +84,10 @@ export function prepareBuildProjectConfig(
         return [project];
       }
 
-      const hostPath = project.repository.startsWith('file://')
-        ? fileURLToPath(project.repository)
-        : resolveRepositoryHostPath(
-            project.repository,
-            repositoryResolutionRoot
-          );
+      const hostPath = resolveLocalRepositoryReference(
+        project.repository,
+        repositoryResolutionRoot
+      );
 
       if (!existsSync(hostPath)) {
         throw new Error(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,6 +1,13 @@
 import colors from 'ansi-colors';
-import { writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import {
+  writeFileSync,
+  chmodSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+} from 'node:fs';
+import { join, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { tmpdir, userInfo } from 'node:os';
 import {
   ProjectConfigManager,
@@ -36,6 +43,66 @@ import {
   resolvePathWithinRoot,
 } from '../utils/path-safety.js';
 import { shellEscape } from '../utils/shell.js';
+
+interface BuildRepositoryMount {
+  hostPath: string;
+  containerPath: string;
+}
+
+function isLocalRepositoryReference(repository: string): boolean {
+  return (
+    repository.startsWith('file://') ||
+    isAbsolute(repository) ||
+    repository === '.' ||
+    repository === '..' ||
+    repository.startsWith('./') ||
+    repository.startsWith('../')
+  );
+}
+
+export function prepareBuildProjectConfig(
+  projectPath: string,
+  projectConfig: ProjectConfigManager
+): {
+  buildProjectConfig: ProjectConfigManager;
+  repositoryMounts: BuildRepositoryMount[];
+} {
+  const repositoryMounts: BuildRepositoryMount[] = [];
+  const buildProjects = (projectConfig.projects ?? []).map((project, index) => {
+    if (
+      typeof project.repository !== 'string' ||
+      !isLocalRepositoryReference(project.repository)
+    ) {
+      return project;
+    }
+
+    const hostPath = project.repository.startsWith('file://')
+      ? fileURLToPath(project.repository)
+      : resolve(projectPath, project.repository);
+
+    if (!existsSync(hostPath)) {
+      throw new Error(
+        `Local workspace repository for ${project.name} not found: ${hostPath}`
+      );
+    }
+
+    const containerPath = `/workspace-repos/${index}`;
+    repositoryMounts.push({ hostPath, containerPath });
+
+    return {
+      ...project,
+      repository: containerPath,
+    };
+  });
+
+  return {
+    buildProjectConfig: {
+      ...projectConfig,
+      projects: buildProjects,
+    } as ProjectConfigManager,
+    repositoryMounts,
+  };
+}
 
 function generateProjectRepositorySyncSection(
   projectConfig: ProjectConfigManager
@@ -201,31 +268,54 @@ ${dependencyResolutionCommands.join('\n')}
   let mcpSection = '';
   if (mcps.length > 0) {
     const mcpCmds = mcps.map(mcp => {
-      let cmd = `rover-agent config mcp ${agent} '${mcp.name}' --transport '${mcp.transport}'`;
-      for (const env of mcp.envs ?? []) cmd += ` --env '${env}'`;
-      for (const header of mcp.headers ?? []) cmd += ` --header '${header}'`;
-      cmd += ` '${mcp.commandOrUrl}'`;
+      let cmd = `rover-agent config mcp ${shellEscape(agent)} ${shellEscape(mcp.name)} --transport ${shellEscape(mcp.transport)}`;
+      for (const env of mcp.envs ?? []) cmd += ` --env ${shellEscape(env)}`;
+      for (const header of mcp.headers ?? [])
+        cmd += ` --header ${shellEscape(header)}`;
+      cmd += ` ${shellEscape(mcp.commandOrUrl)}`;
       return cmd;
     });
     mcpSection = `
 # Configure MCPs
-rover-agent config mcp ${agent} package-manager --transport "http" http://127.0.0.1:8090/mcp
+rover-agent config mcp ${shellEscape(agent)} package-manager --transport "http" http://127.0.0.1:8090/mcp
 ${mcpCmds.join('\n')}
 `;
   } else {
     mcpSection = `
 # Configure built-in MCP
-rover-agent config mcp ${agent} package-manager --transport "http" http://127.0.0.1:8090/mcp
+rover-agent config mcp ${shellEscape(agent)} package-manager --transport "http" http://127.0.0.1:8090/mcp
 `;
   }
 
   return `#!/usr/bin/env bash
 set -euo pipefail
 
-AGENT="${agent}"
+AGENT=${shellEscape(agent)}
 
 safe_exit() {
   exit "\${1:-1}"
+}
+
+# Detect sudo availability once for use throughout the build script.
+_SUDO=""
+if command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
+  _SUDO="sudo"
+fi
+
+run_as_root() {
+  if [ -n "$_SUDO" ]; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+run_as_root_with_env() {
+  if [ -n "$_SUDO" ]; then
+    sudo -E "$@"
+  else
+    "$@"
+  fi
 }
 
 # Home setup — running as root during build
@@ -237,7 +327,7 @@ source $HOME/.profile
 
 # Update package lists
 if [[ -f /etc/debian_version ]]; then
-  sudo apt-get update -qq
+  run_as_root apt-get update -qq
 fi
 
 # Create a writable build workspace from the read-only host project mount.
@@ -252,25 +342,26 @@ cp -a /workspace-src/. "$BUILD_WORKSPACE/"
 rm -rf /workspace 2>/dev/null || true
 ln -s "$BUILD_WORKSPACE" /workspace
 
-# Install languages, package managers, task managers
-${installScripts.join('\n')}
-
 echo "Installing agent CLI ($AGENT)..."
-sudo -E rover-agent install $AGENT || echo "Agent install failed (non-fatal for build)"
-sudo chown -R $(id -u):$(id -g) $HOME
+run_as_root_with_env rover-agent install $AGENT || echo "Agent install failed (non-fatal for build)"
+run_as_root chown -R $(id -u):$(id -g) $HOME
 
 # Copy credentials
 echo "Copying agent credentials..."
-sudo rover-agent-install $AGENT || true
+run_as_root rover-agent-install $AGENT || true
 for _cred_dir in $HOME/.codex $HOME/.claude $HOME/.config/github-copilot $HOME/.gemini $HOME/.qwen $HOME/.opencode; do
-  [ -d "$_cred_dir" ] && sudo chown -R $(id -u):$(id -g) "$_cred_dir"
+  [ -d "$_cred_dir" ] && run_as_root chown -R $(id -u):$(id -g) "$_cred_dir"
 done
 
 ${generateProjectRepositorySyncSection(projectConfig)}
 
-${dependencyResolutionSection}
+# Install languages, package managers, task managers after child repositories
+# are synced so installers can inspect child-repo manifests for versions.
+${installScripts.join('\n')}
 
 ${initScriptSection}
+
+${dependencyResolutionSection}
 
 ${mcpSection}
 
@@ -308,6 +399,10 @@ const buildCommand = async (
   try {
     const projectPath = getProjectPath() || process.cwd();
     const projectConfig = ProjectConfigManager.load(projectPath);
+    const { buildProjectConfig, repositoryMounts } = prepareBuildProjectConfig(
+      projectPath,
+      projectConfig
+    );
     const agent = options.agent ?? getUserAIAgent() ?? 'claude';
 
     if (!isJsonMode()) {
@@ -379,7 +474,12 @@ const buildCommand = async (
     const hostUser = userInfo();
     writeFileSync(
       entrypointPath,
-      generateBuildEntrypoint(agent, projectConfig, hostUser.uid, hostUser.gid)
+      generateBuildEntrypoint(
+        agent,
+        buildProjectConfig,
+        hostUser.uid,
+        hostUser.gid
+      )
     );
     chmodSync(entrypointPath, 0o755);
 
@@ -407,6 +507,13 @@ const buildCommand = async (
       '--entrypoint',
       '/entrypoint.sh',
     ];
+
+    for (const repositoryMount of repositoryMounts) {
+      dockerArgs.push(
+        '-v',
+        `${repositoryMount.hostPath}:${repositoryMount.containerPath}:Z,ro`
+      );
+    }
 
     // Add agent-specific mounts (credential files)
     try {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -58,14 +58,7 @@ import { MakeSandboxPackage } from '../lib/sandbox/task-managers/make.js';
 import { TaskSandboxPackage } from '../lib/sandbox/task-managers/task.js';
 
 import type { SandboxPackage } from '../lib/sandbox/types.js';
-
-function exitProcessIfNeeded(code: number): void {
-  if (process.env.VITEST) {
-    return;
-  }
-
-  process.exit(code);
-}
+import { getDependencyResolutionCommands } from '../lib/dependency-resolution.js';
 
 function getPackages(projectConfig: ProjectConfigManager): SandboxPackage[] {
   const packages: SandboxPackage[] = [];
@@ -114,139 +107,6 @@ function shellEscape(value: string): string {
   return `'${value.replace(/'/g, `'\"'\"'`)}'`;
 }
 
-function getDependencyResolutionCommands(
-  projectConfig: ProjectConfigManager
-): string[] {
-  const commands: string[] = [];
-  const locations = [
-    {
-      path: '/workspace',
-      packageManagers: projectConfig.packageManagers ?? [],
-      label: 'workspace root',
-    },
-    ...(projectConfig.projects ?? []).map(project => ({
-      path: `/workspace/${project.path}`,
-      packageManagers: project.packageManagers ?? [],
-      label: project.path,
-    })),
-  ];
-
-  for (const location of locations) {
-    const quotedPath = shellEscape(location.path);
-    const pms = location.packageManagers;
-
-    if (pms.includes('uv')) {
-      commands.push(
-        `if [ -f ${quotedPath}/pyproject.toml ]; then`,
-        `  echo "📦 Resolving Python dependencies (uv) in ${location.label}..."`,
-        `  cd ${quotedPath} && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('poetry')) {
-      commands.push(
-        `if [ -f ${quotedPath}/pyproject.toml ]; then`,
-        `  echo "📦 Resolving Python dependencies (poetry) in ${location.label}..."`,
-        `  cd ${quotedPath} && poetry install --no-interaction 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('pub')) {
-      commands.push(
-        `if [ -f ${quotedPath}/pubspec.yaml ]; then`,
-        `  echo "📦 Resolving Dart dependencies in ${location.label}..."`,
-        `  cd ${quotedPath} && flutter pub get 2>/dev/null || dart pub get 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('npm')) {
-      commands.push(
-        `if [ -f ${quotedPath}/package-lock.json ]; then`,
-        `  echo "📦 Resolving Node.js dependencies (npm) in ${location.label}..."`,
-        `  cd ${quotedPath} && npm ci 2>/dev/null || npm install 2>/dev/null || true`,
-        `elif [ -f ${quotedPath}/package.json ]; then`,
-        `  echo "📦 Resolving Node.js dependencies (npm) in ${location.label}..."`,
-        `  cd ${quotedPath} && npm install 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('pnpm')) {
-      commands.push(
-        `if [ -f ${quotedPath}/pnpm-lock.yaml ]; then`,
-        `  echo "📦 Resolving Node.js dependencies (pnpm) in ${location.label}..."`,
-        `  cd ${quotedPath} && pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true`,
-        `elif [ -f ${quotedPath}/package.json ]; then`,
-        `  echo "📦 Resolving Node.js dependencies (pnpm) in ${location.label}..."`,
-        `  cd ${quotedPath} && pnpm install 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('yarn')) {
-      commands.push(
-        `if [ -f ${quotedPath}/yarn.lock ]; then`,
-        `  echo "📦 Resolving Node.js dependencies (yarn) in ${location.label}..."`,
-        `  cd ${quotedPath} && yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true`,
-        `elif [ -f ${quotedPath}/package.json ]; then`,
-        `  echo "📦 Resolving Node.js dependencies (yarn) in ${location.label}..."`,
-        `  cd ${quotedPath} && yarn install 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('composer')) {
-      commands.push(
-        `if [ -f ${quotedPath}/composer.json ]; then`,
-        `  echo "📦 Resolving PHP dependencies in ${location.label}..."`,
-        `  cd ${quotedPath} && composer install --no-interaction 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('cargo')) {
-      commands.push(
-        `if [ -f ${quotedPath}/Cargo.toml ]; then`,
-        `  echo "📦 Resolving Rust dependencies in ${location.label}..."`,
-        `  cd ${quotedPath} && cargo fetch 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('gomod')) {
-      commands.push(
-        `if [ -f ${quotedPath}/go.mod ]; then`,
-        `  echo "📦 Resolving Go dependencies in ${location.label}..."`,
-        `  cd ${quotedPath} && go mod download 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('pip')) {
-      commands.push(
-        `if [ -f ${quotedPath}/requirements.txt ]; then`,
-        `  echo "📦 Resolving Python dependencies (pip) in ${location.label}..."`,
-        `  cd ${quotedPath} && pip install -r requirements.txt 2>/dev/null || true`,
-        'fi'
-      );
-    }
-
-    if (pms.includes('rubygems')) {
-      commands.push(
-        `if [ -f ${quotedPath}/Gemfile ]; then`,
-        `  echo "📦 Resolving Ruby dependencies in ${location.label}..."`,
-        `  cd ${quotedPath} && bundle install 2>/dev/null || true`,
-        'fi'
-      );
-    }
-  }
-
-  return commands;
-}
-
 function generateProjectRepositorySyncSection(
   projectConfig: ProjectConfigManager
 ): string {
@@ -262,49 +122,23 @@ function generateProjectRepositorySyncSection(
     const targetPath = `/workspace/${project.path}`;
     const escapedName = shellEscape(project.name);
     const escapedPath = shellEscape(targetPath);
-    const escapedRepository = shellEscape(project.repository!);
-    const escapedRef = project.ref ? shellEscape(project.ref) : '';
 
-    const checkoutRef = project.ref
-      ? `
-echo "🔀 Checking out ${escapedRef} for ${escapedName}"
-if git -C ${escapedPath} rev-parse --verify refs/remotes/origin/${escapedRef} >/dev/null 2>&1; then
-  git -C ${escapedPath} checkout -B ${escapedRef} refs/remotes/origin/${escapedRef}
-elif git -C ${escapedPath} rev-parse --verify ${escapedRef} >/dev/null 2>&1; then
-  git -C ${escapedPath} checkout --detach ${escapedRef}
-else
-  echo "❌ Could not resolve ref ${escapedRef} in ${escapedName}"
-  safe_exit 1
-fi`
-      : `
-default_remote_ref=$(git -C ${escapedPath} symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
-if [ -z "$default_remote_ref" ]; then
-  echo "❌ Could not determine default remote branch for ${escapedName}"
+    return `echo "📥 Validating local child repository ${escapedName} for build cache"
+if [ ! -d ${escapedPath} ]; then
+  echo "❌ Missing child repository ${escapedName} at ${escapedPath} in the staged build workspace"
+  echo "   rover build does not clone child repositories from project.repository."
+  echo "   Make sure ${escapedName} is already materialized under ${escapedPath} before building the cache image."
   safe_exit 1
 fi
-default_branch="\${default_remote_ref#origin/}"
-echo "🔀 Checking out default branch $default_branch for ${escapedName}"
-git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"`;
-
-    return `echo "📥 Syncing repository ${escapedName} for build cache"
-mkdir -p "$(dirname ${escapedPath})"
-rm -rf ${escapedPath}
-git clone ${escapedRepository} ${escapedPath}
-if ! git -C ${escapedPath} fetch --all --tags --prune; then
-  echo "❌ Failed to fetch repository ${escapedName}"
-  safe_exit 1
-fi
-${checkoutRef}
-git -C ${escapedPath} reset --hard HEAD
-git -C ${escapedPath} clean -fd
-echo "✅ Repository ${escapedName} is ready for build caching"`;
+echo "✅ Local child repository ${escapedName} is present for build caching"`;
   });
 
   return `
-# Materialize external project repositories so multi-repo dependency setup can
-# be baked into the cache image just like the root repository.
+# Validate external project repositories are already present in the staged
+# workspace so multi-repo dependency setup can be baked into the cache image
+# without requiring build-time Git credentials.
 echo -e "\\n======================================="
-echo "📥 Syncing external repositories for cache build"
+echo "📥 Validating external repositories for cache build"
 echo "======================================="
 ${syncBlocks.join('\n')}
 `;
@@ -332,16 +166,12 @@ function generateBuildEntrypoint(
     }
   }
 
-  const rootInitScripts = (projectConfig.allInitScripts ?? []).filter(
-    () => true
-  );
+  const rootInitScripts = projectConfig.allInitScripts ?? [];
   const initScriptBlocks = rootInitScripts.map(entry => {
     const workspaceScript = entry.path
       ? `/workspace/${entry.path}/${entry.script}`
       : `/workspace/${entry.script}`;
-    const workspaceDir = entry.path
-      ? `/workspace/${entry.path}`
-      : '/workspace';
+    const workspaceDir = entry.path ? `/workspace/${entry.path}` : '/workspace';
     const label = entry.path ? ` (${entry.path})` : '';
 
     return `echo "🔧 Running initialization script${label}"
@@ -359,9 +189,10 @@ ${initScriptBlocks.join('\n')}
 `
       : '';
 
-  const dependencyResolutionCommands = getDependencyResolutionCommands(
-    projectConfig
-  );
+  const dependencyResolutionCommands = getDependencyResolutionCommands({
+    rootPackageManagers: projectConfig.packageManagers ?? [],
+    projects: projectConfig.projects,
+  });
   const dependencyResolutionSection =
     dependencyResolutionCommands.length > 0
       ? `
@@ -420,10 +251,6 @@ mkdir -p "$BUILD_WORKSPACE"
 cp -a /workspace-src/. "$BUILD_WORKSPACE/"
 rm -rf /workspace 2>/dev/null || true
 ln -s "$BUILD_WORKSPACE" /workspace
-
-# Allow local source repos copied into the staged workspace to be used as
-# clone/fetch remotes during cache builds regardless of runtime UID/GID.
-git config --global --add safe.directory '*' 2>/dev/null || true
 
 # Install languages, package managers, task managers
 ${installScripts.join('\n')}
@@ -529,7 +356,6 @@ const buildCommand = async (
       jsonOutput.cacheTag = cacheTag;
       jsonOutput.cached = true;
       await exitWithSuccess(null, jsonOutput, { telemetry });
-      exitProcessIfNeeded(0);
       return;
     }
 
@@ -667,18 +493,15 @@ const buildCommand = async (
       jsonOutput.elapsed = parseFloat(elapsed);
       jsonOutput.cached = false;
       await exitWithSuccess(null, jsonOutput, { telemetry });
-      exitProcessIfNeeded(0);
     } else {
       jsonOutput.success = false;
       jsonOutput.error = 'Container init failed — image was not committed';
       await exitWithError(jsonOutput, { telemetry });
-      exitProcessIfNeeded(1);
     }
   } catch (error) {
     jsonOutput.success = false;
     jsonOutput.error = error instanceof Error ? error.message : String(error);
     await exitWithError(jsonOutput, { telemetry });
-    exitProcessIfNeeded(1);
   }
 };
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -19,9 +19,9 @@ import { getProjectPath, isJsonMode } from '../lib/context.js';
 import { getAvailableSandboxBackend } from '../lib/sandbox/index.js';
 import {
   ContainerBackend,
+  getBuildContainerExtraArgs,
   getInitScriptMounts,
   getRootInitScriptMountPath,
-  normalizeExtraArgs,
   resolveAgentImage,
 } from '../lib/sandbox/container-common.js';
 import {
@@ -70,6 +70,7 @@ export function prepareBuildProjectConfig(
   repositoryMounts: BuildRepositoryMount[];
 } {
   const repositoryMounts: BuildRepositoryMount[] = [];
+  const repositoryResolutionRoot = projectConfig.projectRoot ?? projectPath;
   const buildProjects = (projectConfig.projects ?? []).flatMap(
     (project, index) => {
       const projectPathIsSafe =
@@ -93,7 +94,7 @@ export function prepareBuildProjectConfig(
 
       const hostPath = project.repository.startsWith('file://')
         ? fileURLToPath(project.repository)
-        : resolve(projectPath, project.repository);
+        : resolve(repositoryResolutionRoot, project.repository);
 
       if (!existsSync(hostPath)) {
         throw new Error(
@@ -163,29 +164,28 @@ fi
 `
       : `
 default_remote_ref=$(git -C ${escapedPath} symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
-if [ -z "$default_remote_ref" ]; then
-  echo "❌ Could not determine default remote branch for ${escapedName}"
-  safe_exit 1
+if [ -n "$default_remote_ref" ]; then
+  default_branch="\${default_remote_ref#origin/}"
+  echo "🔀 Checking out default branch $default_branch for ${escapedName}"
+  git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"
+else
+  echo "🔀 Remote HEAD not advertised for ${escapedName}; using cloned default checkout"
 fi
-default_branch="\${default_remote_ref#origin/}"
-echo "🔀 Checking out default branch $default_branch for ${escapedName}"
-git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"
 `;
 
     return `echo "📥 Syncing child repository ${escapedName} for build cache"
 mkdir -p "$(dirname ${escapedPath})"
-if [ ! -d ${escapedPath}/.git ]; then
-  rm -rf ${escapedPath}
-  if ! git clone ${escapedRepository} ${escapedPath}; then
-    echo "❌ Failed to clone repository ${escapedName}"
-    safe_exit 1
-  fi
-else
+if [ -d ${escapedPath}/.git ]; then
   current_origin=$(git -C ${escapedPath} remote get-url origin 2>/dev/null || true)
   if [ "$current_origin" != ${escapedRepository} ]; then
     echo "❌ Existing repository at ${escapedPath} points to a different origin"
     safe_exit 1
   fi
+fi
+rm -rf ${escapedPath}
+if ! git clone ${escapedRepository} ${escapedPath}; then
+  echo "❌ Failed to clone repository ${escapedName}"
+  safe_exit 1
 fi
 if ! git -C ${escapedPath} fetch --all --tags --prune; then
   echo "❌ Failed to fetch repository ${escapedName}"
@@ -305,10 +305,13 @@ ${dependencyResolutionCommands.join('\n')}
       : '';
 
   const mcps = projectConfig.mcps ?? [];
+  // rover-agent commands only accept the agent name (e.g. "claude"), not
+  // the full agent:model string (e.g. "claude:haiku").
+  const agentName = agent.split(':')[0];
   let mcpSection = '';
   if (mcps.length > 0) {
     const mcpCmds = mcps.map(mcp => {
-      let cmd = `rover-agent config mcp ${shellEscape(agent)} ${shellEscape(mcp.name)} --transport ${shellEscape(mcp.transport)}`;
+      let cmd = `rover-agent config mcp ${shellEscape(agentName)} ${shellEscape(mcp.name)} --transport ${shellEscape(mcp.transport)}`;
       for (const env of mcp.envs ?? []) cmd += ` --env ${shellEscape(env)}`;
       for (const header of mcp.headers ?? [])
         cmd += ` --header ${shellEscape(header)}`;
@@ -317,13 +320,13 @@ ${dependencyResolutionCommands.join('\n')}
     });
     mcpSection = `
 # Configure MCPs
-rover-agent config mcp ${shellEscape(agent)} package-manager --transport "http" http://127.0.0.1:8090/mcp
+rover-agent config mcp ${shellEscape(agentName)} package-manager --transport "http" http://127.0.0.1:8090/mcp
 ${mcpCmds.join('\n')}
 `;
   } else {
     mcpSection = `
 # Configure built-in MCP
-rover-agent config mcp ${shellEscape(agent)} package-manager --transport "http" http://127.0.0.1:8090/mcp
+rover-agent config mcp ${shellEscape(agentName)} package-manager --transport "http" http://127.0.0.1:8090/mcp
 `;
   }
 
@@ -331,6 +334,9 @@ rover-agent config mcp ${shellEscape(agent)} package-manager --transport "http" 
 set -euo pipefail
 
 AGENT=${shellEscape(agent)}
+# Strip model suffix (e.g. "claude:haiku" → "claude") for commands that
+# only accept the agent name.
+AGENT_NAME="\${AGENT%%:*}"
 
 safe_exit() {
   exit "\${1:-1}"
@@ -382,16 +388,22 @@ cp -a /workspace-src/. "$BUILD_WORKSPACE/"
 rm -rf /workspace 2>/dev/null || true
 ln -s "$BUILD_WORKSPACE" /workspace
 
-echo "Installing agent CLI ($AGENT)..."
-run_as_root_with_env rover-agent install $AGENT || echo "Agent install failed (non-fatal for build)"
+echo "Installing agent CLI ($AGENT_NAME)..."
+run_as_root_with_env rover-agent install $AGENT_NAME || echo "Agent install failed (non-fatal for build)"
 run_as_root chown -R $(id -u):$(id -g) $HOME
 
 # Copy credentials
 echo "Copying agent credentials..."
-run_as_root rover-agent-install $AGENT || true
+run_as_root rover-agent-install $AGENT_NAME || true
 for _cred_dir in $HOME/.codex $HOME/.claude $HOME/.config/github-copilot $HOME/.gemini $HOME/.qwen $HOME/.opencode; do
   [ -d "$_cred_dir" ] && run_as_root chown -R $(id -u):$(id -g) "$_cred_dir"
 done
+
+# Mark all directories as git-safe so they work with any UID.
+# Must run before syncing external repositories so clones from bind-mounted
+# bare repos don't fail with "dubious ownership" errors.
+git config --global --add safe.directory '*' 2>/dev/null || true
+git config --system --add safe.directory '*' 2>/dev/null || true
 
 ${generateProjectRepositorySyncSection(projectConfig)}
 
@@ -419,10 +431,6 @@ chmod -R a+rwX $HOME 2>/dev/null || true
 for _dlcache_dir in /var/cache/apt; do
   [ -d "$_dlcache_dir" ] && chmod -R a+rwX "$_dlcache_dir" 2>/dev/null || true
 done
-
-# Mark all directories as git-safe so they work with any UID.
-# Safe inside build containers — ephemeral, single-user, no multi-tenant concerns.
-git config --system --add safe.directory '*' 2>/dev/null || true
 
 echo ""
 echo "Build complete!"
@@ -475,12 +483,16 @@ const buildCommand = async (
     // 2. Resolve agent image
     const agentImage = resolveAgentImage(projectConfig, undefined);
 
-    // 3. Check if cache already exists
+    // 3. Check if cache already exists.
+    // Use the agent name without model suffix for cache hashing so that
+    // `rover build -a claude:haiku` and `rover task -a claude:haiku` (which
+    // stores agent="claude") produce the same hash.
+    const agentNameForCache = agent.split(':')[0];
     const { hasCachedImage, cacheTag } = checkImageCache(
       backend,
       projectConfig,
       agentImage,
-      agent
+      agentNameForCache
     );
 
     if (hasCachedImage && !options.force) {
@@ -578,20 +590,9 @@ const buildCommand = async (
     // (languages, package caches) is baked into the committed image rather
     // than going into named volumes that docker commit ignores.
     // This way the cache image is self-contained and works without volumes.
-    const configExtraArgs = normalizeExtraArgs(projectConfig.sandboxExtraArgs);
-    for (let i = 0; i < configExtraArgs.length; i++) {
-      const arg = configExtraArgs[i];
-      if (arg === '-v' || arg === '--volume') {
-        // Skip -v and its value
-        i++;
-        continue;
-      }
-      // Skip --volume=... form
-      if (arg.startsWith('--volume=') || arg.startsWith('-v=')) {
-        continue;
-      }
-      dockerArgs.push(arg);
-    }
+    dockerArgs.push(
+      ...getBuildContainerExtraArgs(projectConfig.sandboxExtraArgs)
+    );
 
     // Init-only: run entrypoint then exit with 'true'
     dockerArgs.push(agentImage, 'true');

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -68,38 +68,57 @@ export function prepareBuildProjectConfig(
   repositoryMounts: BuildRepositoryMount[];
 } {
   const repositoryMounts: BuildRepositoryMount[] = [];
-  const buildProjects = (projectConfig.projects ?? []).map((project, index) => {
-    if (
-      typeof project.repository !== 'string' ||
-      !isLocalRepositoryReference(project.repository)
-    ) {
-      return project;
+  const buildProjects = (projectConfig.projects ?? []).flatMap(
+    (project, index) => {
+      const projectPathIsSafe =
+        typeof project.path === 'string' &&
+        (typeof projectConfig.projectRoot !== 'string'
+          ? isSafeRelativePath(project.path)
+          : resolvePathWithinRoot(projectConfig.projectRoot, project.path) !==
+            null);
+      if (!projectPathIsSafe) {
+        // Exclude projects with unsafe paths — they cannot be safely
+        // mounted or cloned inside the container.
+        return [];
+      }
+
+      if (
+        typeof project.repository !== 'string' ||
+        !isLocalRepositoryReference(project.repository)
+      ) {
+        return [project];
+      }
+
+      const hostPath = project.repository.startsWith('file://')
+        ? fileURLToPath(project.repository)
+        : resolve(projectPath, project.repository);
+
+      if (!existsSync(hostPath)) {
+        throw new Error(
+          `Local workspace repository for ${project.name} not found: ${hostPath}`
+        );
+      }
+
+      const containerPath = `/workspace-repos/${index}`;
+      repositoryMounts.push({ hostPath, containerPath });
+
+      return [
+        {
+          ...project,
+          repository: containerPath,
+        },
+      ];
     }
-
-    const hostPath = project.repository.startsWith('file://')
-      ? fileURLToPath(project.repository)
-      : resolve(projectPath, project.repository);
-
-    if (!existsSync(hostPath)) {
-      throw new Error(
-        `Local workspace repository for ${project.name} not found: ${hostPath}`
-      );
-    }
-
-    const containerPath = `/workspace-repos/${index}`;
-    repositoryMounts.push({ hostPath, containerPath });
-
-    return {
-      ...project,
-      repository: containerPath,
-    };
-  });
+  );
 
   return {
-    buildProjectConfig: {
-      ...projectConfig,
-      projects: buildProjects,
-    } as ProjectConfigManager,
+    buildProjectConfig: new ProjectConfigManager(
+      {
+        ...projectConfig.toJSON(),
+        projects: buildProjects,
+      },
+      projectConfig.projectRoot ?? projectPath
+    ),
     repositoryMounts,
   };
 }
@@ -218,17 +237,13 @@ function generateBuildEntrypoint(
 
       if (entry.path) {
         return `echo "🔧 Running initialization script${label}"
-workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
 workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
 if [ -f "$workspace_project_script_${index}" ]; then
   workspace_script_${index}="$workspace_project_script_${index}"
   workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
-elif [ -f "$workspace_root_script_${index}" ]; then
-  workspace_script_${index}="$workspace_root_script_${index}"
-  workspace_dir_${index}='/workspace'
 else
-  workspace_script_${index}="$workspace_root_script_${index}"
-  workspace_dir_${index}='/workspace'
+  echo "❌ Initialization script${label} not found at $workspace_project_script_${index}"
+  safe_exit 1
 fi
 cd "$workspace_dir_${index}"
 bash "$workspace_script_${index}"

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -59,6 +59,7 @@ import { TaskSandboxPackage } from '../lib/sandbox/task-managers/task.js';
 
 import type { SandboxPackage } from '../lib/sandbox/types.js';
 import { getDependencyResolutionCommands } from '../lib/dependency-resolution.js';
+import { shellEscape } from '../utils/shell.js';
 
 function getPackages(projectConfig: ProjectConfigManager): SandboxPackage[] {
   const packages: SandboxPackage[] = [];
@@ -101,10 +102,6 @@ function getPackages(projectConfig: ProjectConfigManager): SandboxPackage[] {
     if (tmMap[tm]) packages.push(tmMap[tm]());
   }
   return packages;
-}
-
-function shellEscape(value: string): string {
-  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
 }
 
 function generateProjectRepositorySyncSection(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -125,12 +125,12 @@ function generateProjectRepositorySyncSection(
 
     return `echo "📥 Validating local child repository ${escapedName} for build cache"
 if [ ! -d ${escapedPath} ]; then
-  echo "⚠ Missing child repository ${escapedName} at ${escapedPath} in the staged build workspace"
-  echo "  Skipping project-specific cache setup for ${escapedName}."
-  echo "  rover build does not clone child repositories from project.repository."
-else
-  echo "✅ Local child repository ${escapedName} is present for build caching"
-fi`;
+  echo "❌ Missing child repository ${escapedName} at ${escapedPath} in the staged build workspace"
+  echo "   rover build does not clone child repositories from project.repository."
+  echo "   Make sure ${escapedName} is already materialized under ${escapedPath} before building the cache image."
+  safe_exit 1
+fi
+echo "✅ Local child repository ${escapedName} is present for build caching"`;
   });
 
   return `

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -44,7 +44,10 @@ import {
   isSafeRelativePath,
   resolvePathWithinRoot,
 } from '../utils/path-safety.js';
-import { isLocalRepositoryReference } from '../utils/repository-reference.js';
+import {
+  isLocalRepositoryReference,
+  resolveRepositoryHostPath,
+} from '../utils/repository-reference.js';
 import { shellEscape } from '../utils/shell.js';
 
 interface BuildRepositoryMount {
@@ -84,7 +87,10 @@ export function prepareBuildProjectConfig(
 
       const hostPath = project.repository.startsWith('file://')
         ? fileURLToPath(project.repository)
-        : resolve(repositoryResolutionRoot, project.repository);
+        : resolveRepositoryHostPath(
+            project.repository,
+            repositoryResolutionRoot
+          );
 
       if (!existsSync(hostPath)) {
         throw new Error(

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -78,7 +78,10 @@ git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"
 mkdir -p "$(dirname ${escapedPath})"
 if [ ! -d ${escapedPath}/.git ]; then
   rm -rf ${escapedPath}
-  git clone ${escapedRepository} ${escapedPath}
+  if ! git clone ${escapedRepository} ${escapedPath}; then
+    echo "❌ Failed to clone repository ${escapedName}"
+    safe_exit 1
+  fi
 else
   current_origin=$(git -C ${escapedPath} remote get-url origin 2>/dev/null || true)
   if [ "$current_origin" != ${escapedRepository} ]; then

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -31,13 +31,23 @@ import { getUserAIAgent, getAIAgentTool } from '../lib/agents/index.js';
 
 import { getPackagesFromConfig } from '../lib/sandbox/packages.js';
 import { getDependencyResolutionCommands } from '../lib/dependency-resolution.js';
+import {
+  isSafeRelativePath,
+  resolvePathWithinRoot,
+} from '../utils/path-safety.js';
 import { shellEscape } from '../utils/shell.js';
 
 function generateProjectRepositorySyncSection(
   projectConfig: ProjectConfigManager
 ): string {
   const projectsWithRepositories = (projectConfig.projects || []).filter(
-    project => project.repository
+    project =>
+      project.repository &&
+      typeof project.path === 'string' &&
+      (typeof projectConfig.projectRoot !== 'string'
+        ? isSafeRelativePath(project.path)
+        : resolvePathWithinRoot(projectConfig.projectRoot, project.path) !==
+          null)
   );
 
   if (projectsWithRepositories.length === 0) {
@@ -134,18 +144,22 @@ function generateBuildEntrypoint(
   }
 
   const rootInitScripts = projectConfig.allInitScripts ?? [];
-  const initScriptBlocks = rootInitScripts.map(entry => {
-    const workspaceScript = entry.path
-      ? `/workspace/${entry.path}/${entry.script}`
-      : `/workspace/${entry.script}`;
-    const workspaceDir = entry.path ? `/workspace/${entry.path}` : '/workspace';
-    const label = entry.path ? ` (${entry.path})` : '';
+  const initScriptBlocks = rootInitScripts
+    .filter(entry => !entry.path || isSafeRelativePath(entry.path))
+    .map(entry => {
+      const workspaceScript = entry.path
+        ? `/workspace/${entry.path}/${entry.script}`
+        : `/workspace/${entry.script}`;
+      const workspaceDir = entry.path
+        ? `/workspace/${entry.path}`
+        : '/workspace';
+      const label = entry.path ? ` (${entry.path})` : '';
 
-    return `echo "🔧 Running initialization script${label}"
+      return `echo "🔧 Running initialization script${label}"
 cd ${JSON.stringify(workspaceDir)}
 bash ${JSON.stringify(workspaceScript)}
 echo "✅ Initialization script${label} completed successfully"`;
-  });
+    });
 
   const initScriptSection =
     initScriptBlocks.length > 0

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -125,12 +125,12 @@ function generateProjectRepositorySyncSection(
 
     return `echo "📥 Validating local child repository ${escapedName} for build cache"
 if [ ! -d ${escapedPath} ]; then
-  echo "❌ Missing child repository ${escapedName} at ${escapedPath} in the staged build workspace"
-  echo "   rover build does not clone child repositories from project.repository."
-  echo "   Make sure ${escapedName} is already materialized under ${escapedPath} before building the cache image."
-  safe_exit 1
-fi
-echo "✅ Local child repository ${escapedName} is present for build caching"`;
+  echo "⚠ Missing child repository ${escapedName} at ${escapedPath} in the staged build workspace"
+  echo "  Skipping project-specific cache setup for ${escapedName}."
+  echo "  rover build does not clone child repositories from project.repository."
+else
+  echo "✅ Local child repository ${escapedName} is present for build caching"
+fi`;
   });
 
   return `

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -59,6 +59,14 @@ import { TaskSandboxPackage } from '../lib/sandbox/task-managers/task.js';
 
 import type { SandboxPackage } from '../lib/sandbox/types.js';
 
+function exitProcessIfNeeded(code: number): void {
+  if (process.env.VITEST) {
+    return;
+  }
+
+  process.exit(code);
+}
+
 function getPackages(projectConfig: ProjectConfigManager): SandboxPackage[] {
   const packages: SandboxPackage[] = [];
   const langMap: Record<string, () => SandboxPackage> = {
@@ -102,6 +110,206 @@ function getPackages(projectConfig: ProjectConfigManager): SandboxPackage[] {
   return packages;
 }
 
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function getDependencyResolutionCommands(
+  projectConfig: ProjectConfigManager
+): string[] {
+  const commands: string[] = [];
+  const locations = [
+    {
+      path: '/workspace',
+      packageManagers: projectConfig.packageManagers ?? [],
+      label: 'workspace root',
+    },
+    ...(projectConfig.projects ?? []).map(project => ({
+      path: `/workspace/${project.path}`,
+      packageManagers: project.packageManagers ?? [],
+      label: project.path,
+    })),
+  ];
+
+  for (const location of locations) {
+    const quotedPath = shellEscape(location.path);
+    const pms = location.packageManagers;
+
+    if (pms.includes('uv')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pyproject.toml ]; then`,
+        `  echo "📦 Resolving Python dependencies (uv) in ${location.label}..."`,
+        `  cd ${quotedPath} && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('poetry')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pyproject.toml ]; then`,
+        `  echo "📦 Resolving Python dependencies (poetry) in ${location.label}..."`,
+        `  cd ${quotedPath} && poetry install --no-interaction 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('pub')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pubspec.yaml ]; then`,
+        `  echo "📦 Resolving Dart dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && flutter pub get 2>/dev/null || dart pub get 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('npm')) {
+      commands.push(
+        `if [ -f ${quotedPath}/package-lock.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (npm) in ${location.label}..."`,
+        `  cd ${quotedPath} && npm ci 2>/dev/null || npm install 2>/dev/null || true`,
+        `elif [ -f ${quotedPath}/package.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (npm) in ${location.label}..."`,
+        `  cd ${quotedPath} && npm install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('pnpm')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pnpm-lock.yaml ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (pnpm) in ${location.label}..."`,
+        `  cd ${quotedPath} && pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true`,
+        `elif [ -f ${quotedPath}/package.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (pnpm) in ${location.label}..."`,
+        `  cd ${quotedPath} && pnpm install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('yarn')) {
+      commands.push(
+        `if [ -f ${quotedPath}/yarn.lock ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (yarn) in ${location.label}..."`,
+        `  cd ${quotedPath} && yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true`,
+        `elif [ -f ${quotedPath}/package.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (yarn) in ${location.label}..."`,
+        `  cd ${quotedPath} && yarn install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('composer')) {
+      commands.push(
+        `if [ -f ${quotedPath}/composer.json ]; then`,
+        `  echo "📦 Resolving PHP dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && composer install --no-interaction 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('cargo')) {
+      commands.push(
+        `if [ -f ${quotedPath}/Cargo.toml ]; then`,
+        `  echo "📦 Resolving Rust dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && cargo fetch 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('gomod')) {
+      commands.push(
+        `if [ -f ${quotedPath}/go.mod ]; then`,
+        `  echo "📦 Resolving Go dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && go mod download 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('pip')) {
+      commands.push(
+        `if [ -f ${quotedPath}/requirements.txt ]; then`,
+        `  echo "📦 Resolving Python dependencies (pip) in ${location.label}..."`,
+        `  cd ${quotedPath} && pip install -r requirements.txt 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('rubygems')) {
+      commands.push(
+        `if [ -f ${quotedPath}/Gemfile ]; then`,
+        `  echo "📦 Resolving Ruby dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && bundle install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+  }
+
+  return commands;
+}
+
+function generateProjectRepositorySyncSection(
+  projectConfig: ProjectConfigManager
+): string {
+  const projectsWithRepositories = (projectConfig.projects || []).filter(
+    project => project.repository
+  );
+
+  if (projectsWithRepositories.length === 0) {
+    return '';
+  }
+
+  const syncBlocks = projectsWithRepositories.map(project => {
+    const targetPath = `/workspace/${project.path}`;
+    const escapedName = shellEscape(project.name);
+    const escapedPath = shellEscape(targetPath);
+    const escapedRepository = shellEscape(project.repository!);
+    const escapedRef = project.ref ? shellEscape(project.ref) : '';
+
+    const checkoutRef = project.ref
+      ? `
+echo "🔀 Checking out ${escapedRef} for ${escapedName}"
+if git -C ${escapedPath} rev-parse --verify refs/remotes/origin/${escapedRef} >/dev/null 2>&1; then
+  git -C ${escapedPath} checkout -B ${escapedRef} refs/remotes/origin/${escapedRef}
+elif git -C ${escapedPath} rev-parse --verify ${escapedRef} >/dev/null 2>&1; then
+  git -C ${escapedPath} checkout --detach ${escapedRef}
+else
+  echo "❌ Could not resolve ref ${escapedRef} in ${escapedName}"
+  safe_exit 1
+fi`
+      : `
+default_remote_ref=$(git -C ${escapedPath} symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+if [ -z "$default_remote_ref" ]; then
+  echo "❌ Could not determine default remote branch for ${escapedName}"
+  safe_exit 1
+fi
+default_branch="\${default_remote_ref#origin/}"
+echo "🔀 Checking out default branch $default_branch for ${escapedName}"
+git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"`;
+
+    return `echo "📥 Syncing repository ${escapedName} for build cache"
+mkdir -p "$(dirname ${escapedPath})"
+rm -rf ${escapedPath}
+git clone ${escapedRepository} ${escapedPath}
+if ! git -C ${escapedPath} fetch --all --tags --prune; then
+  echo "❌ Failed to fetch repository ${escapedName}"
+  safe_exit 1
+fi
+${checkoutRef}
+git -C ${escapedPath} reset --hard HEAD
+git -C ${escapedPath} clean -fd
+echo "✅ Repository ${escapedName} is ready for build caching"`;
+  });
+
+  return `
+# Materialize external project repositories so multi-repo dependency setup can
+# be baked into the cache image just like the root repository.
+echo -e "\\n======================================="
+echo "📥 Syncing external repositories for cache build"
+echo "======================================="
+${syncBlocks.join('\n')}
+`;
+}
+
 function generateBuildEntrypoint(
   agent: string,
   projectConfig: ProjectConfigManager,
@@ -123,6 +331,44 @@ function generateBuildEntrypoint(
       installScripts.push(init);
     }
   }
+
+  const rootInitScripts = (projectConfig.allInitScripts ?? []).filter(
+    () => true
+  );
+  const initScriptBlocks = rootInitScripts.map(entry => {
+    const workspaceScript = entry.path
+      ? `/workspace/${entry.path}/${entry.script}`
+      : `/workspace/${entry.script}`;
+    const workspaceDir = entry.path
+      ? `/workspace/${entry.path}`
+      : '/workspace';
+    const label = entry.path ? ` (${entry.path})` : '';
+
+    return `echo "🔧 Running initialization script${label}"
+cd ${JSON.stringify(workspaceDir)}
+bash ${JSON.stringify(workspaceScript)}
+echo "✅ Initialization script${label} completed successfully"`;
+  });
+
+  const initScriptSection =
+    initScriptBlocks.length > 0
+      ? `
+# Run root and project init scripts after project repositories have been
+# materialized into the writable build workspace.
+${initScriptBlocks.join('\n')}
+`
+      : '';
+
+  const dependencyResolutionCommands = getDependencyResolutionCommands(
+    projectConfig
+  );
+  const dependencyResolutionSection =
+    dependencyResolutionCommands.length > 0
+      ? `
+# Resolve root and project dependencies in the staged build workspace.
+${dependencyResolutionCommands.join('\n')}
+`
+      : '';
 
   const mcps = projectConfig.mcps ?? [];
   let mcpSection = '';
@@ -167,10 +413,26 @@ if [[ -f /etc/debian_version ]]; then
   sudo apt-get update -qq
 fi
 
+# Create a writable build workspace from the read-only host project mount.
+export BUILD_WORKSPACE=/tmp/rover-build-workspace
+rm -rf "$BUILD_WORKSPACE"
+mkdir -p "$BUILD_WORKSPACE"
+cp -a /workspace-src/. "$BUILD_WORKSPACE/"
+rm -rf /workspace 2>/dev/null || true
+ln -s "$BUILD_WORKSPACE" /workspace
+
+# Allow local source repos copied into the staged workspace to be used as
+# clone/fetch remotes during cache builds regardless of runtime UID/GID.
+git config --global --add safe.directory '*' 2>/dev/null || true
+
 # Install languages, package managers, task managers
 ${installScripts.join('\n')}
 
-# Install agent CLI
+${generateProjectRepositorySyncSection(projectConfig)}
+
+${dependencyResolutionSection}
+
+${initScriptSection}
 echo "Installing agent CLI ($AGENT)..."
 sudo -E rover-agent install $AGENT || echo "Agent install failed (non-fatal for build)"
 sudo chown -R $(id -u):$(id -g) $HOME
@@ -267,6 +529,7 @@ const buildCommand = async (
       jsonOutput.cacheTag = cacheTag;
       jsonOutput.cached = true;
       await exitWithSuccess(null, jsonOutput, { telemetry });
+      exitProcessIfNeeded(0);
       return;
     }
 
@@ -310,11 +573,9 @@ const buildCommand = async (
       '--name',
       containerName,
       '-v',
-      `${projectPath}:/workspace:Z,ro`,
+      `${projectPath}:/workspace-src:Z,ro`,
       '-v',
       `${entrypointPath}:/entrypoint.sh:Z,ro`,
-      '-w',
-      '/workspace',
       '--entrypoint',
       '/entrypoint.sh',
     ];
@@ -406,19 +667,23 @@ const buildCommand = async (
       jsonOutput.elapsed = parseFloat(elapsed);
       jsonOutput.cached = false;
       await exitWithSuccess(null, jsonOutput, { telemetry });
+      exitProcessIfNeeded(0);
     } else {
       jsonOutput.success = false;
       jsonOutput.error = 'Container init failed — image was not committed';
       await exitWithError(jsonOutput, { telemetry });
+      exitProcessIfNeeded(1);
     }
   } catch (error) {
     jsonOutput.success = false;
     jsonOutput.error = error instanceof Error ? error.message : String(error);
     await exitWithError(jsonOutput, { telemetry });
+    exitProcessIfNeeded(1);
   }
 };
 
 export { buildCommand };
+export { generateBuildEntrypoint };
 
 export default {
   name: 'build',

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -12,6 +12,7 @@ import { getProjectPath, isJsonMode } from '../lib/context.js';
 import { getAvailableSandboxBackend } from '../lib/sandbox/index.js';
 import {
   ContainerBackend,
+  normalizeExtraArgs,
   resolveAgentImage,
 } from '../lib/sandbox/container-common.js';
 import {
@@ -26,8 +27,7 @@ import { exitWithError, exitWithSuccess } from '../utils/exit.js';
 import type { CommandDefinition } from '../types.js';
 import type { BuildOutput } from '../output-types.js';
 import { getTelemetry } from '../lib/telemetry.js';
-import { getUserAIAgent } from '../lib/agents/index.js';
-import { getAIAgentTool } from '../lib/agents/index.js';
+import { getUserAIAgent, getAIAgentTool } from '../lib/agents/index.js';
 
 // Language packages
 import { JavaScriptSandboxPackage } from '../lib/sandbox/languages/javascript.js';
@@ -461,7 +461,7 @@ const buildCommand = async (
     // (languages, package caches) is baked into the committed image rather
     // than going into named volumes that docker commit ignores.
     // This way the cache image is self-contained and works without volumes.
-    const configExtraArgs = projectConfig.sandboxExtraArgs ?? [];
+    const configExtraArgs = normalizeExtraArgs(projectConfig.sandboxExtraArgs);
     for (let i = 0; i < configExtraArgs.length; i++) {
       const arg = configExtraArgs[i];
       if (arg === '-v' || arg === '--volume') {

--- a/packages/cli/src/commands/cleanup.ts
+++ b/packages/cli/src/commands/cleanup.ts
@@ -320,9 +320,12 @@ const cleanupCommand = async (
       }
 
       if (removedVolumes.length > 0) {
-        showList(removedVolumes.map(v => colors.cyan(v)), {
-          title: 'Download caches removed',
-        });
+        showList(
+          removedVolumes.map(v => colors.cyan(v)),
+          {
+            title: 'Download caches removed',
+          }
+        );
       }
 
       if (toKeep.length > 0) {

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -57,10 +57,10 @@ const deleteCommand = async (
   // Convert string taskId to number
   const numericTaskIds: number[] = [];
   for (const taskId of taskIds) {
-    const numericTaskId = parseInt(taskId, 10);
-    if (Number.isNaN(numericTaskId)) {
+    if (!/^\d+$/.test(taskId)) {
       jsonOutput.errors?.push(`Invalid task ID '${taskId}' - must be a number`);
     } else {
+      const numericTaskId = parseInt(taskId, 10);
       numericTaskIds.push(numericTaskId);
     }
   }

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -20,7 +20,10 @@ import {
   setJsonMode,
   requireProjectContext,
 } from '../lib/context.js';
-import { createSandbox } from '../lib/sandbox/index.js';
+import {
+  createSandbox,
+  isSandboxBackendUnavailableError,
+} from '../lib/sandbox/index.js';
 import type { CommandDefinition } from '../types.js';
 
 const { prompt } = enquirer;
@@ -174,7 +177,7 @@ const deleteCommand = async (
   // Process deletions
   const succeededTasks: number[] = [];
   const failedTasks: number[] = [];
-  const warningTasks: number[] = [];
+  const warningTasks = new Set<number>();
 
   try {
     for (const task of tasksToDelete) {
@@ -186,11 +189,23 @@ const deleteCommand = async (
           });
           await sandbox.stopAndRemove();
         } else if (task.sandboxMetadata) {
-          const sandbox = await createSandbox(task, undefined, {
-            projectPath: project.path,
-            sandboxMetadata: task.sandboxMetadata,
-          });
-          await sandbox.teardownServices();
+          try {
+            const sandbox = await createSandbox(task, undefined, {
+              projectPath: project.path,
+              sandboxMetadata: task.sandboxMetadata,
+            });
+            await sandbox.teardownServices();
+          } catch (error) {
+            if (!isSandboxBackendUnavailableError(error)) {
+              throw error;
+            }
+
+            jsonOutput.errors?.push(
+              `Task ${task.id}: sandbox service cleanup could not run because no container backend is available; task metadata was preserved so cleanup can be retried later`
+            );
+            failedTasks.push(task.id);
+            continue;
+          }
         }
 
         // Delete the task using ProjectManager
@@ -203,7 +218,7 @@ const deleteCommand = async (
         if (prune) {
           succeededTasks.push(task.id);
         } else {
-          warningTasks.push(task.id);
+          warningTasks.add(task.id);
           jsonOutput.errors?.push(
             `There was an error pruning task ${task.id.toString()} worktree`
           );
@@ -217,7 +232,7 @@ const deleteCommand = async (
     }
   } finally {
     // Determine overall success
-    const allSucceeded = failedTasks.length === 0 && warningTasks.length === 0;
+    const allSucceeded = failedTasks.length === 0 && warningTasks.size === 0;
     const someSucceeded = succeededTasks.length > 0;
 
     jsonOutput.success = allSucceeded;

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -20,6 +20,7 @@ import {
   setJsonMode,
   requireProjectContext,
 } from '../lib/context.js';
+import { createSandbox } from '../lib/sandbox/index.js';
 import type { CommandDefinition } from '../types.js';
 
 const { prompt } = enquirer;
@@ -178,6 +179,20 @@ const deleteCommand = async (
   try {
     for (const task of tasksToDelete) {
       try {
+        if (task.containerId) {
+          const sandbox = await createSandbox(task, undefined, {
+            projectPath: project.path,
+            sandboxMetadata: task.sandboxMetadata,
+          });
+          await sandbox.stopAndRemove();
+        } else if (task.sandboxMetadata) {
+          const sandbox = await createSandbox(task, undefined, {
+            projectPath: project.path,
+            sandboxMetadata: task.sandboxMetadata,
+          });
+          await sandbox.teardownServices();
+        }
+
         // Delete the task using ProjectManager
         telemetry?.eventDeleteTask();
         project.deleteTask(task);

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -68,9 +68,7 @@ const diffCommand = async (
   }
 
   const telemetry = getTelemetry();
-  // Convert string taskId to number
-  const numericTaskId = parseInt(taskId, 10);
-  if (isNaN(numericTaskId)) {
+  if (!/^\d+$/.test(taskId)) {
     await exitWithError(
       {
         success: false,
@@ -80,6 +78,7 @@ const diffCommand = async (
     );
     return;
   }
+  const numericTaskId = parseInt(taskId, 10);
 
   // Require project context
   let project;
@@ -407,6 +406,8 @@ const diffCommand = async (
         { telemetry }
       );
     }
+  } finally {
+    await telemetry?.shutdown();
   }
 };
 

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -118,10 +118,7 @@ const inspectCommand = async (
   const telemetry = getTelemetry();
   telemetry?.eventInspectTask();
 
-  // Convert string taskId to number
-  const numericTaskId = parseInt(taskId, 10);
-
-  if (isNaN(numericTaskId)) {
+  if (!/^\d+$/.test(taskId)) {
     const errorOutput = jsonErrorOutput(
       `Invalid task ID '${taskId}' - must be a number`
     );
@@ -135,6 +132,7 @@ const inspectCommand = async (
     });
     return;
   }
+  const numericTaskId = parseInt(taskId, 10);
 
   // Validate mutually exclusive options
   if (options.file && options.rawFile) {

--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -538,15 +538,15 @@ const iterateCommand = async (
         ),
       });
       const containerId = await sandbox.createAndStart();
+      const sandboxMetadata =
+        typeof sandbox.getSandboxMetadata === 'function'
+          ? sandbox.getSandboxMetadata()
+          : process.env.DOCKER_HOST
+            ? { dockerHost: process.env.DOCKER_HOST }
+            : undefined;
 
       // Update task metadata with new container ID for this iteration
-      task.setContainerInfo(
-        containerId,
-        'running',
-        process.env.DOCKER_HOST
-          ? { dockerHost: process.env.DOCKER_HOST }
-          : undefined
-      );
+      task.setContainerInfo(containerId, 'running', sandboxMetadata);
 
       result.success = true;
 

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -109,6 +109,10 @@ interface TaskWithProject {
   project: ProjectManager | null;
 }
 
+interface OrphanCandidate extends TaskWithProject {
+  forceInspect?: boolean;
+}
+
 /**
  * Helper to safely get iteration status
  */
@@ -349,16 +353,26 @@ const listCommand = async (
     }
 
     const refreshedTasksWithProjects: TaskWithProject[] = [];
-    const orphanCandidates: TaskWithProject[] = [];
+    const orphanCandidates: OrphanCandidate[] = [];
     for (const { task, project: projectData } of tasksWithProjects) {
+      const wasActiveBeforeRefresh =
+        task.status === 'IN_PROGRESS' || task.status === 'ITERATING';
       try {
         if (task.status !== 'PAUSED' && task.status !== 'FAILED') {
           task.updateStatusFromIteration();
         }
-        orphanCandidates.push({ task, project: projectData });
+        orphanCandidates.push({
+          task,
+          project: projectData,
+          forceInspect: wasActiveBeforeRefresh,
+        });
         refreshedTasksWithProjects.push({ task, project: projectData });
       } catch (err) {
-        orphanCandidates.push({ task, project: projectData });
+        orphanCandidates.push({
+          task,
+          project: projectData,
+          forceInspect: wasActiveBeforeRefresh,
+        });
         refreshedTasksWithProjects.push({ task, project: projectData });
         if (!isJsonMode()) {
           console.log(

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -226,7 +226,8 @@ const buildTaskRow = (
         : undefined;
     if (operatingMs != null) {
       const opTime = formatDurationMs(operatingMs);
-      durationDisplay = opTime !== wallClock ? `${opTime} (${wallClock})` : opTime;
+      durationDisplay =
+        opTime !== wallClock ? `${opTime} (${wallClock})` : opTime;
     } else {
       durationDisplay = wallClock;
     }
@@ -738,7 +739,10 @@ const listCommand = async (
     console.error(colors.red('Error getting task status:'), error);
     // Recursive watch refreshes share one scheduler across refresh cycles.
     // Only destroy it when the outer list command is unwinding.
-    if (!options.watching && typeof options._retryScheduler?.destroy === 'function') {
+    if (
+      !options.watching &&
+      typeof options._retryScheduler?.destroy === 'function'
+    ) {
       options._retryScheduler?.destroy();
     }
   } finally {

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -122,13 +122,22 @@ const logsCommand = async (
     }
 
     // Determine which iteration to show logs for
-    const actualIteration =
-      targetIteration || availableIterations[availableIterations.length - 1];
+    const latestIteration = availableIterations[availableIterations.length - 1];
+    const actualIteration = targetIteration || latestIteration;
 
     // Check if specific iteration exists (if requested)
     if (targetIteration && !availableIterations.includes(targetIteration)) {
       jsonOutput.error = `Iteration ${targetIteration} not found for task '${numericTaskId}'. Available iterations: ${availableIterations.join(', ')}`;
       await exitWithError(jsonOutput, { telemetry });
+      return;
+    }
+
+    if (targetIteration && targetIteration !== latestIteration) {
+      await exitWithWarn(
+        `Logs for iteration ${targetIteration} are no longer available for task '${numericTaskId}'. Rover can only read logs for the latest iteration's container.`,
+        jsonOutput,
+        { telemetry }
+      );
       return;
     }
 
@@ -288,8 +297,8 @@ const logsCommand = async (
           console.log(colors.gray('💡 Tips:'));
           tips.push(
             'Use ' +
-              colors.cyan(`rover logs ${numericTaskId} <iteration>`) +
-              ' to view specific iteration (if container exists)'
+              colors.cyan(`rover logs ${numericTaskId} ${latestIteration}`) +
+              ' to view the latest iteration logs'
           );
         }
       }

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -74,13 +74,12 @@ const logsCommand = async (
     success: false,
   };
 
-  // Convert string taskId to number
-  const numericTaskId = parseInt(taskId, 10);
-  if (isNaN(numericTaskId)) {
+  if (!/^\d+$/.test(taskId)) {
     jsonOutput.error = `Invalid task ID '${taskId}' - must be a number`;
     await exitWithError(jsonOutput, { telemetry });
     return;
   }
+  const numericTaskId = parseInt(taskId, 10);
 
   // Require project context
   let project;
@@ -102,12 +101,12 @@ const logsCommand = async (
     // Parse iteration number if provided
     let targetIteration: number | undefined;
     if (iterationNumber) {
-      targetIteration = parseInt(iterationNumber, 10);
-      if (Number.isNaN(targetIteration)) {
+      if (!/^\d+$/.test(iterationNumber)) {
         jsonOutput.error = `Invalid iteration number: '${iterationNumber}'`;
         await exitWithError(jsonOutput, { telemetry });
         return;
       }
+      targetIteration = parseInt(iterationNumber, 10);
     }
 
     // Get available iterations for context

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -38,6 +38,10 @@ import {
 
 const { prompt } = enquirer;
 
+function hasNamedCurrentBranch(branchName: string): boolean {
+  return branchName.length > 0 && branchName !== 'unknown';
+}
+
 /**
  * AI-powered merge conflict resolver.
  * Delegates to the shared resolveConflicts utility with merge-specific defaults.
@@ -257,6 +261,16 @@ const mergeCommand = async (taskId: string, options: MergeOptions = {}) => {
 
     // Get current branch name
     jsonOutput.currentBranch = git.getCurrentBranch();
+
+    if (!hasNamedCurrentBranch(jsonOutput.currentBranch)) {
+      jsonOutput.error =
+        'Current checkout is detached. Check out a branch before merging.';
+      await exitWithError(jsonOutput, {
+        tips: ['Run `git checkout <branch>` and retry the merge'],
+        telemetry,
+      });
+      return;
+    }
 
     // Check for uncommitted changes in main repo
     if (git.hasUncommittedChanges()) {

--- a/packages/cli/src/commands/pause.ts
+++ b/packages/cli/src/commands/pause.ts
@@ -64,12 +64,12 @@ const pauseCommand = async (
     : new ProcessManager({ title: 'Pause task' });
   processManager?.start();
 
-  const numericTaskId = parseInt(taskId, 10);
-  if (isNaN(numericTaskId)) {
+  if (!/^\d+$/.test(taskId)) {
     jsonOutput.error = `Invalid task ID '${taskId}' - must be a number`;
     await exitWithError(jsonOutput, { telemetry });
     return;
   }
+  const numericTaskId = parseInt(taskId, 10);
 
   let project;
   try {

--- a/packages/cli/src/commands/pause.ts
+++ b/packages/cli/src/commands/pause.ts
@@ -86,15 +86,15 @@ const pauseCommand = async (
       throw new TaskNotFoundError(numericTaskId);
     }
 
-    // Only running tasks can be paused
-    if (!task.isInProgress() && !task.isIterating()) {
-      jsonOutput.error = `Task ${numericTaskId} is not running (status: ${task.status}). Only IN_PROGRESS or ITERATING tasks can be paused.`;
+    if (task.isPaused()) {
+      jsonOutput.error = `Task ${numericTaskId} is already paused`;
       await exitWithError(jsonOutput, { telemetry });
       return;
     }
 
-    if (task.isPaused()) {
-      jsonOutput.error = `Task ${numericTaskId} is already paused`;
+    // Only running tasks can be paused
+    if (!task.isInProgress() && !task.isIterating()) {
+      jsonOutput.error = `Task ${numericTaskId} is not running (status: ${task.status}). Only IN_PROGRESS or ITERATING tasks can be paused.`;
       await exitWithError(jsonOutput, { telemetry });
       return;
     }

--- a/packages/cli/src/commands/pause.ts
+++ b/packages/cli/src/commands/pause.ts
@@ -120,8 +120,9 @@ const pauseCommand = async (
     // We detect this by watching for the task status to change or
     // the container to exit.
     let agentExited = false;
+    let sandbox: Awaited<ReturnType<typeof createSandbox>> | undefined;
     if (task.containerId) {
-      const sandbox = await createSandbox(task, undefined, {
+      sandbox = await createSandbox(task, undefined, {
         projectPath: project.path,
         sandboxMetadata: task.sandboxMetadata,
       });
@@ -134,6 +135,10 @@ const pauseCommand = async (
           break;
         }
         await new Promise(resolve => setTimeout(resolve, POLL_MS));
+      }
+
+      if (agentExited) {
+        await sandbox.teardownServices();
       }
 
       // If the agent is still running, fall back to SIGTERM
@@ -165,11 +170,22 @@ const pauseCommand = async (
 
     processManager?.completeLastItem();
 
-    const hasCheckpoint = existsSync(checkpointPath);
+    if (!agentExited) {
+      jsonOutput.error = `Task ${numericTaskId} did not exit after pause request and SIGTERM; task is still running`;
+      await exitWithError(jsonOutput, { telemetry });
+      return;
+    }
 
-    // Mark the task as PAUSED and clear container info
+    const hasCheckpoint = existsSync(checkpointPath);
+    const sandboxMetadata =
+      typeof sandbox?.getSandboxMetadata === 'function'
+        ? sandbox.getSandboxMetadata()
+        : task.sandboxMetadata;
+
+    // Mark the task as PAUSED and clear the task container identity while
+    // preserving any sandbox metadata still needed for resume.
     task.markPaused(reason);
-    task.setContainerInfo('', '');
+    task.setContainerInfo('', '', sandboxMetadata);
 
     if (!isJsonMode()) {
       if (hasCheckpoint) {
@@ -178,16 +194,10 @@ const pauseCommand = async (
             '  Checkpoint saved — task can be resumed from where it left off'
           )
         );
-      } else if (agentExited) {
+      } else {
         console.log(
           colors.yellow(
             '  No checkpoint detected — resume will restart the current iteration'
-          )
-        );
-      } else {
-        console.log(
-          colors.red(
-            '  Agent did not exit cleanly — task marked PAUSED but may need manual intervention'
           )
         );
       }

--- a/packages/cli/src/commands/pause.ts
+++ b/packages/cli/src/commands/pause.ts
@@ -1,18 +1,18 @@
-import colors from 'ansi-colors';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { createSandbox } from '../lib/sandbox/index.js';
-import { TaskNotFoundError } from 'rover-schemas';
+import colors from 'ansi-colors';
 import { ProcessManager } from 'rover-core';
-import { exitWithError, exitWithSuccess } from '../utils/exit.js';
-import type { TaskPauseOutput } from '../output-types.js';
-import { getTelemetry } from '../lib/telemetry.js';
+import { TaskNotFoundError } from 'rover-schemas';
 import {
   isJsonMode,
-  setJsonMode,
   requireProjectContext,
+  setJsonMode,
 } from '../lib/context.js';
+import { createSandbox } from '../lib/sandbox/index.js';
+import { getTelemetry } from '../lib/telemetry.js';
+import type { TaskPauseOutput } from '../output-types.js';
 import type { CommandDefinition } from '../types.js';
+import { exitWithError, exitWithSuccess } from '../utils/exit.js';
 
 /**
  * Maximum time (ms) to wait for the agent to finish its current step
@@ -110,7 +110,9 @@ const pauseCommand = async (
     const pauseRequestFile = join(iterationPath, '.pause-requested');
     const checkpointPath = join(iterationPath, 'checkpoint.json');
 
-    processManager?.addItem('Requesting graceful pause (waiting for current step to finish)');
+    processManager?.addItem(
+      'Requesting graceful pause (waiting for current step to finish)'
+    );
 
     writeFileSync(pauseRequestFile, reason, 'utf-8');
 
@@ -120,6 +122,7 @@ const pauseCommand = async (
     let agentExited = false;
     if (task.containerId) {
       const sandbox = await createSandbox(task, undefined, {
+        projectPath: project.path,
         sandboxMetadata: task.sandboxMetadata,
       });
 

--- a/packages/cli/src/commands/pause.ts
+++ b/packages/cli/src/commands/pause.ts
@@ -129,16 +129,12 @@ const pauseCommand = async (
 
       const deadline = Date.now() + GRACEFUL_WAIT_MS;
       while (Date.now() < deadline) {
-        const state = await sandbox.inspect();
+        const state = await sandbox.inspect({ teardownServices: false });
         if (!state || state.status === 'exited' || state.status === '') {
           agentExited = true;
           break;
         }
         await new Promise(resolve => setTimeout(resolve, POLL_MS));
-      }
-
-      if (agentExited) {
-        await sandbox.teardownServices();
       }
 
       // If the agent is still running, fall back to SIGTERM
@@ -155,7 +151,7 @@ const pauseCommand = async (
         // Give it a moment to write the checkpoint
         const sigtermDeadline = Date.now() + SIGTERM_WAIT_MS;
         while (Date.now() < sigtermDeadline) {
-          const state = await sandbox.inspect();
+          const state = await sandbox.inspect({ teardownServices: false });
           if (!state || state.status === 'exited' || state.status === '') {
             agentExited = true;
             break;

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -198,6 +198,26 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       });
     }
 
+    const workspaceRepositories = getWorkspaceRepositories(
+      task.worktreePath,
+      task.getBasePath(),
+      projectConfig
+    );
+    const missingWorkspaceRepositories = workspaceRepositories.filter(
+      repo =>
+        !existsSync(repo.worktreePath) ||
+        !existsSync(join(repo.worktreePath, '.git'))
+    );
+
+    if (missingWorkspaceRepositories.length > 0) {
+      const missingLabels = missingWorkspaceRepositories
+        .map(repo => `${repo.name} (${repo.relativePath})`)
+        .join(', ');
+      result.error = `Configured workspace repositories are missing or invalid: ${missingLabels}`;
+      await exitWithError(result, { telemetry });
+      return;
+    }
+
     const pushTargets: PushTarget[] = [
       {
         label: 'root workspace',
@@ -210,23 +230,17 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         hasLocalChanges: false,
         hasUnpushedCommits: false,
       },
-      ...getWorkspaceRepositories(
-        task.worktreePath,
-        task.getBasePath(),
-        projectConfig
-      )
-        .filter(repo => existsSync(join(repo.worktreePath, '.git')))
-        .map(repo => ({
-          label: repo.name,
-          branchName: task.branchName,
-          currentBranch:
-            git.getCurrentBranch({ worktreePath: repo.worktreePath }) ||
-            'unknown',
-          worktreePath: repo.worktreePath,
-          remoteUrl: git.remoteUrl({ worktreePath: repo.worktreePath }),
-          hasLocalChanges: false,
-          hasUnpushedCommits: false,
-        })),
+      ...workspaceRepositories.map(repo => ({
+        label: repo.name,
+        branchName: task.branchName,
+        currentBranch:
+          git.getCurrentBranch({ worktreePath: repo.worktreePath }) ||
+          'unknown',
+        worktreePath: repo.worktreePath,
+        remoteUrl: git.remoteUrl({ worktreePath: repo.worktreePath }),
+        hasLocalChanges: false,
+        hasUnpushedCommits: false,
+      })),
     ];
 
     for (const target of pushTargets) {
@@ -246,14 +260,38 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         continue;
       }
 
-      try {
+      const hasRemoteTaskBranch = git.remoteBranchExists(
+        target.branchName,
+        'origin',
+        {
+          worktreePath: target.worktreePath,
+        }
+      );
+
+      if (hasRemoteTaskBranch) {
+        try {
+          target.hasUnpushedCommits = git.hasUnmergedCommits(
+            target.branchName,
+            {
+              targetBranch: `origin/${target.branchName}`,
+              worktreePath: target.worktreePath,
+            }
+          );
+        } catch {
+          target.hasUnpushedCommits = true;
+        }
+        continue;
+      }
+
+      if (target.currentBranch !== target.branchName) {
         target.hasUnpushedCommits = git.hasUnmergedCommits(target.branchName, {
-          targetBranch: `origin/${target.branchName}`,
+          targetBranch: target.currentBranch,
           worktreePath: target.worktreePath,
         });
-      } catch {
-        target.hasUnpushedCommits = true;
+        continue;
       }
+
+      target.hasUnpushedCommits = true;
     }
 
     const actionableTargets = pushTargets.filter(

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -302,6 +302,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
 
     telemetry?.eventPushBranch();
 
+    const pushedTargets: string[] = [];
     for (const target of pushTargets) {
       const pushSpinner = !options.json
         ? yoctoSpinner({
@@ -313,6 +314,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
           worktreePath: target.worktreePath,
         });
         result.pushed = true;
+        pushedTargets.push(target.label);
         pushSpinner?.success(`Pushed ${target.label}`);
       } catch (error: unknown) {
         const errorMessage =
@@ -328,15 +330,30 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
               worktreePath: target.worktreePath,
             });
             result.pushed = true;
+            pushedTargets.push(target.label);
             pushSpinner?.success(`Pushed ${target.label}`);
           } catch (retryError: unknown) {
             pushSpinner?.error(`Failed to push ${target.label}`);
+            if (pushedTargets.length > 0 && !isJsonMode()) {
+              console.log(
+                colors.yellow(
+                  `⚠ Already pushed: ${pushedTargets.join(', ')}. These were NOT rolled back.`
+                )
+              );
+            }
             result.error = `Failed to push ${target.label}: ${retryError instanceof Error ? retryError.message : String(retryError)}`;
             await exitWithError(result, { telemetry });
             return;
           }
         } else {
           pushSpinner?.error(`Failed to push ${target.label}`);
+          if (pushedTargets.length > 0 && !isJsonMode()) {
+            console.log(
+              colors.yellow(
+                `⚠ Already pushed: ${pushedTargets.join(', ')}. These were NOT rolled back.`
+              )
+            );
+          }
           result.error = `Failed to push ${target.label}: ${errorMessage}`;
           await exitWithError(result, { telemetry });
           return;

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -2,6 +2,7 @@ import colors from 'ansi-colors';
 import enquirer from 'enquirer';
 import yoctoSpinner from 'yocto-spinner';
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   ProjectConfigManager,
   Git,
@@ -21,6 +22,7 @@ import { showRoverChat, TIP_TITLES } from '../utils/display.js';
 import { statusColor } from '../utils/task-status.js';
 import { executeHooks } from '../lib/hooks.js';
 import type { CommandDefinition } from '../types.js';
+import { getWorkspaceRepositories } from '../lib/workspace-repositories.js';
 
 const { prompt } = enquirer;
 
@@ -34,6 +36,13 @@ interface RepoInfo {
   provider: 'github' | 'gitlab';
   host: string;
   projectPath: string;
+}
+
+interface PushTarget {
+  label: string;
+  branchName: string;
+  worktreePath: string;
+  remoteUrl: string;
 }
 
 /**
@@ -186,35 +195,54 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       });
     }
 
-    // Check for changes
-    const fileChanges = git.uncommittedChanges({
-      worktreePath: task.worktreePath,
+    const pushTargets: PushTarget[] = [
+      {
+        label: 'root workspace',
+        branchName: task.branchName,
+        worktreePath: task.worktreePath,
+        remoteUrl: git.remoteUrl({ worktreePath: task.worktreePath }),
+      },
+      ...getWorkspaceRepositories(task.worktreePath, projectConfig)
+        .filter(repo => existsSync(join(repo.worktreePath, '.git')))
+        .map(repo => ({
+          label: repo.name,
+          branchName:
+            git.getCurrentBranch({ worktreePath: repo.worktreePath }) ||
+            task.branchName,
+          worktreePath: repo.worktreePath,
+          remoteUrl: git.remoteUrl({ worktreePath: repo.worktreePath }),
+        })),
+    ];
+
+    const hasAnyLocalChanges = pushTargets.some(target => {
+      const changes = git.uncommittedChanges({
+        worktreePath: target.worktreePath,
+      });
+      return changes.length > 0;
     });
-    const hasChanges = fileChanges.length > 0;
-    result.hasChanges = hasChanges;
 
-    if (!hasChanges) {
-      // Check if there are unpushed commits
+    const hasAnyUnpushedCommits = pushTargets.some(target => {
       try {
-        const unpushedCommits = git.hasUnmergedCommits(task.branchName, {
-          targetBranch: `origin/${task.branchName}`,
-          worktreePath: task.worktreePath,
+        return git.hasUnmergedCommits(target.branchName, {
+          targetBranch: `origin/${target.branchName}`,
+          worktreePath: target.worktreePath,
         });
-
-        if (!unpushedCommits) {
-          result.success = true;
-          await exitWithWarn('No changes to push', result, { telemetry });
-          return;
-        }
       } catch {
-        // Remote branch doesn't exist yet, continue with push
+        return true;
       }
+    });
+
+    result.hasChanges = hasAnyLocalChanges;
+
+    if (!hasAnyLocalChanges && !hasAnyUnpushedCommits) {
+      result.success = true;
+      await exitWithWarn('No changes to push', result, { telemetry });
+      return;
     }
 
-    // If there are changes, commit them
-    if (hasChanges) {
+    let commitMessage = options.message;
+    if (hasAnyLocalChanges) {
       // Get commit message
-      let commitMessage = options.message;
       if (!commitMessage) {
         const defaultMessage = `Task ${numericTaskId}: ${task.title}`;
         if (isJsonMode()) {
@@ -244,81 +272,83 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       }
 
       result.commitMessage = commitMessage;
-
-      // Stage and commit changes
-      const commitSpinner = !options.json
-        ? yoctoSpinner({ text: 'Committing changes...' }).start()
-        : null;
-      try {
-        git.addAndCommit(commitMessage, {
-          worktreePath: task.worktreePath,
-        });
-        result.committed = true;
-        commitSpinner?.success('Changes committed');
-      } catch (error: unknown) {
-        result.error = `Failed to commit changes: ${error instanceof Error ? error.message : String(error)}`;
-        commitSpinner?.error('Failed to commit changes');
-        await exitWithError(result, { telemetry });
-        return;
-      }
-    }
-
-    // Push to remote
-    telemetry?.eventPushBranch();
-
-    const pushSpinner = !options.json
-      ? yoctoSpinner({
-          text: `Pushing branch ${task.branchName} to remote...`,
-        }).start()
-      : null;
-    try {
-      git.push(task.branchName, {
-        worktreePath: task.worktreePath,
-      });
-      result.pushed = true;
-      task.markPushed(); // Set status to PUSHED
-      if (pushSpinner) {
-        pushSpinner.success(`Branch pushed successfully`);
-      }
-    } catch (error: unknown) {
-      // Check if it's because the remote branch doesn't exist
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      if (errorMessage.includes('has no upstream branch')) {
-        if (pushSpinner) {
-          pushSpinner.text =
-            'Branch does not exist in remote. Setting upstream branch';
+      for (const target of pushTargets) {
+        const hasLocalChanges =
+          git.uncommittedChanges({ worktreePath: target.worktreePath }).length >
+          0;
+        if (!hasLocalChanges) {
+          continue;
         }
 
+        const commitSpinner = !options.json
+          ? yoctoSpinner({
+              text: `Committing changes in ${target.label}...`,
+            }).start()
+          : null;
         try {
-          git.push(task.branchName, {
-            setUpstream: true,
-            worktreePath: task.worktreePath,
+          git.addAndCommit(commitMessage, {
+            worktreePath: target.worktreePath,
           });
-          result.pushed = true;
-          pushSpinner?.success('Branch pushed successfully');
-          task.markPushed(); // Set status to PUSHED
-          if (!isJsonMode()) {
-            console.log(colors.green(`✓ Branch pushed successfully`));
-          }
-        } catch (retryError: unknown) {
-          pushSpinner?.error('Failed to push branch');
-          result.error = `Failed to push branch: ${retryError instanceof Error ? retryError.message : String(retryError)}`;
+          result.committed = true;
+          commitSpinner?.success(`Changes committed in ${target.label}`);
+        } catch (error: unknown) {
+          result.error = `Failed to commit changes in ${target.label}: ${error instanceof Error ? error.message : String(error)}`;
+          commitSpinner?.error(`Failed to commit ${target.label}`);
           await exitWithError(result, { telemetry });
           return;
         }
-      } else {
-        pushSpinner?.error('Failed to push branch');
-        result.error = `Failed to push branch: ${errorMessage}`;
-        await exitWithError(result, { telemetry });
-        return;
       }
     }
+
+    telemetry?.eventPushBranch();
+
+    for (const target of pushTargets) {
+      const pushSpinner = !options.json
+        ? yoctoSpinner({
+            text: `Pushing ${target.branchName} from ${target.label}...`,
+          }).start()
+        : null;
+      try {
+        git.push(target.branchName, {
+          worktreePath: target.worktreePath,
+        });
+        result.pushed = true;
+        pushSpinner?.success(`Pushed ${target.label}`);
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        if (errorMessage.includes('has no upstream branch')) {
+          if (pushSpinner) {
+            pushSpinner.text = `Setting upstream for ${target.label}...`;
+          }
+
+          try {
+            git.push(target.branchName, {
+              setUpstream: true,
+              worktreePath: target.worktreePath,
+            });
+            result.pushed = true;
+            pushSpinner?.success(`Pushed ${target.label}`);
+          } catch (retryError: unknown) {
+            pushSpinner?.error(`Failed to push ${target.label}`);
+            result.error = `Failed to push ${target.label}: ${retryError instanceof Error ? retryError.message : String(retryError)}`;
+            await exitWithError(result, { telemetry });
+            return;
+          }
+        } else {
+          pushSpinner?.error(`Failed to push ${target.label}`);
+          result.error = `Failed to push ${target.label}: ${errorMessage}`;
+          await exitWithError(result, { telemetry });
+          return;
+        }
+      }
+    }
+    task.markPushed(); // Set status to PUSHED
 
     let repoInfo: RepoInfo | null = null;
 
     try {
-      const remoteUrl = git.remoteUrl();
+      const remoteUrl = pushTargets[0]?.remoteUrl ?? '';
       repoInfo = getRepoInfo(remoteUrl);
     } catch (_err) {
       // Ignore the error

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -360,6 +360,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         });
         result.pushed = true;
         pushedTargets.push(target.label);
+        result.pushedRepos = [...pushedTargets];
         pushSpinner?.success(`Pushed ${target.label}`);
       } catch (error: unknown) {
         const errorMessage =
@@ -376,6 +377,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
             });
             result.pushed = true;
             pushedTargets.push(target.label);
+            result.pushedRepos = [...pushedTargets];
             pushSpinner?.success(`Pushed ${target.label}`);
           } catch (retryError: unknown) {
             pushSpinner?.error(`Failed to push ${target.label}`);

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,28 +1,28 @@
-import colors from 'ansi-colors';
-import enquirer from 'enquirer';
-import yoctoSpinner from 'yocto-spinner';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import colors from 'ansi-colors';
+import enquirer from 'enquirer';
 import {
-  ProjectConfigManager,
   Git,
-  showTitle,
+  ProjectConfigManager,
   showProperties,
+  showTitle,
 } from 'rover-core';
 import { TaskNotFoundError } from 'rover-schemas';
-import { getTelemetry } from '../lib/telemetry.js';
-import type { TaskPushOutput } from '../output-types.js';
-import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
+import yoctoSpinner from 'yocto-spinner';
 import {
   isJsonMode,
-  setJsonMode,
   requireProjectContext,
+  setJsonMode,
 } from '../lib/context.js';
-import { showRoverChat, TIP_TITLES } from '../utils/display.js';
-import { statusColor } from '../utils/task-status.js';
 import { executeHooks } from '../lib/hooks.js';
-import type { CommandDefinition } from '../types.js';
+import { getTelemetry } from '../lib/telemetry.js';
 import { getWorkspaceRepositories } from '../lib/workspace-repositories.js';
+import type { TaskPushOutput } from '../output-types.js';
+import type { CommandDefinition } from '../types.js';
+import { showRoverChat, TIP_TITLES } from '../utils/display.js';
+import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
+import { statusColor } from '../utils/task-status.js';
 
 const { prompt } = enquirer;
 
@@ -41,6 +41,7 @@ interface RepoInfo {
 interface PushTarget {
   label: string;
   branchName: string;
+  currentBranch: string;
   worktreePath: string;
   remoteUrl: string;
 }
@@ -199,6 +200,9 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       {
         label: 'root workspace',
         branchName: task.branchName,
+        currentBranch: git.getCurrentBranch({
+          worktreePath: task.worktreePath,
+        }),
         worktreePath: task.worktreePath,
         remoteUrl: git.remoteUrl({ worktreePath: task.worktreePath }),
       },
@@ -206,13 +210,31 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         .filter(repo => existsSync(join(repo.worktreePath, '.git')))
         .map(repo => ({
           label: repo.name,
-          branchName:
+          branchName: task.branchName,
+          currentBranch:
             git.getCurrentBranch({ worktreePath: repo.worktreePath }) ||
-            task.branchName,
+            'unknown',
           worktreePath: repo.worktreePath,
           remoteUrl: git.remoteUrl({ worktreePath: repo.worktreePath }),
         })),
     ];
+
+    for (const target of pushTargets) {
+      if (target.currentBranch === target.branchName) {
+        continue;
+      }
+
+      try {
+        git.checkoutBranch(target.branchName, {
+          worktreePath: target.worktreePath,
+          createIfMissing: true,
+        });
+      } catch (error: unknown) {
+        result.error = `Failed to switch ${target.label} to ${target.branchName}: ${error instanceof Error ? error.message : String(error)}`;
+        await exitWithError(result, { telemetry });
+        return;
+      }
+    }
 
     const hasAnyLocalChanges = pushTargets.some(target => {
       const changes = git.uncommittedChanges({

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -48,6 +48,14 @@ interface PushTarget {
   hasUnpushedCommits: boolean;
 }
 
+function canDiffAgainstCurrentBranch(currentBranch: string): boolean {
+  return (
+    currentBranch.length > 0 &&
+    currentBranch !== 'HEAD' &&
+    currentBranch !== 'unknown'
+  );
+}
+
 /**
  * Get repository info (provider, host, project path) from a git remote URL.
  * Supports GitHub and GitLab, including self-hosted instances and SSH aliases.
@@ -236,9 +244,10 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       {
         label: 'root workspace',
         branchName: task.branchName,
-        currentBranch: git.getCurrentBranch({
-          worktreePath: task.worktreePath,
-        }),
+        currentBranch:
+          git.getCurrentBranch({
+            worktreePath: task.worktreePath,
+          }) || 'unknown',
         worktreePath: task.worktreePath,
         remoteUrl: git.remoteUrl({ worktreePath: task.worktreePath }),
         hasLocalChanges: false,
@@ -298,7 +307,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         continue;
       }
 
-      if (target.currentBranch !== target.branchName) {
+      if (canDiffAgainstCurrentBranch(target.currentBranch)) {
         target.hasUnpushedCommits = git.hasUnmergedCommits(target.branchName, {
           targetBranch: target.currentBranch,
           worktreePath: target.worktreePath,

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -210,7 +210,11 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         hasLocalChanges: false,
         hasUnpushedCommits: false,
       },
-      ...getWorkspaceRepositories(task.worktreePath, projectConfig)
+      ...getWorkspaceRepositories(
+        task.worktreePath,
+        task.getBasePath(),
+        projectConfig
+      )
         .filter(repo => existsSync(join(repo.worktreePath, '.git')))
         .map(repo => ({
           label: repo.name,

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -44,6 +44,8 @@ interface PushTarget {
   currentBranch: string;
   worktreePath: string;
   remoteUrl: string;
+  hasLocalChanges: boolean;
+  hasUnpushedCommits: boolean;
 }
 
 /**
@@ -205,6 +207,8 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         }),
         worktreePath: task.worktreePath,
         remoteUrl: git.remoteUrl({ worktreePath: task.worktreePath }),
+        hasLocalChanges: false,
+        hasUnpushedCommits: false,
       },
       ...getWorkspaceRepositories(task.worktreePath, projectConfig)
         .filter(repo => existsSync(join(repo.worktreePath, '.git')))
@@ -216,10 +220,43 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
             'unknown',
           worktreePath: repo.worktreePath,
           remoteUrl: git.remoteUrl({ worktreePath: repo.worktreePath }),
+          hasLocalChanges: false,
+          hasUnpushedCommits: false,
         })),
     ];
 
     for (const target of pushTargets) {
+      target.hasLocalChanges =
+        git.uncommittedChanges({
+          worktreePath: target.worktreePath,
+        }).length > 0;
+
+      const hasTaskBranch =
+        target.currentBranch === target.branchName ||
+        git.branchExists(target.branchName, {
+          worktreePath: target.worktreePath,
+        });
+
+      if (!hasTaskBranch) {
+        target.hasUnpushedCommits = false;
+        continue;
+      }
+
+      try {
+        target.hasUnpushedCommits = git.hasUnmergedCommits(target.branchName, {
+          targetBranch: `origin/${target.branchName}`,
+          worktreePath: target.worktreePath,
+        });
+      } catch {
+        target.hasUnpushedCommits = true;
+      }
+    }
+
+    const actionableTargets = pushTargets.filter(
+      target => target.hasLocalChanges || target.hasUnpushedCommits
+    );
+
+    for (const target of actionableTargets) {
       if (target.currentBranch === target.branchName) {
         continue;
       }
@@ -236,23 +273,12 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       }
     }
 
-    const hasAnyLocalChanges = pushTargets.some(target => {
-      const changes = git.uncommittedChanges({
-        worktreePath: target.worktreePath,
-      });
-      return changes.length > 0;
-    });
-
-    const hasAnyUnpushedCommits = pushTargets.some(target => {
-      try {
-        return git.hasUnmergedCommits(target.branchName, {
-          targetBranch: `origin/${target.branchName}`,
-          worktreePath: target.worktreePath,
-        });
-      } catch {
-        return true;
-      }
-    });
+    const hasAnyLocalChanges = actionableTargets.some(
+      target => target.hasLocalChanges
+    );
+    const hasAnyUnpushedCommits = actionableTargets.some(
+      target => target.hasUnpushedCommits
+    );
 
     result.hasChanges = hasAnyLocalChanges;
 
@@ -294,11 +320,8 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       }
 
       result.commitMessage = commitMessage;
-      for (const target of pushTargets) {
-        const hasLocalChanges =
-          git.uncommittedChanges({ worktreePath: target.worktreePath }).length >
-          0;
-        if (!hasLocalChanges) {
+      for (const target of actionableTargets) {
+        if (!target.hasLocalChanges) {
           continue;
         }
 
@@ -325,7 +348,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
     telemetry?.eventPushBranch();
 
     const pushedTargets: string[] = [];
-    for (const target of pushTargets) {
+    for (const target of actionableTargets) {
       const pushSpinner = !options.json
         ? yoctoSpinner({
             text: `Pushing ${target.branchName} from ${target.label}...`,

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -265,6 +265,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         'origin',
         {
           worktreePath: target.worktreePath,
+          refreshIfMissing: true,
         }
       );
 

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -17,7 +17,7 @@ import {
 } from '../lib/context.js';
 import { executeHooks } from '../lib/hooks.js';
 import { getTelemetry } from '../lib/telemetry.js';
-import { getWorkspaceRepositories } from '../lib/workspace-repositories.js';
+import { getWorkspaceRepositoriesLookupResult } from '../lib/workspace-repositories.js';
 import type { TaskPushOutput } from '../output-types.js';
 import type { CommandDefinition } from '../types.js';
 import { showRoverChat, TIP_TITLES } from '../utils/display.js';
@@ -198,19 +198,33 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
       });
     }
 
-    const workspaceRepositories = getWorkspaceRepositories(
+    const workspaceRepositoryLookup = getWorkspaceRepositoriesLookupResult(
       task.worktreePath,
       task.getBasePath(),
       projectConfig
     );
-    const missingWorkspaceRepositories = workspaceRepositories.filter(
+    if (workspaceRepositoryLookup.hasPersistedParseErrors) {
+      result.error =
+        'Persisted workspace repository metadata is invalid. Fix or remove the task workspace description before pushing.';
+      await exitWithError(result, { telemetry });
+      return;
+    }
+    const invalidWorkspaceRepositories =
+      workspaceRepositoryLookup.repositories.filter(repo => {
+        if (!existsSync(repo.worktreePath)) {
+          return workspaceRepositoryLookup.foundPersistedState;
+        }
+
+        return !existsSync(join(repo.worktreePath, '.git'));
+      });
+    const workspaceRepositories = workspaceRepositoryLookup.repositories.filter(
       repo =>
-        !existsSync(repo.worktreePath) ||
-        !existsSync(join(repo.worktreePath, '.git'))
+        existsSync(repo.worktreePath) &&
+        existsSync(join(repo.worktreePath, '.git'))
     );
 
-    if (missingWorkspaceRepositories.length > 0) {
-      const missingLabels = missingWorkspaceRepositories
+    if (invalidWorkspaceRepositories.length > 0) {
+      const missingLabels = invalidWorkspaceRepositories
         .map(repo => `${repo.name} (${repo.relativePath})`)
         .join(', ');
       result.error = `Configured workspace repositories are missing or invalid: ${missingLabels}`;
@@ -265,7 +279,7 @@ const pushCommand = async (taskId: string, options: PushOptions) => {
         'origin',
         {
           worktreePath: target.worktreePath,
-          refreshIfMissing: true,
+          refresh: true,
         }
       );
 

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -5,6 +5,7 @@ import enquirer from 'enquirer';
 import {
   AI_AGENT,
   Git,
+  launchSync,
   ProjectConfigManager,
   UserSettingsManager,
 } from 'rover-core';
@@ -89,6 +90,20 @@ interface RebaseTarget {
   worktreePath: string;
   baseBranch: string;
 }
+
+const resolveSubprojectRebaseBase = (
+  worktreePath: string,
+  baseBranch: string
+): string => {
+  const remoteTrackingRef = `refs/remotes/origin/${baseBranch}`;
+  const remoteRefResult = launchSync(
+    'git',
+    ['-C', worktreePath, 'show-ref', '--verify', '--quiet', remoteTrackingRef],
+    { reject: false }
+  );
+
+  return remoteRefResult.exitCode === 0 ? `origin/${baseBranch}` : baseBranch;
+};
 
 /**
  * Rebase a task's branch onto the current branch.
@@ -407,11 +422,40 @@ export const rebaseCommand = async (
       }
 
       for (const target of rebaseTargets) {
+        // Fetch the latest base branch from origin so sub-project repos
+        // rebase onto the current upstream state, not a stale local ref.
+        if (target.label !== 'root workspace') {
+          if (spinner) {
+            spinner.text = `Fetching ${target.baseBranch} in ${target.label}...`;
+          }
+          try {
+            launchSync('git', [
+              '-C',
+              target.worktreePath,
+              'fetch',
+              'origin',
+              target.baseBranch,
+            ]);
+          } catch {
+            // Best-effort: if fetch fails, continue with local ref
+          }
+        }
+
         if (spinner) {
           spinner.text = `Rebasing ${target.label} onto ${target.baseBranch}...`;
         }
 
-        const rebaseResult = git.rebaseBranch(target.baseBranch, {
+        // Sub-project repos track origin/<branch> when that remote-tracking ref
+        // exists, but tags/SHAs must rebase against the raw detached ref.
+        const rebaseOnto =
+          target.label !== 'root workspace'
+            ? resolveSubprojectRebaseBase(
+                target.worktreePath,
+                target.baseBranch
+              )
+            : target.baseBranch;
+
+        const rebaseResult = git.rebaseBranch(rebaseOnto, {
           worktreePath: target.worktreePath,
         });
 

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -253,7 +253,7 @@ export const rebaseCommand = async (
         label: repo.name,
         branchName: task.branchName,
         worktreePath: repo.worktreePath,
-        baseBranch: currentBranch,
+        baseBranch: options.base || repo.ref || currentBranch,
       })),
     ];
 

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -252,9 +252,11 @@ export const rebaseCommand = async (
 
     const workspaceRepositories =
       projectConfig && task.worktreePath
-        ? getWorkspaceRepositories(task.worktreePath, projectConfig).filter(
-            repo => existsSync(join(repo.worktreePath, '.git'))
-          )
+        ? getWorkspaceRepositories(
+            task.worktreePath,
+            task.getBasePath(),
+            projectConfig
+          ).filter(repo => existsSync(join(repo.worktreePath, '.git')))
         : [];
 
     const rebaseTargets: RebaseTarget[] = [

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -5,6 +5,7 @@ import enquirer from 'enquirer';
 import {
   AI_AGENT,
   Git,
+  launchSync,
   ProjectConfigManager,
   UserSettingsManager,
 } from 'rover-core';
@@ -89,6 +90,20 @@ interface RebaseTarget {
   worktreePath: string;
   baseBranch: string;
 }
+
+const resolveSubprojectRebaseBase = (
+  worktreePath: string,
+  baseBranch: string
+): string => {
+  const remoteTrackingRef = `refs/remotes/origin/${baseBranch}`;
+  const remoteRefResult = launchSync(
+    'git',
+    ['-C', worktreePath, 'show-ref', '--verify', '--quiet', remoteTrackingRef],
+    { reject: false }
+  );
+
+  return remoteRefResult.exitCode === 0 ? `origin/${baseBranch}` : baseBranch;
+};
 
 /**
  * Rebase a task's branch onto the current branch.
@@ -410,11 +425,36 @@ export const rebaseCommand = async (
       }
 
       for (const target of rebaseTargets) {
+        if (target.label !== 'root workspace') {
+          if (spinner) {
+            spinner.text = `Fetching ${target.baseBranch} in ${target.label}...`;
+          }
+          try {
+            launchSync('git', [
+              '-C',
+              target.worktreePath,
+              'fetch',
+              'origin',
+              target.baseBranch,
+            ]);
+          } catch {
+            // Best-effort: if fetch fails, continue with local ref
+          }
+        }
+
         if (spinner) {
           spinner.text = `Rebasing ${target.label} onto ${target.baseBranch}...`;
         }
 
-        const rebaseResult = git.rebaseBranch(target.baseBranch, {
+        const rebaseOnto =
+          target.label !== 'root workspace'
+            ? resolveSubprojectRebaseBase(
+                target.worktreePath,
+                target.baseBranch
+              )
+            : target.baseBranch;
+
+        const rebaseResult = git.rebaseBranch(rebaseOnto, {
           worktreePath: target.worktreePath,
         });
 

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -89,6 +89,8 @@ interface RebaseTarget {
   branchName: string;
   worktreePath: string;
   baseBranch: string;
+  /** The actual ref used for `git rebase`, which may be `origin/<baseBranch>` for child repos. */
+  rebaseOnto?: string;
 }
 
 const resolveSubprojectRebaseBase = (
@@ -476,6 +478,7 @@ export const rebaseCommand = async (
                 target.baseBranch
               )
             : target.baseBranch;
+        target.rebaseOnto = rebaseOnto;
 
         const rebaseResult = git.rebaseBranch(rebaseOnto, {
           worktreePath: target.worktreePath,
@@ -600,7 +603,7 @@ export const rebaseCommand = async (
               console.log(
                 colors.gray('├──'),
                 colors.gray(
-                  `1. cd ${target.worktreePath} && git rebase ${target.baseBranch}`
+                  `1. cd ${target.worktreePath} && git rebase ${target.rebaseOnto ?? target.baseBranch}`
                 )
               );
               console.log(

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -1,6 +1,7 @@
 import colors from 'ansi-colors';
 import enquirer from 'enquirer';
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import yoctoSpinner from 'yocto-spinner';
 import {
   getAIAgentTool,
@@ -31,6 +32,7 @@ import {
   generateCommitMessage,
   resolveConflicts,
 } from '../lib/merge-rebase-utils.js';
+import { getWorkspaceRepositories } from '../lib/workspace-repositories.js';
 
 const { prompt } = enquirer;
 
@@ -80,6 +82,13 @@ interface TaskRebaseOutput extends CLIJsonOutput {
   commitMessage?: string;
   rebased?: boolean;
   conflictsResolved?: boolean;
+}
+
+interface RebaseTarget {
+  label: string;
+  branchName: string;
+  worktreePath: string;
+  baseBranch: string;
 }
 
 /**
@@ -227,16 +236,43 @@ export const rebaseCommand = async (
     const currentBranch = options.base || git.getCurrentBranch();
     jsonOutput.currentBranch = currentBranch;
 
-    // Check if worktree has uncommitted changes (before squashing)
-    const hasUncommittedChanges = git.hasUncommittedChanges({
-      worktreePath: task.worktreePath,
-    });
+    const workspaceRepositories =
+      projectConfig && task.worktreePath
+        ? getWorkspaceRepositories(task.worktreePath, projectConfig).filter(
+            repo => existsSync(join(repo.worktreePath, '.git'))
+          )
+        : [];
+
+    const rebaseTargets: RebaseTarget[] = [
+      {
+        label: 'root workspace',
+        branchName: task.branchName,
+        worktreePath: task.worktreePath,
+        baseBranch: currentBranch,
+      },
+      ...workspaceRepositories.map(repo => ({
+        label: repo.name,
+        branchName:
+          git.getCurrentBranch({ worktreePath: repo.worktreePath }) ||
+          task.branchName,
+        worktreePath: repo.worktreePath,
+        baseBranch:
+          repo.ref || new Git({ cwd: repo.worktreePath }).getMainBranch(),
+      })),
+    ];
+
+    // Check if any workspace repo has uncommitted changes (before squashing root)
+    const hasUncommittedChanges = rebaseTargets.some(target =>
+      git.hasUncommittedChanges({
+        worktreePath: target.worktreePath,
+      })
+    );
 
     if (!isJsonMode()) {
       console.log('');
       console.log(colors.cyan('The rebase process will'));
       if (hasUncommittedChanges) {
-        console.log(colors.cyan('├── Commit changes in the task worktree'));
+        console.log(colors.cyan('├── Commit changes in the task worktree(s)'));
       }
       console.log(
         colors.cyan(`├── Rebase the task branch onto ${currentBranch}`)
@@ -290,6 +326,8 @@ export const rebaseCommand = async (
       : null;
 
     try {
+      let finalCommitMessage: string | undefined;
+
       // Commit worktree changes if needed
       if (hasWorktreeChanges) {
         const recentCommits = git.getRecentCommits({
@@ -309,7 +347,6 @@ export const rebaseCommand = async (
 
         const commitMessage = aiCommitMessage || task.title;
 
-        let finalCommitMessage: string;
         if (projectConfig == null || projectConfig?.attribution === true) {
           finalCommitMessage = `${commitMessage}\n\nCo-Authored-By: Rover <noreply@endor.dev>`;
         } else {
@@ -318,37 +355,49 @@ export const rebaseCommand = async (
 
         jsonOutput.commitMessage = finalCommitMessage.split('\n')[0];
 
-        if (spinner) spinner.text = 'Committing changes in worktree...';
-
-        try {
-          git.addAndCommit(finalCommitMessage, {
-            worktreePath: task.worktreePath,
+        for (const target of rebaseTargets) {
+          const targetHasChanges = git.hasUncommittedChanges({
+            worktreePath: target.worktreePath,
           });
-          jsonOutput.committed = true;
-        } catch (error) {
-          jsonOutput.committed = false;
-          spinner?.error('Failed to commit changes');
-          jsonOutput.error =
-            'Failed to add and commit changes in the workspace';
-          await exitWithError(jsonOutput, { telemetry });
-          return;
+          if (!targetHasChanges) {
+            continue;
+          }
+
+          if (spinner) {
+            spinner.text = `Committing changes in ${target.label}...`;
+          }
+
+          try {
+            git.addAndCommit(finalCommitMessage, {
+              worktreePath: target.worktreePath,
+            });
+            jsonOutput.committed = true;
+          } catch (error) {
+            jsonOutput.committed = false;
+            spinner?.error('Failed to commit changes');
+            jsonOutput.error = `Failed to add and commit changes in ${target.label}`;
+            await exitWithError(jsonOutput, { telemetry });
+            return;
+          }
         }
       }
 
-      if (spinner) spinner.text = 'Rebasing task branch...';
+      for (const target of rebaseTargets) {
+        if (spinner) {
+          spinner.text = `Rebasing ${target.label} onto ${target.baseBranch}...`;
+        }
 
-      // Rebase the task branch onto the current branch
-      const rebaseResult = git.rebaseBranch(currentBranch, {
-        worktreePath: task.worktreePath,
-      });
+        const rebaseResult = git.rebaseBranch(target.baseBranch, {
+          worktreePath: target.worktreePath,
+        });
 
-      if (rebaseResult.success) {
-        jsonOutput.rebased = true;
-        spinner?.success('Task branch rebased successfully');
-      } else {
-        // Check for conflicts
+        if (rebaseResult.success) {
+          jsonOutput.rebased = true;
+          continue;
+        }
+
         const rebaseConflicts = git.getMergeConflicts({
-          worktreePath: task.worktreePath,
+          worktreePath: target.worktreePath,
         });
 
         if (rebaseConflicts.length > 0) {
@@ -357,7 +406,7 @@ export const rebaseCommand = async (
           if (!isJsonMode()) {
             console.log(
               colors.yellow(
-                `\n⚠ Rebase conflicts detected in ${rebaseConflicts.length} file(s):`
+                `\n⚠ Rebase conflicts detected in ${target.label} (${rebaseConflicts.length} file(s)):`
               )
             );
             rebaseConflicts.forEach((file, index) => {
@@ -385,7 +434,7 @@ export const rebaseCommand = async (
             git,
             rebaseConflicts,
             aiAgent,
-            task.worktreePath,
+            target.worktreePath,
             concurrency,
             contextLinesNum,
             options.sendFullFile === true
@@ -416,7 +465,7 @@ export const rebaseCommand = async (
               }
 
               if (!applyChanges) {
-                git.abortRebase({ worktreePath: task.worktreePath });
+                git.abortRebase({ worktreePath: target.worktreePath });
                 await exitWithWarn(
                   'User rejected AI resolution. Rebase aborted',
                   jsonOutput,
@@ -428,7 +477,7 @@ export const rebaseCommand = async (
 
             // Continue the rebase with resolved conflicts
             try {
-              git.continueRebase({ worktreePath: task.worktreePath });
+              git.continueRebase({ worktreePath: target.worktreePath });
 
               jsonOutput.rebased = true;
 
@@ -440,7 +489,7 @@ export const rebaseCommand = async (
                 );
               }
             } catch (continueError) {
-              git.abortRebase({ worktreePath: task.worktreePath });
+              git.abortRebase({ worktreePath: target.worktreePath });
 
               jsonOutput.error = `Error completing rebase after conflict resolution: ${continueError}`;
               await exitWithError(jsonOutput, { telemetry });
@@ -450,7 +499,7 @@ export const rebaseCommand = async (
             jsonOutput.error =
               resolution.failureReason ||
               'AI failed to resolve rebase conflicts';
-            git.abortRebase({ worktreePath: task.worktreePath });
+            git.abortRebase({ worktreePath: target.worktreePath });
 
             if (!isJsonMode()) {
               console.log(
@@ -460,7 +509,7 @@ export const rebaseCommand = async (
               console.log(
                 colors.gray('├──'),
                 colors.gray(
-                  `1. cd ${task.worktreePath} && git rebase ${currentBranch}`
+                  `1. cd ${target.worktreePath} && git rebase ${target.baseBranch}`
                 )
               );
               console.log(
@@ -481,10 +530,11 @@ export const rebaseCommand = async (
           }
         } else {
           // Other rebase error, not conflicts — abort to restore worktree
-          git.abortRebase({ worktreePath: task.worktreePath });
+          git.abortRebase({ worktreePath: target.worktreePath });
           if (spinner) spinner.error('Rebase failed');
           jsonOutput.error =
-            rebaseResult.error || 'Rebase failed with an unknown error';
+            rebaseResult.error ||
+            `Rebase failed with an unknown error in ${target.label}`;
           await exitWithError(jsonOutput, { telemetry });
           return;
         }

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -264,15 +264,22 @@ export const rebaseCommand = async (
         worktreePath: task.worktreePath,
         baseBranch: currentBranch,
       },
-      ...workspaceRepositories.map(repo => ({
-        label: repo.name,
-        branchName: task.branchName,
-        worktreePath: repo.worktreePath,
-        baseBranch:
-          options.base ||
-          repo.ref ||
-          new Git({ cwd: repo.worktreePath }).getMainBranch(),
-      })),
+      ...workspaceRepositories.map(repo => {
+        let baseBranch = options.base || repo.ref;
+        if (!baseBranch) {
+          try {
+            baseBranch = new Git({ cwd: repo.worktreePath }).getMainBranch();
+          } catch {
+            baseBranch = 'main';
+          }
+        }
+        return {
+          label: repo.name,
+          branchName: task.branchName,
+          worktreePath: repo.worktreePath,
+          baseBranch,
+        };
+      }),
     ];
 
     for (const target of rebaseTargets) {

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -327,6 +327,7 @@ export const rebaseCommand = async (
 
     try {
       let finalCommitMessage: string | undefined;
+      const rebasedTargets: string[] = [];
 
       // Commit worktree changes if needed
       if (hasWorktreeChanges) {
@@ -375,6 +376,13 @@ export const rebaseCommand = async (
           } catch (error) {
             jsonOutput.committed = false;
             spinner?.error('Failed to commit changes');
+            if (rebasedTargets.length > 0 && !isJsonMode()) {
+              console.log(
+                colors.yellow(
+                  `⚠ Already rebased: ${rebasedTargets.join(', ')}. These were NOT rolled back.`
+                )
+              );
+            }
             jsonOutput.error = `Failed to add and commit changes in ${target.label}`;
             await exitWithError(jsonOutput, { telemetry });
             return;
@@ -393,6 +401,7 @@ export const rebaseCommand = async (
 
         if (rebaseResult.success) {
           jsonOutput.rebased = true;
+          rebasedTargets.push(target.label);
           continue;
         }
 
@@ -532,6 +541,13 @@ export const rebaseCommand = async (
           // Other rebase error, not conflicts — abort to restore worktree
           git.abortRebase({ worktreePath: target.worktreePath });
           if (spinner) spinner.error('Rebase failed');
+          if (rebasedTargets.length > 0 && !isJsonMode()) {
+            console.log(
+              colors.yellow(
+                `⚠ Already rebased: ${rebasedTargets.join(', ')}. These were NOT rolled back.`
+              )
+            );
+          }
           jsonOutput.error =
             rebaseResult.error ||
             `Rebase failed with an unknown error in ${target.label}`;

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -1,13 +1,7 @@
-import colors from 'ansi-colors';
-import enquirer from 'enquirer';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import yoctoSpinner from 'yocto-spinner';
-import {
-  getAIAgentTool,
-  getUserDefaultModel,
-  type AIAgentTool,
-} from '../lib/agents/index.js';
+import colors from 'ansi-colors';
+import enquirer from 'enquirer';
 import {
   AI_AGENT,
   Git,
@@ -15,24 +9,29 @@ import {
   UserSettingsManager,
 } from 'rover-core';
 import { TaskNotFoundError } from 'rover-schemas';
-import { getTelemetry } from '../lib/telemetry.js';
-import { showRoverChat } from '../utils/display.js';
-import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
-import type { CLIJsonOutput } from '../types.js';
+import yoctoSpinner from 'yocto-spinner';
+import {
+  type AIAgentTool,
+  getAIAgentTool,
+  getUserDefaultModel,
+} from '../lib/agents/index.js';
 import {
   isJsonMode,
-  setJsonMode,
   requireProjectContext,
+  setJsonMode,
 } from '../lib/context.js';
-import type { CommandDefinition } from '../types.js';
-import { parseAgentString } from '../utils/agent-parser.js';
-import { collapseTaskCommits } from '../lib/squash.js';
 import {
-  getTaskIterationSummaries,
   generateCommitMessage,
+  getTaskIterationSummaries,
   resolveConflicts,
 } from '../lib/merge-rebase-utils.js';
+import { collapseTaskCommits } from '../lib/squash.js';
+import { getTelemetry } from '../lib/telemetry.js';
 import { getWorkspaceRepositories } from '../lib/workspace-repositories.js';
+import type { CLIJsonOutput, CommandDefinition } from '../types.js';
+import { parseAgentString } from '../utils/agent-parser.js';
+import { showRoverChat } from '../utils/display.js';
+import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
 
 const { prompt } = enquirer;
 
@@ -252,14 +251,31 @@ export const rebaseCommand = async (
       },
       ...workspaceRepositories.map(repo => ({
         label: repo.name,
-        branchName:
-          git.getCurrentBranch({ worktreePath: repo.worktreePath }) ||
-          task.branchName,
+        branchName: task.branchName,
         worktreePath: repo.worktreePath,
-        baseBranch:
-          repo.ref || new Git({ cwd: repo.worktreePath }).getMainBranch(),
+        baseBranch: currentBranch,
       })),
     ];
+
+    for (const target of rebaseTargets) {
+      const checkedOutBranch = git.getCurrentBranch({
+        worktreePath: target.worktreePath,
+      });
+      if (checkedOutBranch === target.branchName) {
+        continue;
+      }
+
+      try {
+        git.checkoutBranch(target.branchName, {
+          worktreePath: target.worktreePath,
+          createIfMissing: true,
+        });
+      } catch (error) {
+        jsonOutput.error = `Failed to switch ${target.label} to ${target.branchName}: ${error instanceof Error ? error.message : String(error)}`;
+        await exitWithError(jsonOutput, { telemetry });
+        return;
+      }
+    }
 
     // Check if any workspace repo has uncommitted changes (before squashing root)
     const hasUncommittedChanges = rebaseTargets.some(target =>

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -28,7 +28,7 @@ import {
 } from '../lib/merge-rebase-utils.js';
 import { collapseTaskCommits } from '../lib/squash.js';
 import { getTelemetry } from '../lib/telemetry.js';
-import { getWorkspaceRepositories } from '../lib/workspace-repositories.js';
+import { getWorkspaceRepositoriesLookupResult } from '../lib/workspace-repositories.js';
 import type { CLIJsonOutput, CommandDefinition } from '../types.js';
 import { parseAgentString } from '../utils/agent-parser.js';
 import { showRoverChat } from '../utils/display.js';
@@ -97,14 +97,10 @@ const resolveSubprojectRebaseBase = (
   worktreePath: string,
   baseBranch: string
 ): string => {
-  const remoteTrackingRef = `refs/remotes/origin/${baseBranch}`;
-  const remoteRefResult = launchSync(
-    'git',
-    ['-C', worktreePath, 'show-ref', '--verify', '--quiet', remoteTrackingRef],
-    { reject: false }
-  );
-
-  return remoteRefResult.exitCode === 0 ? `origin/${baseBranch}` : baseBranch;
+  const worktreeGit = new Git({ cwd: worktreePath });
+  return worktreeGit.remoteBranchExists(baseBranch, 'origin', { refresh: true })
+    ? `origin/${baseBranch}`
+    : baseBranch;
 };
 
 /**
@@ -252,18 +248,36 @@ export const rebaseCommand = async (
     const currentBranch = options.base || git.getCurrentBranch();
     jsonOutput.currentBranch = currentBranch;
 
-    const workspaceRepositories =
+    const workspaceRepositoryLookup =
       projectConfig && task.worktreePath
-        ? getWorkspaceRepositories(
+        ? getWorkspaceRepositoriesLookupResult(
             task.worktreePath,
             task.getBasePath(),
             projectConfig
           )
-        : [];
-    const missingWorkspaceRepositories = workspaceRepositories.filter(
+        : {
+            foundPersistedState: false,
+            hasPersistedParseErrors: false,
+            repositories: [],
+          };
+    if (workspaceRepositoryLookup.hasPersistedParseErrors) {
+      jsonOutput.error =
+        'Persisted workspace repository metadata is invalid. Fix or remove the task workspace description before rebasing.';
+      await exitWithError(jsonOutput, { telemetry });
+      return;
+    }
+    const missingWorkspaceRepositories =
+      workspaceRepositoryLookup.repositories.filter(repo => {
+        if (!existsSync(repo.worktreePath)) {
+          return workspaceRepositoryLookup.foundPersistedState;
+        }
+
+        return !existsSync(join(repo.worktreePath, '.git'));
+      });
+    const workspaceRepositories = workspaceRepositoryLookup.repositories.filter(
       repo =>
-        !existsSync(repo.worktreePath) ||
-        !existsSync(join(repo.worktreePath, '.git'))
+        existsSync(repo.worktreePath) &&
+        existsSync(join(repo.worktreePath, '.git'))
     );
 
     if (missingWorkspaceRepositories.length > 0) {

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -93,6 +93,10 @@ interface RebaseTarget {
   rebaseOnto?: string;
 }
 
+function hasNamedCurrentBranch(branchName: string): boolean {
+  return branchName.length > 0 && branchName !== 'unknown';
+}
+
 const resolveSubprojectRebaseBase = (
   worktreePath: string,
   baseBranch: string
@@ -247,6 +251,13 @@ export const rebaseCommand = async (
     // Determine target branch: explicit --base flag, or fall back to current checkout
     const currentBranch = options.base || git.getCurrentBranch();
     jsonOutput.currentBranch = currentBranch;
+
+    if (!options.base && !hasNamedCurrentBranch(currentBranch)) {
+      jsonOutput.error =
+        'Current checkout is detached. Pass `--base <branch>` or check out a branch before rebasing.';
+      await exitWithError(jsonOutput, { telemetry });
+      return;
+    }
 
     const workspaceRepositoryLookup =
       projectConfig && task.worktreePath

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -256,8 +256,22 @@ export const rebaseCommand = async (
             task.worktreePath,
             task.getBasePath(),
             projectConfig
-          ).filter(repo => existsSync(join(repo.worktreePath, '.git')))
+          )
         : [];
+    const missingWorkspaceRepositories = workspaceRepositories.filter(
+      repo =>
+        !existsSync(repo.worktreePath) ||
+        !existsSync(join(repo.worktreePath, '.git'))
+    );
+
+    if (missingWorkspaceRepositories.length > 0) {
+      const missingLabels = missingWorkspaceRepositories
+        .map(repo => `${repo.name} (${repo.relativePath})`)
+        .join(', ');
+      jsonOutput.error = `Configured workspace repositories are missing or invalid: ${missingLabels}`;
+      await exitWithError(jsonOutput, { telemetry });
+      return;
+    }
 
     const rebaseTargets: RebaseTarget[] = [
       {

--- a/packages/cli/src/commands/rebase.ts
+++ b/packages/cli/src/commands/rebase.ts
@@ -5,7 +5,6 @@ import enquirer from 'enquirer';
 import {
   AI_AGENT,
   Git,
-  launchSync,
   ProjectConfigManager,
   UserSettingsManager,
 } from 'rover-core';
@@ -90,20 +89,6 @@ interface RebaseTarget {
   worktreePath: string;
   baseBranch: string;
 }
-
-const resolveSubprojectRebaseBase = (
-  worktreePath: string,
-  baseBranch: string
-): string => {
-  const remoteTrackingRef = `refs/remotes/origin/${baseBranch}`;
-  const remoteRefResult = launchSync(
-    'git',
-    ['-C', worktreePath, 'show-ref', '--verify', '--quiet', remoteTrackingRef],
-    { reject: false }
-  );
-
-  return remoteRefResult.exitCode === 0 ? `origin/${baseBranch}` : baseBranch;
-};
 
 /**
  * Rebase a task's branch onto the current branch.
@@ -268,7 +253,10 @@ export const rebaseCommand = async (
         label: repo.name,
         branchName: task.branchName,
         worktreePath: repo.worktreePath,
-        baseBranch: options.base || repo.ref || currentBranch,
+        baseBranch:
+          options.base ||
+          repo.ref ||
+          new Git({ cwd: repo.worktreePath }).getMainBranch(),
       })),
     ];
 
@@ -422,40 +410,11 @@ export const rebaseCommand = async (
       }
 
       for (const target of rebaseTargets) {
-        // Fetch the latest base branch from origin so sub-project repos
-        // rebase onto the current upstream state, not a stale local ref.
-        if (target.label !== 'root workspace') {
-          if (spinner) {
-            spinner.text = `Fetching ${target.baseBranch} in ${target.label}...`;
-          }
-          try {
-            launchSync('git', [
-              '-C',
-              target.worktreePath,
-              'fetch',
-              'origin',
-              target.baseBranch,
-            ]);
-          } catch {
-            // Best-effort: if fetch fails, continue with local ref
-          }
-        }
-
         if (spinner) {
           spinner.text = `Rebasing ${target.label} onto ${target.baseBranch}...`;
         }
 
-        // Sub-project repos track origin/<branch> when that remote-tracking ref
-        // exists, but tags/SHAs must rebase against the raw detached ref.
-        const rebaseOnto =
-          target.label !== 'root workspace'
-            ? resolveSubprojectRebaseBase(
-                target.worktreePath,
-                target.baseBranch
-              )
-            : target.baseBranch;
-
-        const rebaseResult = git.rebaseBranch(rebaseOnto, {
+        const rebaseResult = git.rebaseBranch(target.baseBranch, {
           worktreePath: target.worktreePath,
         });
 

--- a/packages/cli/src/commands/reset.ts
+++ b/packages/cli/src/commands/reset.ts
@@ -35,35 +35,34 @@ const resetCommand = async (
   options: { force?: boolean } = {}
 ) => {
   const telemetry = getTelemetry();
-  // Convert string taskId to number
-  const numericTaskId = parseInt(taskId, 10);
-  if (isNaN(numericTaskId)) {
-    await exitWithError(
-      {
-        success: false,
-        error: `Invalid task ID '${taskId}' - must be a number`,
-      },
-      { telemetry }
-    );
-    return;
-  }
-
-  // Require project context
-  let project: ProjectManager;
   try {
-    project = await requireProjectContext();
-  } catch (error) {
-    await exitWithError(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : String(error),
-      },
-      { telemetry }
-    );
-    return;
-  }
+    if (!/^\d+$/.test(taskId)) {
+      await exitWithError(
+        {
+          success: false,
+          error: `Invalid task ID '${taskId}' - must be a number`,
+        },
+        { telemetry }
+      );
+      return;
+    }
+    const numericTaskId = parseInt(taskId, 10);
 
-  try {
+    // Require project context
+    let project: ProjectManager;
+    try {
+      project = await requireProjectContext();
+    } catch (error) {
+      await exitWithError(
+        {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        { telemetry }
+      );
+      return;
+    }
+
     // Load task using ProjectManager
     const task = project.getTask(numericTaskId);
     if (!task) {
@@ -202,6 +201,8 @@ const resetCommand = async (
         { telemetry }
       );
     }
+  } finally {
+    await telemetry?.shutdown();
   }
 };
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -329,6 +329,7 @@ const restartCommand = async (
       try {
         const sandbox = await createSandbox(task, undefined, {
           projectPath: project.path,
+          sandboxMetadata: task.sandboxMetadata,
           iterationLogsPath: project.getTaskIterationLogsPath(
             task.id,
             task.iterations

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -334,15 +334,15 @@ const restartCommand = async (
           ),
         });
         const containerId = await sandbox.createAndStart();
+        const sandboxMetadata =
+          typeof sandbox.getSandboxMetadata === 'function'
+            ? sandbox.getSandboxMetadata()
+            : process.env.DOCKER_HOST
+              ? { dockerHost: process.env.DOCKER_HOST }
+              : undefined;
 
         // Update task metadata with new container ID
-        task.setContainerInfo(
-          containerId,
-          'running',
-          process.env.DOCKER_HOST
-            ? { dockerHost: process.env.DOCKER_HOST }
-            : undefined
-        );
+        task.setContainerInfo(containerId, 'running', sandboxMetadata);
       } catch (error) {
         // If sandbox execution fails, restore the pre-restart task status.
         try {

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -86,6 +86,7 @@ const restartCommand = async (
         try {
           const sandbox = await createSandbox(task, undefined, {
             projectPath: project.path,
+            sandboxMetadata: task.sandboxMetadata,
           });
           const state = await sandbox.inspect();
           // Container is still alive — reject the restart

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -141,8 +141,8 @@ const resumeCommand = async (
           colors.cyan(task.branchName || 'will be created')
       );
       console.log(
-        colors.gray('├── Checkpoint: ') +
-          (hasCheckpoint ? colors.green('found') : colors.yellow('not found'))
+        colors.gray('├── Checkpoint File: ') +
+          (hasCheckpoint ? colors.green('present') : colors.yellow('absent'))
       );
       if (process.env.ROVER_AGENT_IMAGE) {
         console.log(
@@ -194,7 +194,7 @@ const resumeCommand = async (
       description: updatedTask.description,
       status: updatedTask.status,
       resumedAt,
-      hasCheckpoint,
+      hasCheckpoint: result.resumedFromCheckpoint,
     };
 
     await exitWithSuccess('Task resumed successfully!', jsonOutput, {

--- a/packages/cli/src/commands/resume.ts
+++ b/packages/cli/src/commands/resume.ts
@@ -102,7 +102,8 @@ const resumeCommand = async (
           );
         }
       } catch (error) {
-        jsonOutput.error = error instanceof Error ? error.message : String(error);
+        jsonOutput.error =
+          error instanceof Error ? error.message : String(error);
         await exitWithError(jsonOutput, { telemetry });
         return;
       }

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -110,6 +110,7 @@ const shellCommand = async (
       try {
         const sandbox = await createSandbox(task, undefined, {
           projectPath: project.path,
+          sandboxMetadata: task.sandboxMetadata,
         });
 
         spinner.success('Shell started');

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -14,6 +14,33 @@ import {
 } from '../lib/sandbox/index.js';
 import type { CommandDefinition } from '../types.js';
 
+function getShellSandboxMetadata(task: {
+  sandboxMetadata?: Record<string, unknown>;
+  isInProgress?: () => boolean;
+  isIterating?: () => boolean;
+  status?: string;
+}): Record<string, unknown> | undefined {
+  const metadata = task.sandboxMetadata;
+  if (!metadata) {
+    return undefined;
+  }
+
+  const shouldReuseServiceContext =
+    task.isInProgress?.() === true ||
+    task.isIterating?.() === true ||
+    task.status === 'IN_PROGRESS' ||
+    task.status === 'ITERATING';
+
+  if (shouldReuseServiceContext) {
+    return metadata;
+  }
+
+  const { serviceContext: _serviceContext, ...remainingMetadata } = metadata;
+  return Object.keys(remainingMetadata).length > 0
+    ? remainingMetadata
+    : undefined;
+}
+
 /**
  * Open an interactive shell in a task's workspace for manual testing.
  *
@@ -110,15 +137,13 @@ const shellCommand = async (
       try {
         const sandbox = await createSandbox(task, undefined, {
           projectPath: project.path,
-          sandboxMetadata: task.sandboxMetadata,
+          sandboxMetadata: getShellSandboxMetadata(task),
         });
 
         spinner.success('Shell started');
 
         // Use the sandbox implementation to open shell at worktree
-        await sandbox.openShellAtWorktree();
-
-        shellProcess = { exitCode: 0 };
+        shellProcess = await sandbox.openShellAtWorktree();
       } catch (error) {
         spinner.error('Failed to start container shell');
         jsonOutput.error = 'Failed to start container: ' + error;
@@ -230,6 +255,8 @@ const shellCommand = async (
     await telemetry?.shutdown();
   }
 };
+
+export { shellCommand };
 
 export default {
   name: 'shell',

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -14,33 +14,6 @@ import {
 } from '../lib/sandbox/index.js';
 import type { CommandDefinition } from '../types.js';
 
-function getShellSandboxMetadata(task: {
-  sandboxMetadata?: Record<string, unknown>;
-  isInProgress?: () => boolean;
-  isIterating?: () => boolean;
-  status?: string;
-}): Record<string, unknown> | undefined {
-  const metadata = task.sandboxMetadata;
-  if (!metadata) {
-    return undefined;
-  }
-
-  const shouldReuseServiceContext =
-    task.isInProgress?.() === true ||
-    task.isIterating?.() === true ||
-    task.status === 'IN_PROGRESS' ||
-    task.status === 'ITERATING';
-
-  if (shouldReuseServiceContext) {
-    return metadata;
-  }
-
-  const { serviceContext: _serviceContext, ...remainingMetadata } = metadata;
-  return Object.keys(remainingMetadata).length > 0
-    ? remainingMetadata
-    : undefined;
-}
-
 /**
  * Open an interactive shell in a task's workspace for manual testing.
  *
@@ -137,7 +110,7 @@ const shellCommand = async (
       try {
         const sandbox = await createSandbox(task, undefined, {
           projectPath: project.path,
-          sandboxMetadata: getShellSandboxMetadata(task),
+          sandboxMetadata: task.sandboxMetadata,
         });
 
         spinner.success('Shell started');

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -8,10 +8,7 @@ import { getTelemetry } from '../lib/telemetry.js';
 import type { CLIJsonOutput } from '../types.js';
 import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
 import { requireProjectContext } from '../lib/context.js';
-import {
-  createSandbox,
-  getAvailableSandboxBackend,
-} from '../lib/sandbox/index.js';
+import { createSandbox } from '../lib/sandbox/index.js';
 import type { CommandDefinition } from '../types.js';
 
 /**
@@ -80,17 +77,6 @@ const shellCommand = async (
     }
 
     telemetry?.eventShell();
-
-    if (options.container) {
-      // Check if any sandbox backend (Docker or Podman) is available
-      const availableBackend = await getAvailableSandboxBackend();
-
-      if (!availableBackend) {
-        jsonOutput.error = `Neither Docker nor Podman are available. Please install Docker or Podman.`;
-        await exitWithError(jsonOutput, { telemetry });
-        return;
-      }
-    }
 
     console.log(
       colors.green('✓ Starting interactive shell in the task workspace')

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -38,13 +38,13 @@ const shellCommand = async (
   // Fake JSON output
   const jsonOutput: CLIJsonOutput = { success: false };
 
-  // Convert string taskId to number
-  const numericTaskId = parseInt(taskId, 10);
-  if (isNaN(numericTaskId)) {
+  // Convert string taskId to number (strict: reject '123abc' etc.)
+  if (!/^\d+$/.test(taskId)) {
     jsonOutput.error = `Invalid task ID '${taskId}' - must be a number`;
     await exitWithError(jsonOutput, { telemetry });
     return;
   }
+  const numericTaskId = parseInt(taskId, 10);
 
   // Require project context
   let project;

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -1,17 +1,17 @@
-import colors from 'ansi-colors';
 import { rmSync } from 'node:fs';
-import { createSandbox } from '../lib/sandbox/index.js';
-import { TaskNotFoundError } from 'rover-schemas';
+import colors from 'ansi-colors';
 import { launch, ProcessManager } from 'rover-core';
-import { exitWithError, exitWithSuccess } from '../utils/exit.js';
-import type { TaskStopOutput } from '../output-types.js';
-import { getTelemetry } from '../lib/telemetry.js';
+import { TaskNotFoundError } from 'rover-schemas';
 import {
   isJsonMode,
-  setJsonMode,
   requireProjectContext,
+  setJsonMode,
 } from '../lib/context.js';
+import { createSandbox } from '../lib/sandbox/index.js';
+import { getTelemetry } from '../lib/telemetry.js';
+import type { TaskStopOutput } from '../output-types.js';
 import type { CommandDefinition } from '../types.js';
+import { exitWithError, exitWithSuccess } from '../utils/exit.js';
 
 /**
  * Stop a running task and optionally clean up its resources.
@@ -85,6 +85,7 @@ const stopCommand = async (
     // Stop sandbox container if it exists and is running
     if (task.containerId) {
       const sandbox = await createSandbox(task, processManager, {
+        projectPath: project.path,
         sandboxMetadata: task.sandboxMetadata,
       });
 

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -7,11 +7,14 @@ import {
   requireProjectContext,
   setJsonMode,
 } from '../lib/context.js';
-import { createSandbox } from '../lib/sandbox/index.js';
+import {
+  createSandbox,
+  isSandboxBackendUnavailableError,
+} from '../lib/sandbox/index.js';
 import { getTelemetry } from '../lib/telemetry.js';
 import type { TaskStopOutput } from '../output-types.js';
 import type { CommandDefinition } from '../types.js';
-import { exitWithError, exitWithSuccess } from '../utils/exit.js';
+import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
 
 /**
  * Stop a running task and optionally clean up its resources.
@@ -49,6 +52,7 @@ const stopCommand = async (
   let jsonOutput: TaskStopOutput = {
     success: false,
   };
+  let stopWarning: string | undefined;
 
   const processManager = json
     ? undefined
@@ -91,19 +95,35 @@ const stopCommand = async (
 
       await sandbox.stopAndRemove();
     } else if (task.sandboxMetadata) {
-      const sandbox = await createSandbox(task, processManager, {
-        projectPath: project.path,
-        sandboxMetadata: task.sandboxMetadata,
-      });
+      try {
+        const sandbox = await createSandbox(task, processManager, {
+          projectPath: project.path,
+          sandboxMetadata: task.sandboxMetadata,
+        });
 
-      await sandbox.teardownServices();
+        await sandbox.teardownServices();
+      } catch (error) {
+        if (!isSandboxBackendUnavailableError(error)) {
+          throw error;
+        }
+
+        stopWarning =
+          'Skipped sandbox service cleanup because no container backend is available. Task metadata was preserved so cleanup can be retried later.';
+        if (!isJsonMode()) {
+          console.warn(colors.yellow(`Warning: ${stopWarning}`));
+        }
+      }
     }
 
     processManager?.completeLastItem();
 
     // Reset task status to NEW and clear container info
     task.resetToNew();
-    task.setContainerInfo('', '');
+    task.setContainerInfo(
+      '',
+      '',
+      stopWarning ? task.sandboxMetadata : undefined
+    );
 
     const shouldRemoveWorkspace =
       options.removeAll || options.removeGitWorktreeAndBranch;
@@ -171,12 +191,28 @@ const stopCommand = async (
 
     jsonOutput = {
       ...jsonOutput,
-      success: true,
+      success: stopWarning === undefined,
       taskId: task.id,
       title: task.title,
       status: task.status,
       stoppedAt: new Date().toISOString(),
     };
+    if (stopWarning) {
+      jsonOutput.error = stopWarning;
+      await exitWithWarn('Task stopped with warnings', jsonOutput, {
+        tips: [
+          'Use ' +
+            colors.cyan(`rover stop ${task.id}`) +
+            ' to retry sandbox cleanup',
+          'Use ' +
+            colors.cyan(`rover delete ${task.id}`) +
+            ' to delete and clean up the task',
+        ],
+        telemetry,
+      });
+      return;
+    }
+
     await exitWithSuccess('Task stopped successfully!', jsonOutput, {
       tips: [
         'Use ' + colors.cyan(`rover logs ${task.id}`) + ' to check the logs',

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -105,7 +105,10 @@ const stopCommand = async (
     task.resetToNew();
     task.setContainerInfo('', '');
 
-    // Clean up Git worktree and branch
+    const shouldRemoveWorkspace =
+      options.removeAll || options.removeGitWorktreeAndBranch;
+
+    // Clean up Git worktree and branch when explicitly requested
     try {
       // Check if we're in a git repository
       await launch('git', ['rev-parse', '--is-inside-work-tree'], {
@@ -113,10 +116,7 @@ const stopCommand = async (
       });
 
       // Remove git workspace if it exists
-      if (
-        task.worktreePath &&
-        (options.removeAll || options.removeGitWorktreeAndBranch)
-      ) {
+      if (task.worktreePath && shouldRemoveWorkspace) {
         try {
           await launch(
             'git',
@@ -140,10 +140,7 @@ const stopCommand = async (
       }
 
       // Remove git branch if it exists
-      if (
-        task.branchName &&
-        (options.removeAll || options.removeGitWorktreeAndBranch)
-      ) {
+      if (task.branchName && shouldRemoveWorkspace) {
         try {
           // Check if branch exists
           await launch(
@@ -168,12 +165,9 @@ const stopCommand = async (
       // Not in a git repository, skip git operations
     }
 
-    // Delete the iterations
-    const iterationPath = task.iterationsPath();
-    rmSync(iterationPath, { recursive: true, force: true });
-
-    // Clear workspace information
-    task.setWorkspace('', '');
+    if (shouldRemoveWorkspace) {
+      task.setWorkspace('', '');
+    }
 
     jsonOutput = {
       ...jsonOutput,

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -90,6 +90,13 @@ const stopCommand = async (
       });
 
       await sandbox.stopAndRemove();
+    } else if (task.sandboxMetadata) {
+      const sandbox = await createSandbox(task, processManager, {
+        projectPath: project.path,
+        sandboxMetadata: task.sandboxMetadata,
+      });
+
+      await sandbox.teardownServices();
     }
 
     processManager?.completeLastItem();

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -55,13 +55,13 @@ const stopCommand = async (
     : new ProcessManager({ title: 'Stop task' });
   processManager?.start();
 
-  // Convert string taskId to number
-  const numericTaskId = parseInt(taskId, 10);
-  if (isNaN(numericTaskId)) {
+  // Convert string taskId to number (strict: reject '123abc' etc.)
+  if (!/^\d+$/.test(taskId)) {
     jsonOutput.error = `Invalid task ID '${taskId}' - must be a number`;
     await exitWithError(jsonOutput, { telemetry });
     return;
   }
+  const numericTaskId = parseInt(taskId, 10);
 
   // Require project context
   let project;

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -530,6 +530,12 @@ const createTaskForAgent = async (
       ),
     });
     const containerId = await sandbox.createAndStart();
+    const sandboxMetadata =
+      typeof sandbox.getSandboxMetadata === 'function'
+        ? sandbox.getSandboxMetadata()
+        : process.env.DOCKER_HOST
+          ? { dockerHost: process.env.DOCKER_HOST }
+          : undefined;
 
     updateTaskMetadata(
       project,
@@ -538,9 +544,7 @@ const createTaskForAgent = async (
         containerId,
         executionStatus: 'running',
         runningAt: new Date().toISOString(),
-        sandboxMetadata: process.env.DOCKER_HOST
-          ? { dockerHost: process.env.DOCKER_HOST }
-          : undefined,
+        sandboxMetadata,
       },
       jsonMode
     );

--- a/packages/cli/src/lib/__tests__/codex-usage.test.ts
+++ b/packages/cli/src/lib/__tests__/codex-usage.test.ts
@@ -123,7 +123,9 @@ describe('codex-usage', () => {
     });
 
     it('returns null when tokens missing', () => {
-      mockedReadFileSync.mockReturnValue(JSON.stringify({ auth_mode: 'chatgpt' }));
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ auth_mode: 'chatgpt' })
+      );
       expect(readCodexAuth()).toBeNull();
     });
 
@@ -162,8 +164,12 @@ describe('codex-usage', () => {
 
       // Per-model
       expect(result!.models['GPT-5.3-Codex-Spark']).toBeDefined();
-      expect(result!.models['GPT-5.3-Codex-Spark'].five_hour!.utilization).toBe(5);
-      expect(result!.models['GPT-5.3-Codex-Spark'].seven_day!.utilization).toBe(66);
+      expect(result!.models['GPT-5.3-Codex-Spark'].five_hour!.utilization).toBe(
+        5
+      );
+      expect(result!.models['GPT-5.3-Codex-Spark'].seven_day!.utilization).toBe(
+        66
+      );
     });
 
     it('sends correct auth headers', async () => {
@@ -257,7 +263,9 @@ describe('codex-usage', () => {
   });
 
   describe('analyzeCodexUsage', () => {
-    const makeUsage = (overrides: Partial<CodexUsageResponse> = {}): CodexUsageResponse => ({
+    const makeUsage = (
+      overrides: Partial<CodexUsageResponse> = {}
+    ): CodexUsageResponse => ({
       plan_type: 'pro',
       five_hour: { utilization: 10, resets_at: '2099-01-01T00:00:00Z' },
       seven_day: { utilization: 20, resets_at: '2099-01-01T00:00:00Z' },
@@ -273,7 +281,9 @@ describe('codex-usage', () => {
 
     it('exhausted when global bucket >= 99%', () => {
       const result = analyzeCodexUsage(
-        makeUsage({ seven_day: { utilization: 99, resets_at: '2099-01-01T00:00:00Z' } })
+        makeUsage({
+          seven_day: { utilization: 99, resets_at: '2099-01-01T00:00:00Z' },
+        })
       );
       expect(result.isExhausted).toBe(true);
       expect(result.limitingBucket).toBe('seven_day');
@@ -281,7 +291,9 @@ describe('codex-usage', () => {
 
     it('not exhausted at 95% (below 99% threshold)', () => {
       const result = analyzeCodexUsage(
-        makeUsage({ seven_day: { utilization: 95, resets_at: '2099-01-01T00:00:00Z' } })
+        makeUsage({
+          seven_day: { utilization: 95, resets_at: '2099-01-01T00:00:00Z' },
+        })
       );
       expect(result.isExhausted).toBe(false);
     });

--- a/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
+++ b/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getDependencyResolutionCommands } from '../dependency-resolution.js';
 
@@ -221,5 +224,30 @@ describe('getDependencyResolutionCommands', () => {
     expect(joined).toContain("'/workspace/frontend'");
     expect(joined).not.toContain('/workspace/../../escape');
     expect(joined).not.toContain('/workspace//absolute');
+  });
+
+  it('filters project paths that escape the workspace through symlinks', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-dep-resolution-'));
+    const outside = mkdtempSync(
+      join(tmpdir(), 'rover-dep-resolution-outside-')
+    );
+
+    try {
+      mkdirSync(join(outside, 'api'), { recursive: true });
+      symlinkSync(outside, join(root, 'services'));
+
+      const result = getDependencyResolutionCommands({
+        rootPackageManagers: [],
+        projects: [{ path: 'services/api', packageManagers: ['gomod', 'pub'] }],
+        workspaceRoot: root,
+      });
+      const joined = result.join('\n');
+
+      expect(joined).not.toContain('/workspace/services/api');
+      expect(result).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
+++ b/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
@@ -57,6 +57,24 @@ describe('getDependencyResolutionCommands', () => {
     expect(joined).toContain('$HOME/.profile');
   });
 
+  it('does not export subproject uv environments onto the global PATH', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: [],
+      projects: [
+        { path: 'api', packageManagers: ['uv'] },
+        { path: 'worker', packageManagers: ['uv'] },
+      ],
+      addVenvPathExports: true,
+    });
+    const joined = result.join('\n');
+
+    expect(joined).toContain("cd '/workspace/api' && uv sync");
+    expect(joined).toContain("cd '/workspace/worker' && uv sync");
+    expect(joined).not.toContain('/workspace/api/.venv/bin:$PATH');
+    expect(joined).not.toContain('/workspace/worker/.venv/bin:$PATH');
+    expect(joined).not.toContain('$HOME/.profile');
+  });
+
   it('generates poetry commands', () => {
     const result = getDependencyResolutionCommands({
       rootPackageManagers: ['poetry'],
@@ -182,5 +200,21 @@ describe('getDependencyResolutionCommands', () => {
     expect(joined).not.toContain("'/workspace/it's-a-test'");
     expect(joined).toContain('it');
     expect(joined).toContain('npm');
+  });
+
+  it('filters unsafe project paths before generating dependency commands', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: [],
+      projects: [
+        { path: '../../escape', packageManagers: ['npm'] },
+        { path: '/absolute', packageManagers: ['pip'] },
+        { path: 'frontend', packageManagers: ['pnpm'] },
+      ],
+    });
+    const joined = result.join('\n');
+
+    expect(joined).toContain("'/workspace/frontend'");
+    expect(joined).not.toContain('/workspace/../../escape');
+    expect(joined).not.toContain('/workspace//absolute');
   });
 });

--- a/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
+++ b/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
@@ -57,7 +57,7 @@ describe('getDependencyResolutionCommands', () => {
     expect(joined).toContain('$HOME/.profile');
   });
 
-  it('does not export subproject uv environments onto the global PATH', () => {
+  it('exports subproject uv environments onto PATH when requested', () => {
     const result = getDependencyResolutionCommands({
       rootPackageManagers: [],
       projects: [
@@ -70,9 +70,14 @@ describe('getDependencyResolutionCommands', () => {
 
     expect(joined).toContain("cd '/workspace/api' && uv sync");
     expect(joined).toContain("cd '/workspace/worker' && uv sync");
-    expect(joined).not.toContain('/workspace/api/.venv/bin:$PATH');
-    expect(joined).not.toContain('/workspace/worker/.venv/bin:$PATH');
-    expect(joined).not.toContain('$HOME/.profile');
+    expect(joined).toContain('/workspace/api/.venv/bin:$PATH');
+    expect(joined).toContain('/workspace/worker/.venv/bin:$PATH');
+    expect(joined).toContain(
+      `echo 'export PATH="/workspace/api/.venv/bin:$PATH"' >> $HOME/.profile`
+    );
+    expect(joined).toContain(
+      `echo 'export PATH="/workspace/worker/.venv/bin:$PATH"' >> $HOME/.profile`
+    );
   });
 
   it('generates poetry commands', () => {

--- a/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
+++ b/packages/cli/src/lib/__tests__/dependency-resolution.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import { getDependencyResolutionCommands } from '../dependency-resolution.js';
+
+describe('getDependencyResolutionCommands', () => {
+  it('returns empty array for no package managers', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: [],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('generates npm commands for root workspace', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['npm'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('npm ci');
+    expect(joined).toContain("'/workspace'");
+    expect(joined).toContain('cd /workspace');
+  });
+
+  it('generates pnpm commands with lockfile check', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['pnpm'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('pnpm install --frozen-lockfile');
+    expect(joined).toContain('pnpm-lock.yaml');
+  });
+
+  it('generates yarn commands', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['yarn'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('yarn install --frozen-lockfile');
+    expect(joined).toContain('yarn.lock');
+  });
+
+  it('generates uv commands without venv exports by default', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['uv'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('uv sync');
+    expect(joined).toContain('pyproject.toml');
+    expect(joined).not.toContain('.venv/bin');
+  });
+
+  it('generates uv commands with venv PATH exports when requested', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['uv'],
+      addVenvPathExports: true,
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('.venv/bin');
+    expect(joined).toContain('$HOME/.profile');
+  });
+
+  it('generates poetry commands', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['poetry'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('poetry install');
+    expect(joined).toContain('pyproject.toml');
+  });
+
+  it('generates pub commands for Dart', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['pub'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('flutter pub get');
+    expect(joined).toContain('dart pub get');
+    expect(joined).toContain('pubspec.yaml');
+  });
+
+  it('generates gomod commands with src/go.mod fallback', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['gomod'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('go mod download');
+    expect(joined).toContain('go.mod');
+    expect(joined).toContain('src/go.mod');
+  });
+
+  it('generates composer commands', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['composer'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('composer install');
+    expect(joined).toContain('composer.json');
+  });
+
+  it('generates cargo commands', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['cargo'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('cargo fetch');
+    expect(joined).toContain('Cargo.toml');
+  });
+
+  it('generates pip commands', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['pip'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('pip install -r requirements.txt');
+  });
+
+  it('generates rubygems commands', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['rubygems'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('bundle install');
+    expect(joined).toContain('Gemfile');
+  });
+
+  it('generates commands for multiple package managers', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['npm', 'pip'],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain('npm');
+    expect(joined).toContain('pip install');
+  });
+
+  it('generates commands for project subpaths', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: [],
+      projects: [
+        { path: 'frontend', packageManagers: ['pub'] },
+        { path: 'backend', packageManagers: ['gomod'] },
+      ],
+    });
+    const joined = result.join('\n');
+    expect(joined).toContain("'/workspace/frontend'");
+    expect(joined).toContain("'/workspace/backend'");
+    expect(joined).toContain('flutter pub get');
+    expect(joined).toContain('go mod download');
+  });
+
+  it('generates commands for both root and project locations', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['npm'],
+      projects: [{ path: 'e2e', packageManagers: ['pip'] }],
+    });
+    const joined = result.join('\n');
+    // Root npm
+    expect(joined).toContain("'/workspace'/package-lock.json");
+    // Project pip
+    expect(joined).toContain("'/workspace/e2e'/requirements.txt");
+  });
+
+  it('skips projects with no package managers', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: [],
+      projects: [{ path: 'empty', packageManagers: [] }],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('appends cd /workspace at end when commands are generated', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: ['npm'],
+    });
+    expect(result[result.length - 1]).toBe('cd /workspace');
+  });
+
+  it('does not produce shell-unsafe output for paths with single quotes', () => {
+    const result = getDependencyResolutionCommands({
+      rootPackageManagers: [],
+      projects: [{ path: "it's-a-test", packageManagers: ['npm'] }],
+    });
+    const joined = result.join('\n');
+    // Should contain properly escaped path, not bare single quote
+    expect(joined).not.toContain("'/workspace/it's-a-test'");
+    expect(joined).toContain('it');
+    expect(joined).toContain('npm');
+  });
+});

--- a/packages/cli/src/lib/__tests__/network-config.test.ts
+++ b/packages/cli/src/lib/__tests__/network-config.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { generateNetworkScript } from '../network-config.js';
+
+describe('generateNetworkScript', () => {
+  it('allows configured sidecar hostnames in allowlist mode', () => {
+    const script = generateNetworkScript(
+      {
+        mode: 'allowlist',
+        rules: [{ host: 'api.github.com' }],
+        allowDns: true,
+        allowLocalhost: true,
+      },
+      { serviceHostnames: ['postgres', 'redis'] }
+    );
+
+    expect(script).toContain(
+      '# Always allow service container traffic on the task network'
+    );
+    expect(script).toContain('for ip in $(resolve_host "postgres"); do');
+    expect(script).toContain('for ip in $(resolve_host "redis"); do');
+    expect(script).toContain('sudo iptables -A OUTPUT -d "$ip" -j ACCEPT');
+    expect(
+      script.indexOf('sudo iptables -A OUTPUT -o lo -j ACCEPT')
+    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+    expect(
+      script.indexOf('sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT')
+    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+  });
+
+  it('exempts configured sidecar hostnames before blocklist rules', () => {
+    const script = generateNetworkScript(
+      {
+        mode: 'blocklist',
+        rules: [{ host: '10.0.0.0/8' }],
+        allowDns: true,
+        allowLocalhost: true,
+      },
+      { serviceHostnames: ['postgres'] }
+    );
+
+    expect(
+      script.indexOf('for ip in $(resolve_host "postgres"); do')
+    ).toBeLessThan(
+      script.indexOf('sudo iptables -A OUTPUT -d 10.0.0.0/8 -j DROP')
+    );
+  });
+
+  it('still allows loopback and DNS needed for sidecar discovery when disabled explicitly', () => {
+    const script = generateNetworkScript(
+      {
+        mode: 'allowlist',
+        rules: [],
+        allowDns: false,
+        allowLocalhost: false,
+      },
+      { serviceHostnames: ['postgres'] }
+    );
+
+    expect(script).toContain(
+      '# Allow loopback traffic required for sidecar service discovery'
+    );
+    expect(script).toContain(
+      '# Allow DNS required for sidecar service discovery'
+    );
+    expect(
+      script.indexOf('sudo iptables -A OUTPUT -o lo -j ACCEPT')
+    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+    expect(
+      script.indexOf('sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT')
+    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+  });
+});

--- a/packages/cli/src/lib/__tests__/network-config.test.ts
+++ b/packages/cli/src/lib/__tests__/network-config.test.ts
@@ -129,6 +129,20 @@ describe('generateNetworkScript', () => {
     ).toThrow(/Invalid network rules/);
   });
 
+  it('rejects service hostnames containing shell metacharacters', () => {
+    expect(() =>
+      generateNetworkScript(
+        {
+          mode: 'allowlist',
+          rules: [{ host: 'api.github.com' }],
+          allowDns: true,
+          allowLocalhost: true,
+        },
+        { serviceHostnames: ['postgres$(whoami)'] }
+      )
+    ).toThrow(/Invalid characters in service hostname/);
+  });
+
   it('uses IP directly for IP/CIDR hosts without resolve_host', () => {
     const script = generateNetworkScript({
       mode: 'allowlist',

--- a/packages/cli/src/lib/__tests__/network-config.test.ts
+++ b/packages/cli/src/lib/__tests__/network-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { generateNetworkScript } from '../network-config.js';
+import {
+  generateNetworkScript,
+  validateNetworkRules,
+} from '../network-config.js';
 
 describe('generateNetworkScript', () => {
   it('allows configured sidecar hostnames in allowlist mode', () => {
@@ -16,15 +19,15 @@ describe('generateNetworkScript', () => {
     expect(script).toContain(
       '# Always allow service container traffic on the task network'
     );
-    expect(script).toContain('for ip in $(resolve_host "postgres"); do');
-    expect(script).toContain('for ip in $(resolve_host "redis"); do');
+    expect(script).toContain("for ip in $(resolve_host 'postgres'); do");
+    expect(script).toContain("for ip in $(resolve_host 'redis'); do");
     expect(script).toContain('sudo iptables -A OUTPUT -d "$ip" -j ACCEPT');
     expect(
       script.indexOf('sudo iptables -A OUTPUT -o lo -j ACCEPT')
-    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+    ).toBeLessThan(script.indexOf("for ip in $(resolve_host 'postgres'); do"));
     expect(
       script.indexOf('sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT')
-    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+    ).toBeLessThan(script.indexOf("for ip in $(resolve_host 'postgres'); do"));
   });
 
   it('exempts configured sidecar hostnames before blocklist rules', () => {
@@ -39,7 +42,7 @@ describe('generateNetworkScript', () => {
     );
 
     expect(
-      script.indexOf('for ip in $(resolve_host "postgres"); do')
+      script.indexOf("for ip in $(resolve_host 'postgres'); do")
     ).toBeLessThan(
       script.indexOf('sudo iptables -A OUTPUT -d 10.0.0.0/8 -j DROP')
     );
@@ -64,9 +67,121 @@ describe('generateNetworkScript', () => {
     );
     expect(
       script.indexOf('sudo iptables -A OUTPUT -o lo -j ACCEPT')
-    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+    ).toBeLessThan(script.indexOf("for ip in $(resolve_host 'postgres'); do"));
     expect(
       script.indexOf('sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT')
-    ).toBeLessThan(script.indexOf('for ip in $(resolve_host "postgres"); do'));
+    ).toBeLessThan(script.indexOf("for ip in $(resolve_host 'postgres'); do"));
+  });
+
+  it('single-quotes domain hosts to prevent shell expansion', () => {
+    const script = generateNetworkScript({
+      mode: 'allowlist',
+      rules: [{ host: 'example.com' }],
+      allowDns: true,
+      allowLocalhost: true,
+    });
+
+    expect(script).toContain("for ip in $(resolve_host 'example.com'); do");
+    // Must NOT use double quotes for domain hosts
+    expect(script).not.toContain('resolve_host "example.com"');
+  });
+
+  it('sanitizes description to remove shell metacharacters', () => {
+    const script = generateNetworkScript({
+      mode: 'allowlist',
+      rules: [
+        {
+          host: '10.0.0.1',
+          description: 'safe$(malicious)\nnewline`injection`',
+        },
+      ],
+      allowDns: true,
+      allowLocalhost: true,
+    });
+
+    // Newlines and shell metacharacters must be stripped from the comment
+    expect(script).not.toContain('$(malicious)');
+    expect(script).not.toContain('`injection`');
+    // The sanitized description should still appear as a comment on the rule line
+    expect(script).toContain('# safemalicious newlineinjection');
+  });
+
+  it('sanitizes description in blocklist mode', () => {
+    const script = generateNetworkScript({
+      mode: 'blocklist',
+      rules: [{ host: '10.0.0.1', description: 'test\n; rm -rf /' }],
+      allowDns: true,
+      allowLocalhost: true,
+    });
+
+    expect(script).not.toContain('; rm -rf /');
+    expect(script).toContain('# test rm -rf /');
+  });
+
+  it('throws when rules contain shell metacharacters', () => {
+    expect(() =>
+      generateNetworkScript({
+        mode: 'allowlist',
+        rules: [{ host: '$(whoami)' }],
+        allowDns: true,
+        allowLocalhost: true,
+      })
+    ).toThrow(/Invalid network rules/);
+  });
+
+  it('uses IP directly for IP/CIDR hosts without resolve_host', () => {
+    const script = generateNetworkScript({
+      mode: 'allowlist',
+      rules: [{ host: '192.168.1.0/24' }],
+      allowDns: true,
+      allowLocalhost: true,
+    });
+
+    expect(script).toContain(
+      'sudo iptables -A OUTPUT -d 192.168.1.0/24 -j ACCEPT'
+    );
+    // IP/CIDR rules should not call resolve_host — only the function
+    // definition should be present, not any invocation for this rule.
+    expect(script).not.toContain("resolve_host '192.168.1.0/24'");
+  });
+});
+
+describe('validateNetworkRules', () => {
+  it('accepts valid domain hosts', () => {
+    const result = validateNetworkRules([
+      { host: 'api.github.com' },
+      { host: '10.0.0.1' },
+      { host: '192.168.0.0/16' },
+    ]);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects hosts with shell metacharacters', () => {
+    const dangerous = [
+      '$(whoami)',
+      '`whoami`',
+      'host;rm -rf /',
+      'host&echo pwned',
+      'host|cat /etc/passwd',
+      'host\nnewline',
+      'host$(cmd)',
+    ];
+
+    for (const host of dangerous) {
+      const result = validateNetworkRules([{ host }]);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('Invalid characters');
+    }
+  });
+
+  it('rejects empty hosts', () => {
+    const result = validateNetworkRules([{ host: '' }]);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects hosts with angle brackets and other special chars', () => {
+    const result = validateNetworkRules([{ host: '<script>' }]);
+    expect(result.valid).toBe(false);
   });
 });

--- a/packages/cli/src/lib/__tests__/orphan-detector.test.ts
+++ b/packages/cli/src/lib/__tests__/orphan-detector.test.ts
@@ -38,11 +38,15 @@ function mockTask(
     id,
     status,
     containerId,
+    sandboxMetadata: {
+      dockerHost: `tcp://remote-${id}:2375`,
+    },
     iterations: 1,
     iterationsPath: () => `/projects/test/.rover/tasks/${id}`,
     markFailed: vi.fn(),
     markCompleted: vi.fn(),
     markPaused: vi.fn(),
+    setContainerInfo: vi.fn(),
     updateStatusFromIteration: vi.fn(),
     lastRestartAt: undefined,
     runningAt: undefined,
@@ -86,6 +90,11 @@ describe('detectOrphanedTasks', () => {
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
+    );
+    expect(task.setContainerInfo).toHaveBeenCalledWith(
+      '',
+      '',
+      task.sandboxMetadata
     );
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
@@ -151,7 +160,7 @@ describe('detectOrphanedTasks', () => {
 
     expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
       projectPath: '/projects/test',
-      sandboxMetadata: undefined,
+      sandboxMetadata: task.sandboxMetadata,
     });
     expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
@@ -284,6 +293,11 @@ describe('detectOrphanedTasks', () => {
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
     );
+    expect(task.setContainerInfo).toHaveBeenCalledWith(
+      '',
+      '',
+      task.sandboxMetadata
+    );
   });
 
   it('skips PAUSED, FAILED, COMPLETED, and NEW tasks', async () => {
@@ -388,6 +402,11 @@ describe('detectOrphanedTasks', () => {
     expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
+    expect(task.setContainerInfo).toHaveBeenCalledWith(
+      '',
+      '',
+      task.sandboxMetadata
+    );
     expect(task.markCompleted).toHaveBeenCalledTimes(1);
     expect(task.markFailed).not.toHaveBeenCalled();
   });
@@ -425,6 +444,11 @@ describe('detectOrphanedTasks', () => {
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
     );
+    expect(task.setContainerInfo).toHaveBeenCalledWith(
+      '',
+      '',
+      task.sandboxMetadata
+    );
   });
 
   it('marks task as PAUSED when container exited with PAUSED exit code and status file not written', async () => {
@@ -442,6 +466,11 @@ describe('detectOrphanedTasks', () => {
     expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).not.toHaveBeenCalled();
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
+    expect(task.setContainerInfo).toHaveBeenCalledWith(
+      '',
+      '',
+      task.sandboxMetadata
+    );
     expect(task.markPaused).toHaveBeenCalledWith(
       'Workflow paused due to retryable error (e.g. credit limit)'
     );
@@ -466,6 +495,11 @@ describe('detectOrphanedTasks', () => {
     expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).not.toHaveBeenCalled();
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
+    expect(task.setContainerInfo).toHaveBeenCalledWith(
+      '',
+      '',
+      task.sandboxMetadata
+    );
     expect(task.markPaused).not.toHaveBeenCalled();
     expect(task.markFailed).not.toHaveBeenCalled();
   });
@@ -507,6 +541,11 @@ describe('detectOrphanedTasks', () => {
     expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
+    expect(task.setContainerInfo).toHaveBeenCalledWith(
+      '',
+      '',
+      task.sandboxMetadata
+    );
     // Should NOT call markFailed again since updateStatusFromIteration already set FAILED
     expect(task.markFailed).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/lib/__tests__/orphan-detector.test.ts
+++ b/packages/cli/src/lib/__tests__/orphan-detector.test.ts
@@ -138,11 +138,19 @@ describe('detectOrphanedTasks', () => {
 
   it('marks IN_PROGRESS task as FAILED when a known container is gone', async () => {
     const task = mockTask(15, 'IN_PROGRESS', 'container-15');
-    const sandbox = { inspect: vi.fn().mockResolvedValue(null) };
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue(null),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: '/projects/test',
+      sandboxMetadata: undefined,
+    });
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
     );
@@ -169,7 +177,10 @@ describe('detectOrphanedTasks', () => {
 
   it('suppresses warnings when suppressWarnings option is enabled', async () => {
     const task = mockTask(17, 'IN_PROGRESS', 'container-17');
-    const sandbox = { inspect: vi.fn().mockResolvedValue(null) };
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue(null),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }], {
@@ -254,9 +265,11 @@ describe('detectOrphanedTasks', () => {
     mockedCreateSandbox
       .mockResolvedValueOnce({
         inspect: vi.fn().mockResolvedValue(null),
+        teardownServices: vi.fn().mockResolvedValue(undefined),
       } as any)
       .mockResolvedValueOnce({
         inspect: vi.fn().mockResolvedValue({ status: 'running' }),
+        teardownServices: vi.fn().mockResolvedValue(undefined),
       } as any);
 
     await detectOrphanedTasks([
@@ -342,7 +355,10 @@ describe('detectOrphanedTasks', () => {
       lastRestartAt: new Date(now - 20_000).toISOString(),
       runningAt: new Date(now - 10_000).toISOString(),
     });
-    const sandbox = { inspect: vi.fn().mockResolvedValue(null) };
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue(null),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
@@ -451,7 +467,10 @@ describe('detectOrphanedTasks', () => {
       lastRestartAt: new Date(Date.now() - 6 * 60 * 1000).toISOString(),
       runningAt: undefined,
     });
-    const sandbox = { inspect: vi.fn().mockResolvedValue(null) };
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue(null),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
@@ -478,7 +497,10 @@ describe('detectOrphanedTasks', () => {
 
   it('does not treat stale resume lock as active and continues orphan detection', async () => {
     const task = mockTask(26, 'IN_PROGRESS', 'container-26');
-    const sandbox = { inspect: vi.fn().mockResolvedValue(null) };
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue(null),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
     mockedExistsSync.mockImplementation(path =>
       String(path).endsWith('.resume.lock')
@@ -494,5 +516,39 @@ describe('detectOrphanedTasks', () => {
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
     );
+  });
+
+  it('passes persisted sandbox metadata into orphan reconciliation', async () => {
+    const task = mockTask(33, 'IN_PROGRESS', 'container-33', {
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-33-1',
+          containerNames: ['rover-svc-33-1-postgres'],
+          taskId: 33,
+          iteration: 1,
+        },
+      },
+    });
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue({ status: 'running' }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
+    mockedCreateSandbox.mockResolvedValue(sandbox as any);
+
+    await detectOrphanedTasks([{ task, project: mockProject() }]);
+
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: '/projects/test',
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-33-1',
+          containerNames: ['rover-svc-33-1-postgres'],
+          taskId: 33,
+          iteration: 1,
+        },
+      },
+    });
   });
 });

--- a/packages/cli/src/lib/__tests__/orphan-detector.test.ts
+++ b/packages/cli/src/lib/__tests__/orphan-detector.test.ts
@@ -157,6 +157,32 @@ describe('detectOrphanedTasks', () => {
     expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
+  it('does not tear down services when a resume lock appears after inspect returns null', async () => {
+    const task = mockTask(34, 'IN_PROGRESS', 'container-34');
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue(null),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
+    mockedCreateSandbox.mockResolvedValue(sandbox as any);
+    mockedExistsSync.mockImplementationOnce(() => false);
+    mockedExistsSync.mockImplementationOnce(() => false);
+    mockedExistsSync.mockImplementationOnce(() => false);
+    mockedExistsSync.mockImplementationOnce(() => true);
+    mockedReadFileSync.mockReturnValue('424242');
+    vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      if (pid === 424242 && signal === 0) {
+        return true;
+      }
+      throw Object.assign(new Error('No such process'), { code: 'ESRCH' });
+    });
+
+    await detectOrphanedTasks([{ task, project: mockProject() }]);
+
+    expect(sandbox.teardownServices).not.toHaveBeenCalled();
+    expect(task.markFailed).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
   it('does not mark task as FAILED when container inspect errors', async () => {
     const task = mockTask(19, 'IN_PROGRESS', 'container-19');
     const sandbox = {

--- a/packages/cli/src/lib/__tests__/orphan-detector.test.ts
+++ b/packages/cli/src/lib/__tests__/orphan-detector.test.ts
@@ -185,6 +185,28 @@ describe('detectOrphanedTasks', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
+  it('does not fail a force-inspected task that became COMPLETED before inspect returned null', async () => {
+    const task = mockTask(35, 'IN_PROGRESS', 'container-35', {
+      updateStatusFromIteration: vi.fn(() => {
+        task.status = 'COMPLETED';
+      }),
+    });
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue(null),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
+    mockedCreateSandbox.mockResolvedValue(sandbox as any);
+
+    task.updateStatusFromIteration();
+    await detectOrphanedTasks([
+      { task, project: mockProject(), forceInspect: true },
+    ]);
+
+    expect(sandbox.teardownServices).not.toHaveBeenCalled();
+    expect(task.markFailed).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
   it('does not mark task as FAILED when container inspect errors', async () => {
     const task = mockTask(19, 'IN_PROGRESS', 'container-19');
     const sandbox = {

--- a/packages/cli/src/lib/__tests__/orphan-detector.test.ts
+++ b/packages/cli/src/lib/__tests__/orphan-detector.test.ts
@@ -82,6 +82,7 @@ describe('detectOrphanedTasks', () => {
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
@@ -152,6 +153,7 @@ describe('detectOrphanedTasks', () => {
       projectPath: '/projects/test',
       sandboxMetadata: undefined,
     });
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
@@ -277,6 +279,7 @@ describe('detectOrphanedTasks', () => {
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
@@ -382,6 +385,7 @@ describe('detectOrphanedTasks', () => {
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markCompleted).toHaveBeenCalledTimes(1);
@@ -435,7 +439,8 @@ describe('detectOrphanedTasks', () => {
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
-    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
+    expect(sandbox.teardownServices).not.toHaveBeenCalled();
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markPaused).toHaveBeenCalledWith(
       'Workflow paused due to retryable error (e.g. credit limit)'
@@ -458,7 +463,8 @@ describe('detectOrphanedTasks', () => {
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
-    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
+    expect(sandbox.teardownServices).not.toHaveBeenCalled();
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markPaused).not.toHaveBeenCalled();
     expect(task.markFailed).not.toHaveBeenCalled();
@@ -498,6 +504,7 @@ describe('detectOrphanedTasks', () => {
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     // Should NOT call markFailed again since updateStatusFromIteration already set FAILED
@@ -516,6 +523,7 @@ describe('detectOrphanedTasks', () => {
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
@@ -631,7 +639,29 @@ describe('detectOrphanedTasks', () => {
       }
     );
 
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
     expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
+    expect(task.markCompleted).not.toHaveBeenCalled();
+    expect(task.markFailed).not.toHaveBeenCalled();
+    expect(task.markPaused).not.toHaveBeenCalled();
+  });
+
+  it('preserves sidecars when updateStatusFromIteration refreshes to PAUSED after a clean exit', async () => {
+    const task = mockTask(36, 'IN_PROGRESS', 'container-36', {
+      updateStatusFromIteration: vi.fn(() => {
+        task.status = 'PAUSED';
+      }),
+    });
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue({ status: 'exited', exitCode: 0 }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
+    mockedCreateSandbox.mockResolvedValue(sandbox as any);
+
+    await detectOrphanedTasks([{ task, project: mockProject() }]);
+
+    expect(sandbox.inspect).toHaveBeenCalledWith({ teardownServices: false });
+    expect(sandbox.teardownServices).not.toHaveBeenCalled();
     expect(task.markCompleted).not.toHaveBeenCalled();
     expect(task.markFailed).not.toHaveBeenCalled();
     expect(task.markPaused).not.toHaveBeenCalled();

--- a/packages/cli/src/lib/__tests__/orphan-detector.test.ts
+++ b/packages/cli/src/lib/__tests__/orphan-detector.test.ts
@@ -76,11 +76,13 @@ describe('detectOrphanedTasks', () => {
     const task = mockTask(1, 'IN_PROGRESS', 'container-1');
     const sandbox = {
       inspect: vi.fn().mockResolvedValue({ status: 'exited' }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
     };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
     );
@@ -247,11 +249,13 @@ describe('detectOrphanedTasks', () => {
     const task = mockTask(4, 'ITERATING', 'container-4');
     const sandbox = {
       inspect: vi.fn().mockResolvedValue({ status: 'exited' }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
     };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
     );
@@ -350,11 +354,13 @@ describe('detectOrphanedTasks', () => {
     });
     const sandbox = {
       inspect: vi.fn().mockResolvedValue({ status: 'exited', exitCode: 0 }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
     };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markCompleted).toHaveBeenCalledTimes(1);
     expect(task.markFailed).not.toHaveBeenCalled();
@@ -401,11 +407,13 @@ describe('detectOrphanedTasks', () => {
     });
     const sandbox = {
       inspect: vi.fn().mockResolvedValue({ status: 'exited', exitCode: 2 }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
     };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markPaused).toHaveBeenCalledWith(
       'Workflow paused due to retryable error (e.g. credit limit)'
@@ -422,11 +430,13 @@ describe('detectOrphanedTasks', () => {
     });
     const sandbox = {
       inspect: vi.fn().mockResolvedValue({ status: 'exited', exitCode: 2 }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
     };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markPaused).not.toHaveBeenCalled();
     expect(task.markFailed).not.toHaveBeenCalled();
@@ -460,11 +470,13 @@ describe('detectOrphanedTasks', () => {
     });
     const sandbox = {
       inspect: vi.fn().mockResolvedValue({ status: 'exited', exitCode: 1 }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
     };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     // Should NOT call markFailed again since updateStatusFromIteration already set FAILED
     expect(task.markFailed).not.toHaveBeenCalled();
@@ -476,11 +488,13 @@ describe('detectOrphanedTasks', () => {
     });
     const sandbox = {
       inspect: vi.fn().mockResolvedValue({ status: 'exited', exitCode: 1 }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
     };
     mockedCreateSandbox.mockResolvedValue(sandbox as any);
 
     await detectOrphanedTasks([{ task, project: mockProject() }]);
 
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
     expect(task.updateStatusFromIteration).toHaveBeenCalledTimes(1);
     expect(task.markFailed).toHaveBeenCalledWith(
       'Container exited unexpectedly (possible crash or system restart)'
@@ -576,5 +590,28 @@ describe('detectOrphanedTasks', () => {
         },
       },
     });
+  });
+
+  it('tears down sidecars for force-inspected tasks that already refreshed to COMPLETED', async () => {
+    const task = mockTask(35, 'COMPLETED', 'container-35', {
+      updateStatusFromIteration: vi.fn(),
+    });
+    const sandbox = {
+      inspect: vi.fn().mockResolvedValue({ status: 'exited', exitCode: 0 }),
+      teardownServices: vi.fn().mockResolvedValue(undefined),
+    };
+    mockedCreateSandbox.mockResolvedValue(sandbox as any);
+
+    await detectOrphanedTasks(
+      [{ task, project: mockProject(), forceInspect: true }],
+      {
+        suppressWarnings: true,
+      }
+    );
+
+    expect(sandbox.teardownServices).toHaveBeenCalledTimes(1);
+    expect(task.markCompleted).not.toHaveBeenCalled();
+    expect(task.markFailed).not.toHaveBeenCalled();
+    expect(task.markPaused).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/lib/__tests__/resume-helper.test.ts
+++ b/packages/cli/src/lib/__tests__/resume-helper.test.ts
@@ -188,6 +188,9 @@ describe('resumeTask', () => {
       worktreePath,
       iterationsPath: () => iterationPath,
       iterations: 1,
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+      },
     });
     const project = createMockProject(task);
     const checkpointPath = join(iterationPath, '1', 'checkpoint.json');
@@ -213,6 +216,9 @@ describe('resumeTask', () => {
     );
     expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
       projectPath: project.path,
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+      },
       checkpointPath,
       resumeFromCheckpoint: true,
       iterationLogsPath: project.getTaskIterationLogsPath(

--- a/packages/cli/src/lib/__tests__/resume-helper.test.ts
+++ b/packages/cli/src/lib/__tests__/resume-helper.test.ts
@@ -375,6 +375,110 @@ describe('resumeTask', () => {
     expect(mockedLaunchSync).not.toHaveBeenCalled();
   });
 
+  it('resumes from checkpoint when a multi-repo workspace only uses plain relative local repositories', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      '{"completedSteps":[{"id":"step1"}]}',
+      'utf8'
+    );
+    writeFileSync(
+      join(iterationPath, '1', 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'repos/frontend.git',
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-resume'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: join(iterationPath, '1', 'checkpoint.json'),
+      resumeFromCheckpoint: true,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+    expect(mockedLaunchSync).not.toHaveBeenCalled();
+  });
+
+  it('still falls back to a full rerun when a multi-repo checkpoint is missing SCP-style remote repository state', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      '{"completedSteps":[{"id":"step1"}]}',
+      'utf8'
+    );
+    writeFileSync(
+      join(iterationPath, '1', 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'git@github.com:example/frontend.git',
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-rerun'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: undefined,
+      resumeFromCheckpoint: false,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+    expect(mockedLaunchSync).not.toHaveBeenCalled();
+  });
+
   it('preserves legacy root-only checkpoint resumes when current config adds workspace repositories', async () => {
     const iterationPath = join(tempDir, 'iterations');
     const worktreePath = join(tempDir, 'worktree');
@@ -482,7 +586,7 @@ describe('resumeTask', () => {
     expect(mockedLaunchSync).not.toHaveBeenCalled();
   });
 
-  it('treats malformed workspace metadata as root-only during checkpoint validation', async () => {
+  it('falls back to a full rerun when persisted workspace metadata is malformed', async () => {
     const iterationPath = join(tempDir, 'iterations');
     const worktreePath = join(tempDir, 'worktree');
     mkdirSync(worktreePath, { recursive: true });
@@ -518,7 +622,7 @@ describe('resumeTask', () => {
     } as any);
 
     mockedCreateSandbox.mockResolvedValue({
-      createAndStart: vi.fn().mockResolvedValue('container-resume'),
+      createAndStart: vi.fn().mockResolvedValue('container-rerun'),
     } as any);
 
     const result = await resumeTask(project, 1);
@@ -526,8 +630,8 @@ describe('resumeTask', () => {
     expect(result.status).toBe('ok');
     expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
       projectPath: project.path,
-      checkpointPath: join(iterationPath, '1', 'checkpoint.json'),
-      resumeFromCheckpoint: true,
+      checkpointPath: undefined,
+      resumeFromCheckpoint: false,
       iterationLogsPath: project.getTaskIterationLogsPath(
         task.id,
         task.iterations

--- a/packages/cli/src/lib/__tests__/resume-helper.test.ts
+++ b/packages/cli/src/lib/__tests__/resume-helper.test.ts
@@ -318,6 +318,160 @@ describe('resumeTask', () => {
     });
   });
 
+  it('falls back to a full rerun when a multi-repo checkpoint is missing external repository state', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      '{"completedSteps":[{"id":"step1"}]}',
+      'utf8'
+    );
+    writeFileSync(
+      join(iterationPath, '1', 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'https://example.com/frontend.git',
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-rerun'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: undefined,
+      resumeFromCheckpoint: false,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+    expect(mockedLaunchSync).not.toHaveBeenCalled();
+  });
+
+  it('preserves legacy root-only checkpoint resumes when current config adds workspace repositories', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      '{"completedSteps":[{"id":"step1"}]}',
+      'utf8'
+    );
+    mockedProjectConfigManager.load.mockReturnValue({
+      excludePatterns: [],
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    } as any);
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-rerun'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: join(iterationPath, '1', 'checkpoint.json'),
+      resumeFromCheckpoint: true,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+    expect(mockedLaunchSync).not.toHaveBeenCalled();
+  });
+
+  it('treats malformed workspace metadata as root-only during checkpoint validation', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      '{"completedSteps":[{"id":"step1"}]}',
+      'utf8'
+    );
+    writeFileSync(
+      join(iterationPath, '1', 'workspace-description.json'),
+      'not json {{{',
+      'utf8'
+    );
+    mockedProjectConfigManager.load.mockReturnValue({
+      excludePatterns: [],
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://example.com/frontend.git',
+        },
+      ],
+    } as any);
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-resume'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: join(iterationPath, '1', 'checkpoint.json'),
+      resumeFromCheckpoint: true,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+  });
+
   it('refuses automatic recreation when the checkpoint is malformed and the worktree is missing', async () => {
     const iterationPath = join(tempDir, 'iterations');
     const missingWorktreePath = join(tempDir, 'missing-worktree');

--- a/packages/cli/src/lib/__tests__/resume-helper.test.ts
+++ b/packages/cli/src/lib/__tests__/resume-helper.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 
 // Mock all external dependencies
 vi.mock('rover-core', () => ({
+  VERBOSE: false,
   IterationManager: {
     createInitial: vi.fn(),
   },
@@ -79,6 +80,7 @@ let mockIterationStatus = {
   pause: vi.fn(),
   fail: vi.fn(),
 };
+let currentProjectPath = '/tmp/project';
 
 function createMockTask(overrides: Record<string, any> = {}) {
   const merged: any = {
@@ -111,12 +113,14 @@ function createMockTask(overrides: Record<string, any> = {}) {
 
 function createMockProject(task?: any) {
   return {
-    path: '/tmp/project',
+    path: currentProjectPath,
     getTask: vi.fn().mockReturnValue(task || null),
     getWorkspacePath: vi.fn().mockReturnValue('/tmp/workspace-1'),
     getTaskIterationLogsPath: vi
       .fn()
-      .mockReturnValue('/tmp/project/logs/tasks/1/iterations/1'),
+      .mockImplementation(() =>
+        join(currentProjectPath, 'logs/tasks/1/iterations/1')
+      ),
   } as any;
 }
 
@@ -147,6 +151,7 @@ describe('resumeTask', () => {
       stderr: '',
     } as any);
     tempDir = mkdtempSync(join(tmpdir(), 'rover-resume-helper-test-'));
+    currentProjectPath = join(tempDir, 'project');
   });
 
   afterEach(() => {
@@ -383,6 +388,7 @@ describe('resumeTask', () => {
       iterations: 1,
     });
     const project = createMockProject(task);
+    mkdirSync(project.path, { recursive: true });
     mkdirSync(join(iterationPath, '1'), { recursive: true });
     writeFileSync(
       join(iterationPath, '1', 'checkpoint.json'),
@@ -411,6 +417,63 @@ describe('resumeTask', () => {
       projectPath: project.path,
       checkpointPath: join(iterationPath, '1', 'checkpoint.json'),
       resumeFromCheckpoint: true,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+    expect(mockedLaunchSync).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a full rerun when legacy workspace metadata requires external repository state', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(project.path, { recursive: true });
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      '{"completedSteps":[{"id":"step1"}]}',
+      'utf8'
+    );
+    writeFileSync(
+      join(worktreePath, '.rover-workspace.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'https://example.com/frontend.git',
+          },
+        ],
+      }),
+      'utf8'
+    );
+    mockedProjectConfigManager.load.mockReturnValue({
+      excludePatterns: [],
+      projects: [],
+    } as any);
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-rerun'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: undefined,
+      resumeFromCheckpoint: false,
       iterationLogsPath: project.getTaskIterationLogsPath(
         task.id,
         task.iterations

--- a/packages/cli/src/lib/__tests__/resume-helper.test.ts
+++ b/packages/cli/src/lib/__tests__/resume-helper.test.ts
@@ -375,7 +375,7 @@ describe('resumeTask', () => {
     expect(mockedLaunchSync).not.toHaveBeenCalled();
   });
 
-  it('resumes from checkpoint when a multi-repo workspace only uses plain relative local repositories', async () => {
+  it('falls back to a full rerun when a local child repository checkpoint is missing repository state', async () => {
     const iterationPath = join(tempDir, 'iterations');
     const worktreePath = join(tempDir, 'worktree');
     mkdirSync(worktreePath, { recursive: true });
@@ -402,6 +402,134 @@ describe('resumeTask', () => {
             name: 'frontend',
             path: 'frontend',
             repository: 'repos/frontend.git',
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-resume'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: undefined,
+      resumeFromCheckpoint: false,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+    expect(mockedLaunchSync).not.toHaveBeenCalled();
+  });
+
+  it('resumes from checkpoint when a local child repository has checkpointed repository state', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      JSON.stringify({
+        completedSteps: [{ id: 'step1' }],
+        externalRepositories: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'repos/frontend.git',
+            head: 'abc123',
+            trackedDiffHash: 'def456',
+            untrackedHash: 'ghi789',
+          },
+        ],
+      }),
+      'utf8'
+    );
+    writeFileSync(
+      join(iterationPath, '1', 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'repos/frontend.git',
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    mockedCreateSandbox.mockResolvedValue({
+      createAndStart: vi.fn().mockResolvedValue('container-resume'),
+    } as any);
+
+    const result = await resumeTask(project, 1);
+
+    expect(result.status).toBe('ok');
+    expect(mockedCreateSandbox).toHaveBeenCalledWith(task, undefined, {
+      projectPath: project.path,
+      checkpointPath: join(iterationPath, '1', 'checkpoint.json'),
+      resumeFromCheckpoint: true,
+      iterationLogsPath: project.getTaskIterationLogsPath(
+        task.id,
+        task.iterations
+      ),
+    });
+    expect(mockedLaunchSync).not.toHaveBeenCalled();
+  });
+
+  it('resumes from checkpoint when a multi-repo workspace uses absolute local repositories under /workspace', async () => {
+    const iterationPath = join(tempDir, 'iterations');
+    const worktreePath = join(tempDir, 'worktree');
+    mkdirSync(worktreePath, { recursive: true });
+    const task = createMockTask({
+      status: 'PAUSED',
+      worktreePath,
+      branchName: 'rover/task-1',
+      sourceBranch: 'main',
+      iterationsPath: () => iterationPath,
+      iterations: 1,
+    });
+    const project = createMockProject(task);
+    mkdirSync(join(iterationPath, '1'), { recursive: true });
+    writeFileSync(
+      join(iterationPath, '1', 'checkpoint.json'),
+      JSON.stringify({
+        completedSteps: [{ id: 'step1' }],
+        externalRepositories: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: '/workspace/sources/frontend.git',
+            head: 'abc123',
+            trackedDiffHash: 'def456',
+            untrackedHash: 'ghi789',
+          },
+        ],
+      }),
+      'utf8'
+    );
+    writeFileSync(
+      join(iterationPath, '1', 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: '/workspace/sources/frontend.git',
           },
         ],
       }),

--- a/packages/cli/src/lib/__tests__/retry-scheduler.test.ts
+++ b/packages/cli/src/lib/__tests__/retry-scheduler.test.ts
@@ -295,7 +295,10 @@ describe('RetryScheduler', () => {
     it('removes only the matching project task when task ids collide', async () => {
       const projectA = makeMockProject('/tmp/project-a');
       const projectB = makeMockProject('/tmp/project-b');
-      mockedResumeTask.mockResolvedValue({ status: 'ok' });
+      mockedResumeTask.mockResolvedValue({
+        status: 'ok',
+        resumedFromCheckpoint: false,
+      });
 
       await scheduler.registerPausedTask('claude', 1, projectA);
       await scheduler.registerPausedTask('claude', 1, projectB);
@@ -330,6 +333,42 @@ describe('RetryScheduler', () => {
 
       expect(scheduler.getRetryCount(colonProject, 1)).toBe(0);
       expect(scheduler.getScheduledTime('claude')).toBeUndefined();
+    });
+
+    it('does not clear retry state for a different provider when unregistering without a project', async () => {
+      const claudeProject = makeMockProject('/tmp/claude-project');
+      const geminiProject = makeMockProject('/tmp/gemini-project');
+      mockedResumeTask.mockResolvedValue({
+        status: 'failed',
+        error: 'still paused',
+      });
+
+      await scheduler.registerPausedTask('claude', 1, claudeProject);
+      await scheduler.registerPausedTask('gemini', 1, geminiProject);
+      await vi.advanceTimersToNextTimerAsync();
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(scheduler.getRetryCount(claudeProject, 1)).toBe(1);
+      expect(scheduler.getRetryCount(geminiProject, 1)).toBe(1);
+
+      scheduler.unregisterTask('claude', 1);
+
+      expect(scheduler.getScheduledTime('claude')).toBeUndefined();
+      expect(scheduler.getScheduledTime('gemini')).toBeDefined();
+      expect(scheduler.getRetryCount(claudeProject, 1)).toBe(0);
+      expect(scheduler.getRetryCount(geminiProject, 1)).toBe(1);
+    });
+
+    it('tracks the replacement provider after a provider change for the same task key', async () => {
+      const sharedProject = makeMockProject('/tmp/shared-project');
+
+      await scheduler.registerPausedTask('claude', 1, sharedProject);
+      await scheduler.registerPausedTask('gemini', 1, sharedProject);
+
+      scheduler.unregisterTask('gemini', 1);
+
+      expect(scheduler.getScheduledTime('gemini')).toBeUndefined();
+      expect(scheduler.getRetryCount(sharedProject, 1)).toBe(0);
     });
 
     it('clears retry counts without project after timers are exhausted', async () => {
@@ -409,7 +448,10 @@ describe('RetryScheduler', () => {
   describe('timer firing', () => {
     it('calls resumeTask for all registered tasks when timer fires', async () => {
       const mockProject = makeMockProject();
-      mockedResumeTask.mockResolvedValue({ status: 'ok' });
+      mockedResumeTask.mockResolvedValue({
+        status: 'ok',
+        resumedFromCheckpoint: false,
+      });
 
       await scheduler.registerPausedTask('claude', 1, mockProject);
       await scheduler.registerPausedTask('claude', 2, mockProject);
@@ -560,7 +602,10 @@ describe('RetryScheduler', () => {
       mockedResumeTask
         .mockResolvedValueOnce({ status: 'failed', error: 'still paused' })
         .mockResolvedValueOnce({ status: 'failed', error: 'still paused' })
-        .mockResolvedValueOnce({ status: 'ok' });
+        .mockResolvedValueOnce({
+          status: 'ok',
+          resumedFromCheckpoint: false,
+        });
 
       await scheduler.registerPausedTask('claude', 1, mockProject);
 
@@ -603,7 +648,10 @@ describe('RetryScheduler', () => {
           .mockReturnValue(resumedTask),
       };
 
-      mockedResumeTask.mockResolvedValue({ status: 'ok' });
+      mockedResumeTask.mockResolvedValue({
+        status: 'ok',
+        resumedFromCheckpoint: false,
+      });
 
       await scheduler.registerPausedTask('claude', 1, mockProject as any);
       await vi.advanceTimersToNextTimerAsync();
@@ -617,7 +665,10 @@ describe('RetryScheduler', () => {
 
       mockedResumeTask
         .mockResolvedValueOnce({ status: 'failed', error: 'still paused' })
-        .mockResolvedValue({ status: 'ok' });
+        .mockResolvedValue({
+          status: 'ok',
+          resumedFromCheckpoint: false,
+        });
 
       await scheduler.registerPausedTask('claude', 1, mockProject);
       await vi.advanceTimersToNextTimerAsync();
@@ -780,7 +831,10 @@ describe('RetryScheduler', () => {
     it('proceeds with resume when usage is available at fire time', async () => {
       const mockProject = makeMockProject();
       mockedCheckClaudeUsage.mockResolvedValue(null);
-      mockedResumeTask.mockResolvedValue({ status: 'ok' });
+      mockedResumeTask.mockResolvedValue({
+        status: 'ok',
+        resumedFromCheckpoint: false,
+      });
 
       await scheduler.registerPausedTask('claude', 1, mockProject);
 
@@ -800,7 +854,10 @@ describe('RetryScheduler', () => {
     it('proceeds with resume when pre-fire usage check fails', async () => {
       const mockProject = makeMockProject();
       mockedCheckClaudeUsage.mockResolvedValue(null);
-      mockedResumeTask.mockResolvedValue({ status: 'ok' });
+      mockedResumeTask.mockResolvedValue({
+        status: 'ok',
+        resumedFromCheckpoint: false,
+      });
 
       await scheduler.registerPausedTask('claude', 1, mockProject);
 
@@ -814,7 +871,10 @@ describe('RetryScheduler', () => {
 
     it('skips pre-fire usage check for non-Claude providers', async () => {
       const mockProject = makeMockProject();
-      mockedResumeTask.mockResolvedValue({ status: 'ok' });
+      mockedResumeTask.mockResolvedValue({
+        status: 'ok',
+        resumedFromCheckpoint: false,
+      });
 
       await scheduler.registerPausedTask('gemini', 1, mockProject);
 
@@ -834,7 +894,10 @@ describe('RetryScheduler', () => {
       );
       // Initial registration: usage check returns null → blind backoff
       mockedCheckClaudeUsage.mockResolvedValue(null);
-      mockedResumeTask.mockResolvedValue({ status: 'ok' });
+      mockedResumeTask.mockResolvedValue({
+        status: 'ok',
+        resumedFromCheckpoint: false,
+      });
 
       await scheduler.registerPausedTask('claude', 1, mockProject);
 

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -3,6 +3,7 @@ import {
   readFileSync,
   rmSync,
   mkdirSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -289,9 +290,7 @@ describe('SetupBuilder multi-repo projects', () => {
     const entrypointPath = builder.generateEntrypoint(false);
     const script = readFileSync(entrypointPath, 'utf8');
 
-    const initScriptIndex = script.indexOf(
-      "bash '/workspace/scripts/root-init.sh'"
-    );
+    const initScriptIndex = script.indexOf('bash "$root_script_0"');
     const dependencyResolutionIndex = script.indexOf(
       "cd '/workspace' && uv sync"
     );
@@ -302,6 +301,49 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(initScriptIndex).toBeGreaterThanOrEqual(0);
     expect(dependencyResolutionIndex).toBeGreaterThan(initScriptIndex);
     expect(sudoersRemovalIndex).toBeGreaterThan(initScriptIndex);
+  });
+
+  it('runs root init scripts from mounted host paths when they live outside /workspace', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: '../shared/root-init.sh',
+      allInitScripts: [{ script: '../shared/root-init.sh' }],
+      network: undefined,
+      projectRoot: root,
+      projects: [],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(script).toContain("mounted_script_0='/init-script.sh'");
+    expect(script).toContain(
+      "workspace_script_0='/workspace/../shared/root-init.sh'"
+    );
+    expect(script).toContain('if [ -f "$mounted_script_0" ]; then');
+    expect(script).toContain('bash "$root_script_0"');
   });
 
   it('syncs repositories before installing languages on non-cached startup', () => {
@@ -512,6 +554,106 @@ describe('SetupBuilder multi-repo projects', () => {
       path: 'frontend',
       repository: './repos/frontend.git',
     });
+  });
+
+  it('does not treat absolute container repository paths as host mounts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: '/workspace/sources/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(builder.getRepositoryMounts()).toEqual([]);
+    expect(script).toContain(
+      "git clone '/workspace/sources/frontend.git' '/workspace/frontend'"
+    );
+  });
+
+  it('treats absolute host repository paths as host mounts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    const hostRepo = mkdtempSync(join(tmpdir(), 'rover-setup-host-repo-'));
+    testDirs.push(root, hostRepo);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: hostRepo,
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(script).toContain(
+      "git clone '/workspace-repos/0' '/workspace/frontend'"
+    );
   });
 
   it('validates external repository state during checkpoint resume', () => {
@@ -735,7 +877,7 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain("workspace_dir_1='/workspace/frontend'");
     expect(script).toContain('if [ -f "$workspace_project_script_1" ]; then');
     expect(script).toContain(
-      'echo "❌ Initialization script (frontend) not found at $workspace_project_script_1"'
+      'echo "❌ Initialization script (frontend) not found at $workspace_project_script_1 or $workspace_root_script_1"'
     );
     expect(script).toContain('bash "$workspace_script_1"');
     expect(script).not.toContain('/bin/sh /init-script-0.sh');
@@ -744,9 +886,60 @@ describe('SetupBuilder multi-repo projects', () => {
     );
     expect(script).not.toContain("\n'/workspace/scripts/root-init.sh'\n");
     expect(script).not.toContain("/bin/sh '/workspace/scripts/root-init.sh'");
-    expect(script).not.toContain(
+    expect(script).toContain(
       "workspace_root_script_1='/workspace/scripts/frontend-init.sh'"
     );
+  });
+
+  it('falls back to root init scripts for project-scoped entries during cached startup', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [
+        { script: 'scripts/frontend-init.sh', path: 'frontend' },
+      ],
+      network: undefined,
+      projectRoot: root,
+      projects: [],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(script).toContain(
+      "workspace_project_script_0='/workspace/frontend/scripts/frontend-init.sh'"
+    );
+    expect(script).toContain(
+      "workspace_root_script_0='/workspace/scripts/frontend-init.sh'"
+    );
+    expect(script).toContain('elif [ -f "$workspace_root_script_0" ]; then');
+    expect(script).toContain("workspace_dir_0='/workspace'");
   });
 
   it('filters unsafe project-scoped init-script paths', () => {
@@ -795,6 +988,51 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain('/workspace/frontend/scripts/frontend-init.sh');
     expect(script).not.toContain('/workspace/../../escape');
     expect(script).not.toContain('scripts/bad.sh');
+  });
+
+  it('filters project-scoped init scripts whose path escapes through a symlink', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    const outside = mkdtempSync(join(tmpdir(), 'rover-setup-outside-'));
+    testDirs.push(root);
+    testDirs.push(outside);
+    symlinkSync(outside, join(root, 'services'));
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [{ script: 'scripts/init.sh', path: 'services/api' }],
+      network: undefined,
+      projectRoot: root,
+      projects: [],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(script).not.toContain('/workspace/services/api/scripts/init.sh');
   });
 
   it('resolves dependencies for configured sub-project package managers', () => {
@@ -1025,11 +1263,315 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(descPath).toBeUndefined();
   });
 
-  it('preserves a legacy root-only workspace when older iterations have no persisted metadata', () => {
+  it('falls back to the current config when older iterations have no persisted metadata', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
 
     mkdirSync(join(root, 'iterations', '1'), { recursive: true });
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      packageManagers: [],
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+          packageManagers: ['pnpm'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(script).toContain(
+      "git clone 'https://github.com/dataforxyz/frontend.git' '/workspace/frontend'"
+    );
+    expect(description.projects).toEqual([
+      expect.objectContaining({
+        name: 'frontend',
+        path: 'frontend',
+        repository: 'https://github.com/dataforxyz/frontend.git',
+        packageManagers: ['pnpm'],
+      }),
+    ]);
+  });
+
+  it('falls back to legacy worktree metadata when iteration metadata is absent', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    const worktreePath = join(root, 'workspace');
+    mkdirSync(worktreePath, { recursive: true });
+
+    writeFileSync(
+      join(worktreePath, '.rover-workspace.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'legacy',
+            path: 'legacy',
+            repository: 'https://github.com/dataforxyz/legacy.git',
+            packageManagers: ['uv'],
+          },
+        ],
+      })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      worktreePath,
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      packageManagers: [],
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+          packageManagers: ['pnpm'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(script).toContain(
+      "git clone 'https://github.com/dataforxyz/legacy.git' '/workspace/legacy'"
+    );
+    expect(script).not.toContain('/workspace/frontend');
+    expect(description.projects).toEqual([
+      expect.objectContaining({
+        name: 'legacy',
+        path: 'legacy',
+        repository: 'https://github.com/dataforxyz/legacy.git',
+        packageManagers: ['uv'],
+      }),
+    ]);
+  });
+
+  it('falls back to legacy worktree metadata when iterations directory exists but is empty', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    const worktreePath = join(root, 'workspace');
+    mkdirSync(worktreePath, { recursive: true });
+    mkdirSync(join(root, 'iterations'), { recursive: true });
+
+    writeFileSync(
+      join(worktreePath, '.rover-workspace.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'legacy',
+            path: 'legacy',
+            repository: 'https://github.com/dataforxyz/legacy.git',
+          },
+        ],
+      })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      worktreePath,
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      packageManagers: [],
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(script).toContain(
+      "git clone 'https://github.com/dataforxyz/legacy.git' '/workspace/legacy'"
+    );
+    expect(script).not.toContain('/workspace/frontend');
+    expect(description.projects).toEqual([
+      expect.objectContaining({
+        name: 'legacy',
+        path: 'legacy',
+        repository: 'https://github.com/dataforxyz/legacy.git',
+      }),
+    ]);
+  });
+
+  it('falls back to legacy worktree metadata when newer iteration metadata is malformed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    const worktreePath = join(root, 'workspace');
+    mkdirSync(worktreePath, { recursive: true });
+
+    mkdirSync(join(root, 'iterations', '1'), { recursive: true });
+    writeFileSync(
+      join(root, 'iterations', '1', 'workspace-description.json'),
+      'not json {{{'
+    );
+    writeFileSync(
+      join(worktreePath, '.rover-workspace.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'legacy',
+            path: 'legacy',
+            repository: 'https://github.com/dataforxyz/legacy.git',
+          },
+        ],
+      })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      worktreePath,
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      packageManagers: [],
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(script).toContain(
+      "git clone 'https://github.com/dataforxyz/legacy.git' '/workspace/legacy'"
+    );
+    expect(script).not.toContain('/workspace/frontend');
+  });
+
+  it('does not infer the current config when persisted metadata is malformed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const iterationOnePath = join(root, 'iterations', '1');
+    mkdirSync(iterationOnePath, { recursive: true });
+    writeFileSync(
+      join(iterationOnePath, 'workspace-description.json'),
+      'not json {{{'
+    );
 
     const fakeTask = {
       id: 1,
@@ -1212,6 +1754,67 @@ describe('SetupBuilder multi-repo projects', () => {
     ]);
   });
 
+  it('ignores configured projects whose path escapes through a symlink', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    const outside = mkdtempSync(join(tmpdir(), 'rover-setup-outside-'));
+    testDirs.push(root);
+    testDirs.push(outside);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+    symlinkSync(outside, join(root, 'services'));
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'escaped',
+          path: 'services/api',
+          repository: './repos/missing.git',
+        },
+        {
+          name: 'safe',
+          path: 'frontend',
+          repository: './repos/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/1',
+      },
+    ]);
+    expect(description.projects).toEqual([
+      expect.objectContaining({ name: 'safe', path: 'frontend' }),
+    ]);
+  });
+
   it('ignores unsafe persisted local repositories before resolving mounts', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
@@ -1270,6 +1873,76 @@ describe('SetupBuilder multi-repo projects', () => {
         hostPath: join(root, 'repos', 'frontend.git'),
         containerPath: '/workspace-repos/1',
       },
+    ]);
+  });
+
+  it('ignores persisted projects whose path escapes through a symlink', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    const outside = mkdtempSync(join(tmpdir(), 'rover-setup-outside-'));
+    testDirs.push(root);
+    testDirs.push(outside);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+    symlinkSync(outside, join(root, 'services'));
+
+    const iterationOnePath = join(root, 'iterations', '1');
+    mkdirSync(iterationOnePath, { recursive: true });
+    writeFileSync(
+      join(iterationOnePath, 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'escaped',
+            path: 'services/api',
+            repository: './repos/missing.git',
+          },
+          {
+            name: 'safe',
+            path: 'frontend',
+            repository: './repos/frontend.git',
+          },
+        ],
+      })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/1',
+      },
+    ]);
+    expect(description.projects).toEqual([
+      expect.objectContaining({ name: 'safe', path: 'frontend' }),
     ]);
   });
 });

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -83,6 +83,9 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain(
       "git -C '/workspace/frontend' checkout --detach 'main'"
     );
+    expect(script).toContain(
+      "git -C '/workspace/frontend' checkout -B 'task/1' HEAD"
+    );
   });
 
   it('installs the agent CLI without unsupported install flags', () => {
@@ -443,8 +446,82 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain('🔧 Running initialization scripts');
     expect(script).toContain('🔧 Running initialization script (frontend)');
     expect(script).toContain("cd '/workspace/frontend'");
-    expect(script).toContain('/bin/sh /init-script-1.sh');
+    expect(script).toContain("'/workspace/frontend/scripts/frontend-init.sh'");
     expect(script).not.toContain('/bin/sh /init-script-0.sh');
-    expect(script).not.toContain('echo "🔧 Running initialization script"\n');
+    expect(script).not.toContain("/bin/sh '/workspace/scripts/root-init.sh'");
+  });
+
+  it('resolves dependencies for configured sub-project package managers', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      packageManagers: [],
+      allLanguages: [],
+      allPackageManagers: ['pub', 'gomod', 'uv'],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+          packageManagers: ['pub'],
+        },
+        {
+          name: 'backend',
+          path: 'backend',
+          repository: 'https://github.com/dataforxyz/backend.git',
+          packageManagers: ['gomod'],
+        },
+        {
+          name: 'e2e',
+          path: 'e2e',
+          repository: 'https://github.com/dataforxyz/e2e.git',
+          packageManagers: ['uv'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(script).toContain('Resolving Dart dependencies in frontend');
+    expect(script).toContain(
+      "cd '/workspace/frontend' && flutter pub get 2>/dev/null || dart pub get 2>/dev/null || true"
+    );
+    expect(script).toContain('Resolving Go dependencies in backend');
+    expect(script).toContain(
+      "cd '/workspace/backend' && go mod download 2>/dev/null || true"
+    );
+    expect(script).toContain('Resolving Python dependencies (uv) in e2e');
+    expect(script).toContain(
+      "cd '/workspace/e2e' && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true"
+    );
   });
 });

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -562,6 +562,158 @@ describe('SetupBuilder multi-repo projects', () => {
     });
   });
 
+  it('treats plain relative child repository paths as host mounts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'repos/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(script).toContain(
+      "git clone '/workspace-repos/0' '/workspace/frontend'"
+    );
+  });
+
+  it('resolves local child repositories against the task base path when projectRoot is unavailable', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'repos/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(script).toContain(
+      "git clone '/workspace-repos/0' '/workspace/frontend'"
+    );
+  });
+
+  it('does not treat SCP-style repository URLs as host mounts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'git@github.com:dataforxyz/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(builder.getRepositoryMounts()).toEqual([]);
+    expect(script).toContain(
+      "git clone 'git@github.com:dataforxyz/frontend.git' '/workspace/frontend'"
+    );
+  });
+
   it('does not treat absolute container repository paths as host mounts', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
@@ -777,6 +929,62 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).not.toContain('sha256sum "$repo_path/$relative_path"');
     expect(script).not.toContain(
       "git clone 'https://github.com/dataforxyz/frontend.git' '/workspace/frontend'"
+    );
+  });
+
+  it('does not require checkpoint external repository state for local child repositories during checkpoint resume', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'repos/frontend.git',
+        },
+      ],
+    };
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any,
+      { resumeFromCheckpoint: true }
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(script).toContain(
+      "current_origin=$(git -C '/workspace/frontend' remote get-url origin 2>/dev/null || true)"
+    );
+    expect(script).toContain('Checkpoint file is missing; cannot resume');
+    expect(script).not.toContain('Checkpoint is missing repository state for');
+    expect(script).not.toContain(
+      "current_head=$(git -C '/workspace/frontend' rev-parse HEAD)"
+    );
+    expect(script).not.toContain(
+      "Repository 'frontend' no longer matches the checkpointed revision"
     );
   });
 

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -594,5 +600,95 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain(
       "cd '/workspace/e2e' && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true"
     );
+  });
+
+  it('prefers persisted workspace projects over the current config for existing tasks', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const iterationOnePath = join(root, 'iterations', '1');
+    mkdirSync(iterationOnePath, { recursive: true });
+    writeFileSync(
+      join(iterationOnePath, 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'frontend',
+            path: 'frontend',
+            repository: 'https://github.com/dataforxyz/frontend.git',
+            ref: 'release/1.0',
+            languages: ['python'],
+            packageManagers: ['uv'],
+          },
+        ],
+      })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      languages: ['typescript'],
+      packageManagers: ['pnpm'],
+      allLanguages: ['typescript'],
+      allPackageManagers: ['pnpm'],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'backend',
+          path: 'backend',
+          repository: 'https://github.com/dataforxyz/backend.git',
+          packageManagers: ['npm'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(script).toContain(
+      "git clone 'https://github.com/dataforxyz/frontend.git' '/workspace/frontend'"
+    );
+    expect(script).toContain("Checking out 'release/1.0' for 'frontend'");
+    expect(script).not.toContain('/workspace/backend');
+    expect(script).toContain('Resolving Python dependencies (uv) in frontend');
+    expect(script).not.toContain(
+      'Resolving Node.js dependencies (npm) in backend'
+    );
+    expect(description.projects).toEqual([
+      expect.objectContaining({
+        name: 'frontend',
+        path: 'frontend',
+        repository: 'https://github.com/dataforxyz/frontend.git',
+        ref: 'release/1.0',
+        languages: ['python'],
+        packageManagers: ['uv'],
+      }),
+    ]);
   });
 });

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -744,7 +744,9 @@ describe('SetupBuilder multi-repo projects', () => {
     );
     expect(script).not.toContain("\n'/workspace/scripts/root-init.sh'\n");
     expect(script).not.toContain("/bin/sh '/workspace/scripts/root-init.sh'");
-    expect(script).not.toContain("workspace_root_script_1='/workspace/scripts/frontend-init.sh'");
+    expect(script).not.toContain(
+      "workspace_root_script_1='/workspace/scripts/frontend-init.sh'"
+    );
   });
 
   it('filters unsafe project-scoped init-script paths', () => {

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -350,7 +350,7 @@ describe('SetupBuilder multi-repo projects', () => {
     const repoSyncIndex = script.indexOf('Syncing external repositories');
     const installGoIndex = script.indexOf('📦 Installing go...');
     const goVersionProbeIndex = script.indexOf(
-      'if [ -f /workspace/go.mod ]; then'
+      "for go_mod_path in '/workspace/go.mod' '/workspace/src/go.mod' '/workspace/backend/go.mod' '/workspace/backend/src/go.mod'; do"
     );
 
     expect(repoSyncIndex).toBeGreaterThanOrEqual(0);
@@ -625,7 +625,7 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain(`repo.path === "apps/it'"'"'s-api"`);
   });
 
-  it('hard resets and cleans reused external repositories before checkout', () => {
+  it('hard resets and fully cleans reused external repositories before checkout', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
 
@@ -668,7 +668,7 @@ describe('SetupBuilder multi-repo projects', () => {
     const script = readFileSync(entrypointPath, 'utf8');
 
     expect(script).toContain("git -C '/workspace/frontend' reset --hard HEAD");
-    expect(script).toContain("git -C '/workspace/frontend' clean -fd");
+    expect(script).toContain("git -C '/workspace/frontend' clean -fdx");
     expect(script).toContain(
       "if ! git -C '/workspace/frontend' fetch --all --tags --prune; then"
     );
@@ -730,13 +730,13 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain('🔧 Running initialization scripts');
     expect(script).toContain('🔧 Running initialization script (frontend)');
     expect(script).toContain(
-      "workspace_root_script_1='/workspace/scripts/frontend-init.sh'"
-    );
-    expect(script).toContain(
       "workspace_project_script_1='/workspace/frontend/scripts/frontend-init.sh'"
     );
     expect(script).toContain("workspace_dir_1='/workspace/frontend'");
     expect(script).toContain('if [ -f "$workspace_project_script_1" ]; then');
+    expect(script).toContain(
+      'echo "❌ Initialization script (frontend) not found at $workspace_project_script_1"'
+    );
     expect(script).toContain('bash "$workspace_script_1"');
     expect(script).not.toContain('/bin/sh /init-script-0.sh');
     expect(script).not.toContain(
@@ -744,6 +744,7 @@ describe('SetupBuilder multi-repo projects', () => {
     );
     expect(script).not.toContain("\n'/workspace/scripts/root-init.sh'\n");
     expect(script).not.toContain("/bin/sh '/workspace/scripts/root-init.sh'");
+    expect(script).not.toContain("workspace_root_script_1='/workspace/scripts/frontend-init.sh'");
   });
 
   it('filters unsafe project-scoped init-script paths', () => {
@@ -866,10 +867,8 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain(
       "cd '/workspace/e2e' && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true"
     );
-    expect(script).not.toContain(
-      'export PATH="/workspace/e2e/.venv/bin:$PATH"'
-    );
-    expect(script).not.toContain(
+    expect(script).toContain('export PATH="/workspace/e2e/.venv/bin:$PATH"');
+    expect(script).toContain(
       `echo 'export PATH="/workspace/e2e/.venv/bin:$PATH"' >> $HOME/.profile`
     );
   });
@@ -964,6 +963,121 @@ describe('SetupBuilder multi-repo projects', () => {
     ]);
   });
 
+  it('preserves a root-only workspace when persisted metadata has no projects', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const iterationOnePath = join(root, 'iterations', '1');
+    mkdirSync(iterationOnePath, { recursive: true });
+    writeFileSync(
+      join(iterationOnePath, 'workspace-description.json'),
+      JSON.stringify({ projects: [] })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      packageManagers: [],
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+          packageManagers: ['pnpm'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+    const descPath = builder.generateWorkspaceDescription();
+
+    expect(script).not.toContain('/workspace/frontend');
+    expect(descPath).toBeUndefined();
+  });
+
+  it('preserves a legacy root-only workspace when older iterations have no persisted metadata', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    mkdirSync(join(root, 'iterations', '1'), { recursive: true });
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      packageManagers: [],
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+          packageManagers: ['pnpm'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+    const descPath = builder.generateWorkspaceDescription();
+
+    expect(script).not.toContain('/workspace/frontend');
+    expect(descPath).toBeUndefined();
+  });
+
   it('filters unsafe workspace project paths from persisted metadata and config', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
@@ -1041,6 +1155,119 @@ describe('SetupBuilder multi-repo projects', () => {
         name: 'safe',
         path: 'frontend',
       }),
+    ]);
+  });
+
+  it('ignores unsafe configured local repositories before resolving mounts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'unsafe',
+          path: '../../escape',
+          repository: './repos/missing.git',
+        },
+        {
+          name: 'safe',
+          path: 'frontend',
+          repository: './repos/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/1',
+      },
+    ]);
+  });
+
+  it('ignores unsafe persisted local repositories before resolving mounts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const iterationOnePath = join(root, 'iterations', '1');
+    mkdirSync(iterationOnePath, { recursive: true });
+    writeFileSync(
+      join(iterationOnePath, 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'unsafe',
+            path: '../../escape',
+            repository: './repos/missing.git',
+          },
+          {
+            name: 'safe',
+            path: 'frontend',
+            repository: './repos/frontend.git',
+          },
+        ],
+      })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/1',
+      },
     ]);
   });
 });

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -189,6 +189,58 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
   });
 
+  it('resolves project dependencies on non-cached startup after syncing repositories', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      packageManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'https://github.com/dataforxyz/frontend.git',
+          packageManagers: ['npm'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    const repoSyncIndex = script.indexOf('Syncing external repositories');
+    const dependencyResolutionIndex = script.indexOf(
+      "cd '/workspace/frontend' && npm install 2>/dev/null || true"
+    );
+
+    expect(repoSyncIndex).toBeGreaterThanOrEqual(0);
+    expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
+  });
+
   it('includes repository metadata in workspace description', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -182,17 +182,23 @@ describe('SetupBuilder multi-repo projects', () => {
     );
   });
 
-  it('runs repository sync before dependency resolution in the runtime entrypoint template', () => {
+  it('runs repository sync before package install, init scripts, and dependency resolution in the runtime entrypoint template', () => {
     const script = readFileSync(
       new URL('../entrypoint.sh', import.meta.url),
       'utf8'
     );
 
     const repoSyncIndex = script.indexOf('{projectRepositoriesSection}');
+    const packageInstallIndex = script.indexOf('{installAllPackages}');
+    const initScriptIndex = script.indexOf('{initScriptExecution}');
     const dependencyResolutionIndex = script.indexOf('{workspaceDeps}');
+    const sudoersRemovalIndex = script.indexOf('{sudoersRemoval}');
 
     expect(repoSyncIndex).toBeGreaterThanOrEqual(0);
-    expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
+    expect(packageInstallIndex).toBeGreaterThan(repoSyncIndex);
+    expect(initScriptIndex).toBeGreaterThan(packageInstallIndex);
+    expect(dependencyResolutionIndex).toBeGreaterThan(initScriptIndex);
+    expect(sudoersRemovalIndex).toBeGreaterThan(initScriptIndex);
   });
 
   it('resolves project dependencies on non-cached startup after syncing repositories', () => {
@@ -247,6 +253,111 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
   });
 
+  it('runs init scripts before dependency resolution and sudo removal on non-cached startup', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      packageManagers: ['uv'],
+      mcps: [],
+      initScript: 'scripts/root-init.sh',
+      allInitScripts: [{ script: 'scripts/root-init.sh' }],
+      network: undefined,
+      projectRoot: root,
+      projects: [],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    const initScriptIndex = script.indexOf(
+      "bash '/workspace/scripts/root-init.sh'"
+    );
+    const dependencyResolutionIndex = script.indexOf(
+      "cd '/workspace' && uv sync"
+    );
+    const sudoersRemovalIndex = script.indexOf(
+      'sudo rm -f /etc/sudoers.d/1-agent-setup'
+    );
+
+    expect(initScriptIndex).toBeGreaterThanOrEqual(0);
+    expect(dependencyResolutionIndex).toBeGreaterThan(initScriptIndex);
+    expect(sudoersRemovalIndex).toBeGreaterThan(initScriptIndex);
+  });
+
+  it('syncs repositories before installing languages on non-cached startup', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: ['go'],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      packageManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'backend',
+          path: 'backend',
+          repository: 'https://github.com/dataforxyz/backend.git',
+          languages: ['go'],
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    const repoSyncIndex = script.indexOf('Syncing external repositories');
+    const installGoIndex = script.indexOf('📦 Installing go...');
+    const goVersionProbeIndex = script.indexOf(
+      'if [ -f /workspace/go.mod ]; then'
+    );
+
+    expect(repoSyncIndex).toBeGreaterThanOrEqual(0);
+    expect(installGoIndex).toBeGreaterThan(repoSyncIndex);
+    expect(goVersionProbeIndex).toBeGreaterThan(repoSyncIndex);
+  });
+
   it('includes repository metadata in workspace description', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
@@ -298,6 +409,108 @@ describe('SetupBuilder multi-repo projects', () => {
       ref: 'develop',
       languages: ['python'],
       packageManagers: ['pip'],
+    });
+  });
+
+  it('mounts local child repositories and clones them via container-visible paths', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: './repos/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: join(root, 'repos', 'frontend.git'),
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(script).toContain(
+      "git clone '/workspace-repos/0' '/workspace/frontend'"
+    );
+  });
+
+  it('preserves original local child repository values in workspace description', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+    mkdirSync(join(root, 'repos', 'frontend.git'), { recursive: true });
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: './repos/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(description.projects[0]).toMatchObject({
+      name: 'frontend',
+      path: 'frontend',
+      repository: './repos/frontend.git',
     });
   });
 
@@ -652,6 +865,12 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain('Resolving Python dependencies (uv) in e2e');
     expect(script).toContain(
       "cd '/workspace/e2e' && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true"
+    );
+    expect(script).not.toContain(
+      'export PATH="/workspace/e2e/.venv/bin:$PATH"'
+    );
+    expect(script).not.toContain(
+      `echo 'export PATH="/workspace/e2e/.venv/bin:$PATH"' >> $HOME/.profile`
     );
   });
 

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -181,6 +181,12 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain(
       `git -C '/workspace/backend' checkout -B "$default_branch" "$default_remote_ref"`
     );
+    expect(script).toContain(
+      `echo "🔀 Remote HEAD not advertised for 'backend'; reusing checked out branch $current_branch"`
+    );
+    expect(script).toContain(
+      `echo "🔀 Remote HEAD not advertised for 'backend'; keeping current checkout"`
+    );
   });
 
   it('runs repository sync before package install, init scripts, and dependency resolution in the runtime entrypoint template', () => {
@@ -632,6 +638,59 @@ describe('SetupBuilder multi-repo projects', () => {
           name: 'frontend',
           path: 'frontend',
           repository: hostRepo,
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(false);
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+    expect(script).toContain(
+      "git clone '/workspace-repos/0' '/workspace/frontend'"
+    );
+  });
+
+  it('treats file URL repositories as host mounts', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    const hostRepo = mkdtempSync(join(tmpdir(), 'rover-setup-host-repo-'));
+    testDirs.push(root, hostRepo);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: `file://${hostRepo}`,
         },
       ],
     };

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -714,9 +714,12 @@ describe('SetupBuilder multi-repo projects', () => {
     );
   });
 
-  it('does not treat absolute container repository paths as host mounts', () => {
+  it('treats absolute repository paths under /workspace as host mounts', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
-    testDirs.push(root);
+    const hostRepoRoot = mkdtempSync(join(tmpdir(), 'rover-setup-host-'));
+    const hostRepo = join(hostRepoRoot, 'sources', 'frontend.git');
+    mkdirSync(hostRepo, { recursive: true });
+    testDirs.push(root, hostRepoRoot);
 
     const fakeTask = {
       id: 1,
@@ -741,7 +744,7 @@ describe('SetupBuilder multi-repo projects', () => {
         {
           name: 'frontend',
           path: 'frontend',
-          repository: '/workspace/sources/frontend.git',
+          repository: hostRepo,
         },
       ],
     };
@@ -755,9 +758,14 @@ describe('SetupBuilder multi-repo projects', () => {
     const entrypointPath = builder.generateEntrypoint(false);
     const script = readFileSync(entrypointPath, 'utf8');
 
-    expect(builder.getRepositoryMounts()).toEqual([]);
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
     expect(script).toContain(
-      "git clone '/workspace/sources/frontend.git' '/workspace/frontend'"
+      "git clone '/workspace-repos/0' '/workspace/frontend'"
     );
   });
 
@@ -932,7 +940,7 @@ describe('SetupBuilder multi-repo projects', () => {
     );
   });
 
-  it('does not require checkpoint external repository state for local child repositories during checkpoint resume', () => {
+  it('requires checkpoint external repository state for local child repositories during checkpoint resume', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
 
@@ -979,11 +987,11 @@ describe('SetupBuilder multi-repo projects', () => {
       "current_origin=$(git -C '/workspace/frontend' remote get-url origin 2>/dev/null || true)"
     );
     expect(script).toContain('Checkpoint file is missing; cannot resume');
-    expect(script).not.toContain('Checkpoint is missing repository state for');
-    expect(script).not.toContain(
+    expect(script).toContain('Checkpoint is missing repository state for');
+    expect(script).toContain(
       "current_head=$(git -C '/workspace/frontend' rev-parse HEAD)"
     );
-    expect(script).not.toContain(
+    expect(script).toContain(
       "Repository 'frontend' no longer matches the checkpointed revision"
     );
   });

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -875,6 +875,57 @@ describe('SetupBuilder multi-repo projects', () => {
     );
   });
 
+  it('maps file URL repositories under /workspace back to the host project root', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    const hostRepoRoot = join(root, 'sources');
+    const hostRepo = join(hostRepoRoot, 'frontend.git');
+    mkdirSync(hostRepo, { recursive: true });
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'frontend',
+          path: 'frontend',
+          repository: 'file:///workspace/sources/frontend.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    builder.generateEntrypoint(false);
+
+    expect(builder.getRepositoryMounts()).toEqual([
+      {
+        hostPath: hostRepo,
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+  });
+
   it('validates external repository state during checkpoint resume', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -528,6 +528,54 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).not.toContain("/bin/sh '/workspace/scripts/root-init.sh'");
   });
 
+  it('filters unsafe project-scoped init-script paths', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '1'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [
+        { script: 'scripts/root-init.sh' },
+        { script: 'scripts/bad.sh', path: '../../escape' },
+        { script: 'scripts/frontend-init.sh', path: 'frontend' },
+      ],
+      network: undefined,
+      projectRoot: root,
+      projects: [],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+
+    expect(script).toContain('/workspace/frontend/scripts/frontend-init.sh');
+    expect(script).not.toContain('/workspace/../../escape');
+    expect(script).not.toContain('scripts/bad.sh');
+  });
+
   it('resolves dependencies for configured sub-project package managers', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);
@@ -688,6 +736,86 @@ describe('SetupBuilder multi-repo projects', () => {
         ref: 'release/1.0',
         languages: ['python'],
         packageManagers: ['uv'],
+      }),
+    ]);
+  });
+
+  it('filters unsafe workspace project paths from persisted metadata and config', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
+    testDirs.push(root);
+
+    const iterationOnePath = join(root, 'iterations', '1');
+    mkdirSync(iterationOnePath, { recursive: true });
+    writeFileSync(
+      join(iterationOnePath, 'workspace-description.json'),
+      JSON.stringify({
+        projects: [
+          {
+            name: 'unsafe',
+            path: '../../outside',
+            repository: 'https://github.com/dataforxyz/unsafe.git',
+          },
+          {
+            name: 'safe',
+            path: 'frontend',
+            repository: 'https://github.com/dataforxyz/frontend.git',
+          },
+        ],
+      })
+    );
+
+    const fakeTask = {
+      id: 1,
+      title: 'test',
+      description: 'test',
+      inputs: {},
+      branchName: 'task/1',
+      networkConfig: undefined,
+      getBasePath: () => root,
+      getIterationPath: () => join(root, 'iterations', '2'),
+    };
+
+    const fakeConfig = {
+      allLanguages: [],
+      allPackageManagers: [],
+      allTaskManagers: [],
+      mcps: [],
+      initScript: undefined,
+      allInitScripts: [],
+      network: undefined,
+      projectRoot: root,
+      projects: [
+        {
+          name: 'also-unsafe',
+          path: '/absolute',
+          repository: 'https://github.com/dataforxyz/absolute.git',
+        },
+      ],
+    };
+
+    const builder = new SetupBuilder(
+      fakeTask as any,
+      'claude',
+      fakeConfig as any
+    );
+
+    const entrypointPath = builder.generateEntrypoint(
+      true,
+      'entrypoint.sh',
+      true
+    );
+    const script = readFileSync(entrypointPath, 'utf8');
+    const descPath = builder.generateWorkspaceDescription();
+    const description = JSON.parse(readFileSync(descPath!, 'utf8'));
+
+    expect(script).toContain('/workspace/frontend');
+    expect(script).not.toContain('../../outside');
+    expect(script).not.toContain('/workspace/../../outside');
+    expect(script).not.toContain('/workspace//absolute');
+    expect(description.projects).toEqual([
+      expect.objectContaining({
+        name: 'safe',
+        path: 'frontend',
       }),
     ]);
   });

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -522,8 +522,8 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain(
       "workspace_project_script_1='/workspace/frontend/scripts/frontend-init.sh'"
     );
-    expect(script).toContain("workspace_dir_1='/workspace'");
     expect(script).toContain("workspace_dir_1='/workspace/frontend'");
+    expect(script).toContain('if [ -f "$workspace_project_script_1" ]; then');
     expect(script).toContain('bash "$workspace_script_1"');
     expect(script).not.toContain('/bin/sh /init-script-0.sh');
     expect(script).not.toContain(

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -516,10 +516,15 @@ describe('SetupBuilder multi-repo projects', () => {
 
     expect(script).toContain('🔧 Running initialization scripts');
     expect(script).toContain('🔧 Running initialization script (frontend)');
-    expect(script).toContain("cd '/workspace/frontend'");
     expect(script).toContain(
-      "bash '/workspace/frontend/scripts/frontend-init.sh'"
+      "workspace_root_script_1='/workspace/scripts/frontend-init.sh'"
     );
+    expect(script).toContain(
+      "workspace_project_script_1='/workspace/frontend/scripts/frontend-init.sh'"
+    );
+    expect(script).toContain("workspace_dir_1='/workspace'");
+    expect(script).toContain("workspace_dir_1='/workspace/frontend'");
+    expect(script).toContain('bash "$workspace_script_1"');
     expect(script).not.toContain('/bin/sh /init-script-0.sh');
     expect(script).not.toContain(
       "\n'/workspace/frontend/scripts/frontend-init.sh'\n"

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -446,8 +446,14 @@ describe('SetupBuilder multi-repo projects', () => {
     expect(script).toContain('🔧 Running initialization scripts');
     expect(script).toContain('🔧 Running initialization script (frontend)');
     expect(script).toContain("cd '/workspace/frontend'");
-    expect(script).toContain("'/workspace/frontend/scripts/frontend-init.sh'");
+    expect(script).toContain(
+      "bash '/workspace/frontend/scripts/frontend-init.sh'"
+    );
     expect(script).not.toContain('/bin/sh /init-script-0.sh');
+    expect(script).not.toContain(
+      "\n'/workspace/frontend/scripts/frontend-init.sh'\n"
+    );
+    expect(script).not.toContain("\n'/workspace/scripts/root-init.sh'\n");
     expect(script).not.toContain("/bin/sh '/workspace/scripts/root-init.sh'");
   });
 

--- a/packages/cli/src/lib/__tests__/setup.test.ts
+++ b/packages/cli/src/lib/__tests__/setup.test.ts
@@ -176,6 +176,19 @@ describe('SetupBuilder multi-repo projects', () => {
     );
   });
 
+  it('runs repository sync before dependency resolution in the runtime entrypoint template', () => {
+    const script = readFileSync(
+      new URL('../entrypoint.sh', import.meta.url),
+      'utf8'
+    );
+
+    const repoSyncIndex = script.indexOf('{projectRepositoriesSection}');
+    const dependencyResolutionIndex = script.indexOf('{workspaceDeps}');
+
+    expect(repoSyncIndex).toBeGreaterThanOrEqual(0);
+    expect(dependencyResolutionIndex).toBeGreaterThan(repoSyncIndex);
+  });
+
   it('includes repository metadata in workspace description', () => {
     const root = mkdtempSync(join(tmpdir(), 'rover-setup-test-'));
     testDirs.push(root);

--- a/packages/cli/src/lib/__tests__/workflow.test.ts
+++ b/packages/cli/src/lib/__tests__/workflow.test.ts
@@ -158,17 +158,25 @@ describe('workflow utilities', () => {
         expect(typeof step.id).toBe('string');
         expect(step.id.length).toBeGreaterThan(0);
 
-        expect(step.type).toBe('agent');
+        expect(['agent', 'command', 'loop']).toContain(step.type);
 
         expect(step.name).toBeDefined();
         expect(typeof step.name).toBe('string');
 
-        expect(step.prompt).toBeDefined();
-        expect(typeof step.prompt).toBe('string');
-        expect(step.prompt.length).toBeGreaterThan(0);
+        if (step.type === 'agent') {
+          expect(step.prompt).toBeDefined();
+          expect(typeof step.prompt).toBe('string');
+          expect(step.prompt.length).toBeGreaterThan(0);
 
-        expect(step.outputs).toBeDefined();
-        expect(Array.isArray(step.outputs)).toBe(true);
+          expect(step.outputs).toBeDefined();
+          expect(Array.isArray(step.outputs)).toBe(true);
+        }
+
+        if (step.type === 'command') {
+          expect(step.command).toBeDefined();
+          expect(typeof step.command).toBe('string');
+          expect(step.command.length).toBeGreaterThan(0);
+        }
       }
     });
 
@@ -405,6 +413,10 @@ describe('workflow utilities', () => {
 
       // Check that step prompts reference valid inputs and previous steps
       for (const step of sweWorkflow!.steps) {
+        if (!step.prompt) {
+          continue;
+        }
+
         // Prompts should not be empty
         expect(step.prompt.trim().length).toBeGreaterThan(0);
 
@@ -439,6 +451,10 @@ describe('workflow utilities', () => {
 
       // Check that step prompts can contain input references
       for (const step of sweWorkflow!.steps) {
+        if (!step.prompt) {
+          continue;
+        }
+
         // Extract input references from prompt (e.g., {{inputs.description}})
         const inputReferencePattern = /{{inputs\.(\w+)}}/g;
         const matches = [...step.prompt.matchAll(inputReferencePattern)];
@@ -465,8 +481,10 @@ describe('workflow utilities', () => {
             continue;
           }
 
-          // Each step should have outputs defined
-          expect(step.outputs).toBeDefined();
+          if (!step.outputs) {
+            continue;
+          }
+
           expect(Array.isArray(step.outputs)).toBe(true);
 
           // Each output should have required properties

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -6,7 +6,7 @@ import {
   symlinkSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   getWorkspaceDescriptionRepositories,
@@ -73,6 +73,39 @@ describe('workspace-repositories', () => {
         'not json {{{'
       );
       expect(getWorkspaceDescriptionRepositories(dir)).toEqual([]);
+    });
+
+    it('falls back to the newest parseable persisted description', () => {
+      const dir = makeTmpDir();
+      const olderIterationDir = makeIterationDir(dir, 1);
+      const latestIterationDir = makeIterationDir(dir, 2);
+      writeFileSync(
+        join(latestIterationDir, 'workspace-description.json'),
+        'not json {{{'
+      );
+      writeFileSync(
+        join(olderIterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: 'https://example.com/frontend.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toEqual([
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: join(dir, 'frontend'),
+          repository: 'https://example.com/frontend.git',
+          ref: undefined,
+        },
+      ]);
     });
 
     it('returns empty array when projects is not an array', () => {
@@ -229,6 +262,29 @@ describe('workspace-repositories', () => {
       const result = getWorkspaceDescriptionRepositories(dir);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('latest');
+    });
+
+    it('falls back to the newest iteration that actually has persisted metadata', () => {
+      const dir = makeTmpDir();
+      const olderIterationDir = makeIterationDir(dir, 1);
+      makeIterationDir(dir, 2);
+
+      writeFileSync(
+        join(olderIterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'older',
+              path: 'older',
+              repository: 'https://example.com/older.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('older');
     });
 
     it('falls back to legacy worktree metadata when persisted iteration metadata is absent', () => {
@@ -498,7 +554,7 @@ describe('workspace-repositories', () => {
       expect(result[0].name).toBe('from-config');
     });
 
-    it('falls back to project config when description file has empty projects', () => {
+    it('preserves a root-only workspace when description file has empty projects', () => {
       const dir = makeTmpDir();
       writeFileSync(
         join(dir, '.rover-workspace.json'),
@@ -515,9 +571,48 @@ describe('workspace-repositories', () => {
         ],
       } as any;
 
-      const result = getWorkspaceRepositories(dir, dir, config);
-      expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('fallback');
+      const result = getWorkspaceRepositories(dir, dirname(dir), config);
+      expect(result).toEqual([]);
+    });
+
+    it('preserves a legacy root-only task when iterations exist without workspace descriptions', () => {
+      const dir = makeTmpDir();
+      makeIterationDir(dir, 1);
+
+      const config = {
+        projects: [
+          {
+            name: 'fallback',
+            path: 'fb',
+            repository: 'https://example.com/fb.git',
+          },
+        ],
+      } as any;
+
+      const result = getWorkspaceRepositories(dir, dirname(dir), config);
+      expect(result).toEqual([]);
+    });
+
+    it('does not infer current config when persisted workspace metadata is malformed', () => {
+      const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 1);
+      writeFileSync(
+        join(iterationDir, 'workspace-description.json'),
+        'not json {{{'
+      );
+
+      const config = {
+        projects: [
+          {
+            name: 'fallback',
+            path: 'fb',
+            repository: 'https://example.com/fb.git',
+          },
+        ],
+      } as any;
+
+      const result = getWorkspaceRepositories(dir, dirname(dir), config);
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   getWorkspaceDescriptionRepositories,
   getConfiguredWorkspaceRepositories,
+  getWorkspaceRepositoriesLookupResult,
   getWorkspaceRepositories,
 } from '../workspace-repositories.js';
 
@@ -505,6 +506,66 @@ describe('workspace-repositories', () => {
   });
 
   // ── getWorkspaceRepositories (priority fallback) ──────────────────
+
+  describe('getWorkspaceRepositoriesLookupResult', () => {
+    it('reports config fallback when no persisted workspace description exists', () => {
+      const dir = makeTmpDir();
+      const config = {
+        projects: [
+          {
+            name: 'from-config',
+            path: 'cfg',
+            repository: 'https://example.com/cfg.git',
+          },
+        ],
+      } as any;
+
+      const result = getWorkspaceRepositoriesLookupResult(dir, dir, config);
+      expect(result).toEqual({
+        foundPersistedState: false,
+        hasPersistedParseErrors: false,
+        repositories: [
+          {
+            name: 'from-config',
+            relativePath: 'cfg',
+            worktreePath: join(dir, 'cfg'),
+            repository: 'https://example.com/cfg.git',
+            ref: undefined,
+          },
+        ],
+      });
+    });
+
+    it('reports persisted state when workspace description exists even if malformed', () => {
+      const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 1);
+      writeFileSync(
+        join(iterationDir, 'workspace-description.json'),
+        'not json {{{'
+      );
+
+      const config = {
+        projects: [
+          {
+            name: 'from-config',
+            path: 'cfg',
+            repository: 'https://example.com/cfg.git',
+          },
+        ],
+      } as any;
+
+      const result = getWorkspaceRepositoriesLookupResult(
+        dir,
+        dirname(dir),
+        config
+      );
+      expect(result).toEqual({
+        foundPersistedState: true,
+        hasPersistedParseErrors: true,
+        repositories: [],
+      });
+    });
+  });
 
   describe('getWorkspaceRepositories', () => {
     it('prefers workspace description over project config', () => {

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -575,7 +575,7 @@ describe('workspace-repositories', () => {
       expect(result).toEqual([]);
     });
 
-    it('preserves a legacy root-only task when iterations exist without workspace descriptions', () => {
+    it('falls back to project config when iterations exist without workspace descriptions', () => {
       const dir = makeTmpDir();
       makeIterationDir(dir, 1);
 
@@ -590,7 +590,15 @@ describe('workspace-repositories', () => {
       } as any;
 
       const result = getWorkspaceRepositories(dir, dirname(dir), config);
-      expect(result).toEqual([]);
+      expect(result).toEqual([
+        {
+          name: 'fallback',
+          relativePath: 'fb',
+          worktreePath: join(dir, 'fb'),
+          repository: 'https://example.com/fb.git',
+          ref: undefined,
+        },
+      ]);
     });
 
     it('does not infer current config when persisted workspace metadata is malformed', () => {

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  mkdirSync,
+  symlinkSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -281,6 +287,30 @@ describe('workspace-repositories', () => {
       expect(result).toHaveLength(0);
     });
 
+    it('rejects projects whose path escapes through a symlink in workspace description', () => {
+      const dir = makeTmpDir();
+      const outsideRepo = mkdtempSync(join(tmpdir(), 'rover-ws-outside-'));
+      testRoots.push(outsideRepo);
+      symlinkSync(outsideRepo, join(dir, 'services'));
+
+      const iterationDir = makeIterationDir(dir, 1);
+      writeFileSync(
+        join(iterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'escaped',
+              path: 'services/api',
+              repository: 'https://example.com/evil.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toEqual([]);
+    });
+
     it('rejects projects with path traversal in project config', () => {
       const dir = makeTmpDir();
       const config = {
@@ -301,6 +331,26 @@ describe('workspace-repositories', () => {
       const result = getConfiguredWorkspaceRepositories(dir, config);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('safe');
+    });
+
+    it('rejects configured projects whose path escapes through a symlink', () => {
+      const dir = makeTmpDir();
+      const outsideRepo = mkdtempSync(join(tmpdir(), 'rover-ws-outside-'));
+      testRoots.push(outsideRepo);
+      symlinkSync(outsideRepo, join(dir, 'services'));
+
+      const config = {
+        projects: [
+          {
+            name: 'escaped',
+            path: 'services/api',
+            repository: 'https://example.com/evil.git',
+          },
+        ],
+      } as any;
+
+      const result = getConfiguredWorkspaceRepositories(dir, config);
+      expect(result).toEqual([]);
     });
   });
 

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -25,6 +25,20 @@ describe('workspace-repositories', () => {
     return worktreeDir;
   }
 
+  function makeCentralTaskDirs(): {
+    rootDir: string;
+    taskDir: string;
+    worktreeDir: string;
+  } {
+    const rootDir = mkdtempSync(join(tmpdir(), 'rover-ws-repo-central-test-'));
+    const taskDir = join(rootDir, 'tasks', '42');
+    const worktreeDir = join(rootDir, 'workspaces', '42');
+    mkdirSync(taskDir, { recursive: true });
+    mkdirSync(worktreeDir, { recursive: true });
+    testRoots.push(rootDir);
+    return { rootDir, taskDir, worktreeDir };
+  }
+
   function makeIterationDir(worktreeDir: string, iteration: number): string {
     const iterationDir = join(
       worktreeDir,
@@ -236,6 +250,35 @@ describe('workspace-repositories', () => {
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('legacy');
     });
+
+    it('reads persisted metadata from the task directory for centralized workspaces', () => {
+      const { taskDir, worktreeDir } = makeCentralTaskDirs();
+      const iterationDir = join(taskDir, 'iterations', '3');
+      mkdirSync(iterationDir, { recursive: true });
+      writeFileSync(
+        join(iterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: 'https://example.com/frontend.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(worktreeDir, taskDir);
+      expect(result).toEqual([
+        {
+          name: 'frontend',
+          relativePath: 'frontend',
+          worktreePath: join(worktreeDir, 'frontend'),
+          repository: 'https://example.com/frontend.git',
+          ref: undefined,
+        },
+      ]);
+    });
   });
 
   // ── path traversal protection ─────────────────────────────────────
@@ -433,7 +476,7 @@ describe('workspace-repositories', () => {
         ],
       } as any;
 
-      const result = getWorkspaceRepositories(dir, config);
+      const result = getWorkspaceRepositories(dir, dir, config);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('from-description');
     });
@@ -450,7 +493,7 @@ describe('workspace-repositories', () => {
         ],
       } as any;
 
-      const result = getWorkspaceRepositories(dir, config);
+      const result = getWorkspaceRepositories(dir, dir, config);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('from-config');
     });
@@ -472,7 +515,7 @@ describe('workspace-repositories', () => {
         ],
       } as any;
 
-      const result = getWorkspaceRepositories(dir, config);
+      const result = getWorkspaceRepositories(dir, dir, config);
       expect(result).toHaveLength(1);
       expect(result[0].name).toBe('fallback');
     });

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -232,6 +232,78 @@ describe('workspace-repositories', () => {
     });
   });
 
+  // ── path traversal protection ─────────────────────────────────────
+
+  describe('path traversal protection', () => {
+    it('rejects projects with path traversal in workspace description', () => {
+      const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 1);
+      writeFileSync(
+        join(iterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'escape',
+              path: '../../etc',
+              repository: 'https://example.com/evil.git',
+            },
+            {
+              name: 'safe',
+              path: 'frontend',
+              repository: 'https://example.com/safe.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('safe');
+    });
+
+    it('rejects projects with absolute paths in workspace description', () => {
+      const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 1);
+      writeFileSync(
+        join(iterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'abs',
+              path: '/tmp/evil',
+              repository: 'https://example.com/evil.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toHaveLength(0);
+    });
+
+    it('rejects projects with path traversal in project config', () => {
+      const dir = makeTmpDir();
+      const config = {
+        projects: [
+          {
+            name: 'escape',
+            path: '../../../etc/passwd',
+            repository: 'https://example.com/evil.git',
+          },
+          {
+            name: 'safe',
+            path: 'backend',
+            repository: 'https://example.com/safe.git',
+          },
+        ],
+      } as any;
+
+      const result = getConfiguredWorkspaceRepositories(dir, config);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('safe');
+    });
+  });
+
   // ── getConfiguredWorkspaceRepositories ────────────────────────────
 
   describe('getConfiguredWorkspaceRepositories', () => {

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -9,39 +9,57 @@ import {
 } from '../workspace-repositories.js';
 
 describe('workspace-repositories', () => {
-  const testDirs: string[] = [];
+  const testRoots: string[] = [];
 
   function makeTmpDir(): string {
-    const dir = mkdtempSync(join(tmpdir(), 'rover-ws-repo-test-'));
-    testDirs.push(dir);
-    return dir;
+    const rootDir = mkdtempSync(join(tmpdir(), 'rover-ws-repo-test-'));
+    const worktreeDir = join(rootDir, 'workspace');
+    mkdirSync(worktreeDir, { recursive: true });
+    testRoots.push(rootDir);
+    return worktreeDir;
+  }
+
+  function makeIterationDir(worktreeDir: string, iteration: number): string {
+    const iterationDir = join(
+      worktreeDir,
+      '..',
+      'iterations',
+      iteration.toString()
+    );
+    mkdirSync(iterationDir, { recursive: true });
+    return iterationDir;
   }
 
   afterEach(() => {
-    for (const dir of testDirs) {
-      rmSync(dir, { recursive: true, force: true });
+    for (const rootDir of testRoots) {
+      rmSync(rootDir, { recursive: true, force: true });
     }
-    testDirs.length = 0;
+    testRoots.length = 0;
   });
 
   // ── getWorkspaceDescriptionRepositories ───────────────────────────
 
   describe('getWorkspaceDescriptionRepositories', () => {
-    it('returns empty array when .rover-workspace.json does not exist', () => {
+    it('returns empty array when no persisted description exists', () => {
       const dir = makeTmpDir();
       expect(getWorkspaceDescriptionRepositories(dir)).toEqual([]);
     });
 
-    it('returns empty array for malformed JSON', () => {
+    it('returns empty array for malformed persisted JSON', () => {
       const dir = makeTmpDir();
-      writeFileSync(join(dir, '.rover-workspace.json'), 'not json {{{');
+      const iterationDir = makeIterationDir(dir, 1);
+      writeFileSync(
+        join(iterationDir, 'workspace-description.json'),
+        'not json {{{'
+      );
       expect(getWorkspaceDescriptionRepositories(dir)).toEqual([]);
     });
 
     it('returns empty array when projects is not an array', () => {
       const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 1);
       writeFileSync(
-        join(dir, '.rover-workspace.json'),
+        join(iterationDir, 'workspace-description.json'),
         JSON.stringify({ projects: 'not-an-array' })
       );
       expect(getWorkspaceDescriptionRepositories(dir)).toEqual([]);
@@ -49,8 +67,9 @@ describe('workspace-repositories', () => {
 
     it('filters out projects missing required fields', () => {
       const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 1);
       writeFileSync(
-        join(dir, '.rover-workspace.json'),
+        join(iterationDir, 'workspace-description.json'),
         JSON.stringify({
           projects: [
             {
@@ -84,8 +103,9 @@ describe('workspace-repositories', () => {
 
     it('parses valid workspace description correctly', () => {
       const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 2);
       writeFileSync(
-        join(dir, '.rover-workspace.json'),
+        join(iterationDir, 'workspace-description.json'),
         JSON.stringify({
           projects: [
             {
@@ -123,8 +143,9 @@ describe('workspace-repositories', () => {
 
     it('ignores non-string ref values', () => {
       const dir = makeTmpDir();
+      const iterationDir = makeIterationDir(dir, 1);
       writeFileSync(
-        join(dir, '.rover-workspace.json'),
+        join(iterationDir, 'workspace-description.json'),
         JSON.stringify({
           projects: [
             {
@@ -139,6 +160,75 @@ describe('workspace-repositories', () => {
 
       const result = getWorkspaceDescriptionRepositories(dir);
       expect(result[0].ref).toBeUndefined();
+    });
+
+    it('prefers the latest persisted iteration description over legacy worktree metadata', () => {
+      const dir = makeTmpDir();
+      const olderIterationDir = makeIterationDir(dir, 1);
+      const latestIterationDir = makeIterationDir(dir, 2);
+
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'legacy',
+              path: 'legacy',
+              repository: 'https://example.com/legacy.git',
+            },
+          ],
+        })
+      );
+
+      writeFileSync(
+        join(olderIterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'older',
+              path: 'older',
+              repository: 'https://example.com/older.git',
+            },
+          ],
+        })
+      );
+
+      writeFileSync(
+        join(latestIterationDir, 'workspace-description.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'latest',
+              path: 'latest',
+              repository: 'https://example.com/latest.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('latest');
+    });
+
+    it('falls back to legacy worktree metadata when persisted iteration metadata is absent', () => {
+      const dir = makeTmpDir();
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'legacy',
+              path: 'legacy',
+              repository: 'https://example.com/legacy.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('legacy');
     });
   });
 

--- a/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
+++ b/packages/cli/src/lib/__tests__/workspace-repositories.test.ts
@@ -1,0 +1,268 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getWorkspaceDescriptionRepositories,
+  getConfiguredWorkspaceRepositories,
+  getWorkspaceRepositories,
+} from '../workspace-repositories.js';
+
+describe('workspace-repositories', () => {
+  const testDirs: string[] = [];
+
+  function makeTmpDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'rover-ws-repo-test-'));
+    testDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    for (const dir of testDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    testDirs.length = 0;
+  });
+
+  // ── getWorkspaceDescriptionRepositories ───────────────────────────
+
+  describe('getWorkspaceDescriptionRepositories', () => {
+    it('returns empty array when .rover-workspace.json does not exist', () => {
+      const dir = makeTmpDir();
+      expect(getWorkspaceDescriptionRepositories(dir)).toEqual([]);
+    });
+
+    it('returns empty array for malformed JSON', () => {
+      const dir = makeTmpDir();
+      writeFileSync(join(dir, '.rover-workspace.json'), 'not json {{{');
+      expect(getWorkspaceDescriptionRepositories(dir)).toEqual([]);
+    });
+
+    it('returns empty array when projects is not an array', () => {
+      const dir = makeTmpDir();
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({ projects: 'not-an-array' })
+      );
+      expect(getWorkspaceDescriptionRepositories(dir)).toEqual([]);
+    });
+
+    it('filters out projects missing required fields', () => {
+      const dir = makeTmpDir();
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'valid',
+              path: 'valid-path',
+              repository: 'https://example.com/repo.git',
+            },
+            {
+              name: 'missing-path',
+              repository: 'https://example.com/repo.git',
+            },
+            {
+              path: 'missing-name',
+              repository: 'https://example.com/repo.git',
+            },
+            { name: 'missing-repo', path: 'some-path' },
+            {
+              name: 123,
+              path: 'num-name',
+              repository: 'https://example.com/repo.git',
+            },
+            null,
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('valid');
+    });
+
+    it('parses valid workspace description correctly', () => {
+      const dir = makeTmpDir();
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'frontend',
+              path: 'frontend',
+              repository: 'https://github.com/org/frontend.git',
+              ref: 'main',
+            },
+            {
+              name: 'backend',
+              path: 'backend',
+              repository: 'https://github.com/org/backend.git',
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        name: 'frontend',
+        relativePath: 'frontend',
+        worktreePath: join(dir, 'frontend'),
+        repository: 'https://github.com/org/frontend.git',
+        ref: 'main',
+      });
+      expect(result[1]).toEqual({
+        name: 'backend',
+        relativePath: 'backend',
+        worktreePath: join(dir, 'backend'),
+        repository: 'https://github.com/org/backend.git',
+        ref: undefined,
+      });
+    });
+
+    it('ignores non-string ref values', () => {
+      const dir = makeTmpDir();
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'app',
+              path: 'app',
+              repository: 'https://example.com/app.git',
+              ref: 42,
+            },
+          ],
+        })
+      );
+
+      const result = getWorkspaceDescriptionRepositories(dir);
+      expect(result[0].ref).toBeUndefined();
+    });
+  });
+
+  // ── getConfiguredWorkspaceRepositories ────────────────────────────
+
+  describe('getConfiguredWorkspaceRepositories', () => {
+    it('returns empty array when projectConfig has no projects', () => {
+      const dir = makeTmpDir();
+      const config = { projects: undefined } as any;
+      expect(getConfiguredWorkspaceRepositories(dir, config)).toEqual([]);
+    });
+
+    it('filters projects without repository field', () => {
+      const dir = makeTmpDir();
+      const config = {
+        projects: [
+          {
+            name: 'has-repo',
+            path: 'a',
+            repository: 'https://example.com/a.git',
+          },
+          { name: 'no-repo', path: 'b' },
+        ],
+      } as any;
+
+      const result = getConfiguredWorkspaceRepositories(dir, config);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('has-repo');
+    });
+
+    it('maps project config entries to WorkspaceRepository shape', () => {
+      const dir = makeTmpDir();
+      const config = {
+        projects: [
+          {
+            name: 'svc',
+            path: 'services/svc',
+            repository: 'git@github.com:org/svc.git',
+            ref: 'develop',
+          },
+        ],
+      } as any;
+
+      const result = getConfiguredWorkspaceRepositories(dir, config);
+      expect(result[0]).toEqual({
+        name: 'svc',
+        relativePath: 'services/svc',
+        worktreePath: join(dir, 'services/svc'),
+        repository: 'git@github.com:org/svc.git',
+        ref: 'develop',
+      });
+    });
+  });
+
+  // ── getWorkspaceRepositories (priority fallback) ──────────────────
+
+  describe('getWorkspaceRepositories', () => {
+    it('prefers workspace description over project config', () => {
+      const dir = makeTmpDir();
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({
+          projects: [
+            {
+              name: 'from-description',
+              path: 'desc',
+              repository: 'https://example.com/desc.git',
+            },
+          ],
+        })
+      );
+
+      const config = {
+        projects: [
+          {
+            name: 'from-config',
+            path: 'cfg',
+            repository: 'https://example.com/cfg.git',
+          },
+        ],
+      } as any;
+
+      const result = getWorkspaceRepositories(dir, config);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('from-description');
+    });
+
+    it('falls back to project config when no description file exists', () => {
+      const dir = makeTmpDir();
+      const config = {
+        projects: [
+          {
+            name: 'from-config',
+            path: 'cfg',
+            repository: 'https://example.com/cfg.git',
+          },
+        ],
+      } as any;
+
+      const result = getWorkspaceRepositories(dir, config);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('from-config');
+    });
+
+    it('falls back to project config when description file has empty projects', () => {
+      const dir = makeTmpDir();
+      writeFileSync(
+        join(dir, '.rover-workspace.json'),
+        JSON.stringify({ projects: [] })
+      );
+
+      const config = {
+        projects: [
+          {
+            name: 'fallback',
+            path: 'fb',
+            repository: 'https://example.com/fb.git',
+          },
+        ],
+      } as any;
+
+      const result = getWorkspaceRepositories(dir, config);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('fallback');
+    });
+  });
+});

--- a/packages/cli/src/lib/claude-usage.ts
+++ b/packages/cli/src/lib/claude-usage.ts
@@ -40,6 +40,18 @@ export interface UsageCheckResult {
   limitingBucket: string | null;
 }
 
+function isUsageBucket(
+  bucket: ClaudeUsageResponse[keyof ClaudeUsageResponse]
+): bucket is UsageBucket {
+  return (
+    bucket != null &&
+    typeof bucket === 'object' &&
+    'resets_at' in bucket &&
+    typeof bucket.resets_at === 'string' &&
+    typeof bucket.utilization === 'number'
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Credential reading
 // ---------------------------------------------------------------------------
@@ -214,7 +226,7 @@ export function analyzeUsage(
 
   for (const name of bucketNames) {
     const bucket = usage[name];
-    if (!bucket) continue;
+    if (!isUsageBucket(bucket)) continue;
 
     const util = bucket.utilization;
     if (util > highestUtilization) {

--- a/packages/cli/src/lib/codex-usage.ts
+++ b/packages/cli/src/lib/codex-usage.ts
@@ -104,7 +104,9 @@ export function invalidateCodexUsageCache(): void {
   cacheTimestamp = 0;
 }
 
-function normalizeWindow(w: CodexRateWindow | null | undefined): NormalizedBucket | null {
+function normalizeWindow(
+  w: CodexRateWindow | null | undefined
+): NormalizedBucket | null {
   if (!w) return null;
   return {
     utilization: w.used_percent,
@@ -221,14 +223,22 @@ export function analyzeCodexUsage(
   if (model) {
     const modelLower = model.toLowerCase();
     for (const [slug, limits] of Object.entries(usage.models)) {
-      if (slug.toLowerCase().includes(modelLower) || modelLower.includes(slug.toLowerCase())) {
+      if (
+        slug.toLowerCase().includes(modelLower) ||
+        modelLower.includes(slug.toLowerCase())
+      ) {
         checkBucket(limits.five_hour, `${slug}/five_hour`);
         checkBucket(limits.seven_day, `${slug}/seven_day`);
       }
     }
   }
 
-  return { isExhausted, resetsAt: earliestReset, utilization: highestUtil, limitingBucket };
+  return {
+    isExhausted,
+    resetsAt: earliestReset,
+    utilization: highestUtil,
+    limitingBucket,
+  };
 }
 
 /**

--- a/packages/cli/src/lib/dependency-resolution.ts
+++ b/packages/cli/src/lib/dependency-resolution.ts
@@ -7,6 +7,7 @@
  */
 
 import { shellEscape } from '../utils/shell.js';
+import { isSafeRelativePath } from '../utils/path-safety.js';
 
 interface DependencyLocation {
   path: string;
@@ -36,11 +37,13 @@ export function getDependencyResolutionCommands(
       packageManagers: config.rootPackageManagers,
       label: 'workspace root',
     },
-    ...(config.projects ?? []).map(project => ({
-      path: `/workspace/${project.path}`,
-      packageManagers: project.packageManagers ?? [],
-      label: project.path,
-    })),
+    ...(config.projects ?? [])
+      .filter(project => isSafeRelativePath(project.path))
+      .map(project => ({
+        path: `/workspace/${project.path}`,
+        packageManagers: project.packageManagers ?? [],
+        label: project.path,
+      })),
   ];
 
   for (const location of locations) {
@@ -53,7 +56,7 @@ export function getDependencyResolutionCommands(
         `  echo "📦 Resolving Python dependencies (uv) in ${location.label}..."`,
         `  cd ${quotedPath} && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true`
       );
-      if (config.addVenvPathExports) {
+      if (config.addVenvPathExports && location.path === '/workspace') {
         commands.push(
           `  if [ -d ${quotedPath}/.venv/bin ]; then`,
           `    export PATH="${location.path}/.venv/bin:$PATH"`,

--- a/packages/cli/src/lib/dependency-resolution.ts
+++ b/packages/cli/src/lib/dependency-resolution.ts
@@ -1,0 +1,179 @@
+/**
+ * Shared dependency resolution command generation for build and setup entrypoints.
+ *
+ * Both `build.ts` (cache image builds) and `setup.ts` (task entrypoints) need to
+ * generate shell commands that resolve workspace dependencies. This module provides
+ * a single implementation to keep them in sync.
+ */
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}' `;
+}
+
+interface DependencyLocation {
+  path: string;
+  packageManagers: string[];
+  label: string;
+}
+
+interface ProjectEntry {
+  path: string;
+  packageManagers?: string[];
+}
+
+interface DependencyResolutionConfig {
+  rootPackageManagers: string[];
+  projects?: ProjectEntry[];
+  /** Whether to add venv PATH exports for uv projects (used in setup, not build) */
+  addVenvPathExports?: boolean;
+}
+
+export function getDependencyResolutionCommands(
+  config: DependencyResolutionConfig
+): string[] {
+  const commands: string[] = [];
+  const locations: DependencyLocation[] = [
+    {
+      path: '/workspace',
+      packageManagers: config.rootPackageManagers,
+      label: 'workspace root',
+    },
+    ...(config.projects ?? []).map(project => ({
+      path: `/workspace/${project.path}`,
+      packageManagers: project.packageManagers ?? [],
+      label: project.path,
+    })),
+  ];
+
+  for (const location of locations) {
+    const quotedPath = shellEscape(location.path).trim();
+    const pms = location.packageManagers;
+
+    if (pms.includes('uv')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pyproject.toml ]; then`,
+        `  echo "📦 Resolving Python dependencies (uv) in ${location.label}..."`,
+        `  cd ${quotedPath} && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true`
+      );
+      if (config.addVenvPathExports) {
+        commands.push(
+          `  if [ -d ${quotedPath}/.venv/bin ]; then`,
+          `    export PATH="${location.path}/.venv/bin:$PATH"`,
+          `    echo 'export PATH="${location.path}/.venv/bin:$PATH"' >> $HOME/.profile`,
+          '  fi'
+        );
+      }
+      commands.push('fi');
+    }
+
+    if (pms.includes('poetry')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pyproject.toml ]; then`,
+        `  echo "📦 Resolving Python dependencies (poetry) in ${location.label}..."`,
+        `  cd ${quotedPath} && poetry install --no-interaction 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('pub')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pubspec.yaml ]; then`,
+        `  echo "📦 Resolving Dart dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && flutter pub get 2>/dev/null || dart pub get 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('npm')) {
+      commands.push(
+        `if [ -f ${quotedPath}/package-lock.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (npm) in ${location.label}..."`,
+        `  cd ${quotedPath} && npm ci 2>/dev/null || npm install 2>/dev/null || true`,
+        `elif [ -f ${quotedPath}/package.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (npm) in ${location.label}..."`,
+        `  cd ${quotedPath} && npm install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('pnpm')) {
+      commands.push(
+        `if [ -f ${quotedPath}/pnpm-lock.yaml ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (pnpm) in ${location.label}..."`,
+        `  cd ${quotedPath} && pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true`,
+        `elif [ -f ${quotedPath}/package.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (pnpm) in ${location.label}..."`,
+        `  cd ${quotedPath} && pnpm install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('yarn')) {
+      commands.push(
+        `if [ -f ${quotedPath}/yarn.lock ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (yarn) in ${location.label}..."`,
+        `  cd ${quotedPath} && yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true`,
+        `elif [ -f ${quotedPath}/package.json ]; then`,
+        `  echo "📦 Resolving Node.js dependencies (yarn) in ${location.label}..."`,
+        `  cd ${quotedPath} && yarn install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('composer')) {
+      commands.push(
+        `if [ -f ${quotedPath}/composer.json ]; then`,
+        `  echo "📦 Resolving PHP dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && composer install --no-interaction 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('cargo')) {
+      commands.push(
+        `if [ -f ${quotedPath}/Cargo.toml ]; then`,
+        `  echo "📦 Resolving Rust dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && cargo fetch 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('gomod')) {
+      commands.push(
+        `if [ -f ${quotedPath}/go.mod ]; then`,
+        `  echo "📦 Resolving Go dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && go mod download 2>/dev/null || true`
+      );
+      // setup.ts also checks src/go.mod; build.ts does not — keep the superset
+      commands.push(
+        `elif [ -f ${quotedPath}/src/go.mod ]; then`,
+        `  cd ${quotedPath}/src && go mod download 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('pip')) {
+      commands.push(
+        `if [ -f ${quotedPath}/requirements.txt ]; then`,
+        `  echo "📦 Resolving Python dependencies (pip) in ${location.label}..."`,
+        `  cd ${quotedPath} && pip install -r requirements.txt 2>/dev/null || true`,
+        'fi'
+      );
+    }
+
+    if (pms.includes('rubygems')) {
+      commands.push(
+        `if [ -f ${quotedPath}/Gemfile ]; then`,
+        `  echo "📦 Resolving Ruby dependencies in ${location.label}..."`,
+        `  cd ${quotedPath} && bundle install 2>/dev/null || true`,
+        'fi'
+      );
+    }
+  }
+
+  if (commands.length > 0) {
+    commands.push('cd /workspace');
+  }
+
+  return commands;
+}

--- a/packages/cli/src/lib/dependency-resolution.ts
+++ b/packages/cli/src/lib/dependency-resolution.ts
@@ -6,9 +6,7 @@
  * a single implementation to keep them in sync.
  */
 
-function shellEscape(value: string): string {
-  return `'${value.replace(/'/g, `'\"'\"'`)}' `;
-}
+import { shellEscape } from '../utils/shell.js';
 
 interface DependencyLocation {
   path: string;
@@ -46,7 +44,7 @@ export function getDependencyResolutionCommands(
   ];
 
   for (const location of locations) {
-    const quotedPath = shellEscape(location.path).trim();
+    const quotedPath = shellEscape(location.path);
     const pms = location.packageManagers;
 
     if (pms.includes('uv')) {

--- a/packages/cli/src/lib/dependency-resolution.ts
+++ b/packages/cli/src/lib/dependency-resolution.ts
@@ -7,7 +7,10 @@
  */
 
 import { shellEscape } from '../utils/shell.js';
-import { isSafeRelativePath } from '../utils/path-safety.js';
+import {
+  isSafeRelativePath,
+  resolvePathWithinRoot,
+} from '../utils/path-safety.js';
 
 interface DependencyLocation {
   path: string;
@@ -23,6 +26,7 @@ interface ProjectEntry {
 interface DependencyResolutionConfig {
   rootPackageManagers: string[];
   projects?: ProjectEntry[];
+  workspaceRoot?: string;
   /** Whether to add venv PATH exports for uv projects (used in setup, not build) */
   addVenvPathExports?: boolean;
 }
@@ -31,6 +35,10 @@ export function getDependencyResolutionCommands(
   config: DependencyResolutionConfig
 ): string[] {
   const commands: string[] = [];
+  const isSafeProjectPath = (projectPath: string): boolean =>
+    typeof config.workspaceRoot === 'string'
+      ? resolvePathWithinRoot(config.workspaceRoot, projectPath) !== null
+      : isSafeRelativePath(projectPath);
   const locations: DependencyLocation[] = [
     {
       path: '/workspace',
@@ -38,7 +46,7 @@ export function getDependencyResolutionCommands(
       label: 'workspace root',
     },
     ...(config.projects ?? [])
-      .filter(project => isSafeRelativePath(project.path))
+      .filter(project => isSafeProjectPath(project.path))
       .map(project => ({
         path: `/workspace/${project.path}`,
         packageManagers: project.packageManagers ?? [],

--- a/packages/cli/src/lib/dependency-resolution.ts
+++ b/packages/cli/src/lib/dependency-resolution.ts
@@ -56,7 +56,7 @@ export function getDependencyResolutionCommands(
         `  echo "📦 Resolving Python dependencies (uv) in ${location.label}..."`,
         `  cd ${quotedPath} && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true`
       );
-      if (config.addVenvPathExports && location.path === '/workspace') {
+      if (config.addVenvPathExports) {
         commands.push(
           `  if [ -d ${quotedPath}/.venv/bin ]; then`,
           `    export PATH="${location.path}/.venv/bin:$PATH"`,

--- a/packages/cli/src/lib/entrypoint.sh
+++ b/packages/cli/src/lib/entrypoint.sh
@@ -167,11 +167,12 @@ done
 
 echo "✅ Package manager MCP is ready"
 {taskDataSection}
-{installAllPackages}
 {agentInstallSection}
 {credentialInstallSection}
-{mcpConfigSection}
 {projectRepositoriesSection}
+{installAllPackages}
+{mcpConfigSection}
+{initScriptExecution}
 {workspaceDeps}
 {exportTaskVariables}
 
@@ -184,6 +185,5 @@ done
 
 {networkConfigSection}
 {sudoersRemoval}
-{initScriptExecution}
 {workflowExecutionSection}
 "$@"

--- a/packages/cli/src/lib/entrypoint.sh
+++ b/packages/cli/src/lib/entrypoint.sh
@@ -168,11 +168,11 @@ done
 echo "✅ Package manager MCP is ready"
 {taskDataSection}
 {installAllPackages}
-{workspaceDeps}
 {agentInstallSection}
 {credentialInstallSection}
 {mcpConfigSection}
 {projectRepositoriesSection}
+{workspaceDeps}
 {exportTaskVariables}
 
 # Ensure agent-installed toolchains are never committed

--- a/packages/cli/src/lib/entrypoint.sh
+++ b/packages/cli/src/lib/entrypoint.sh
@@ -46,6 +46,7 @@ export PATH=/root/local/.bin:$PATH
 
 {aptGetUpdate}
 {homeSetup}
+{gitSafeDirectorySetup}
 
 # Function to shred secrets before exit
 shred_secrets() {

--- a/packages/cli/src/lib/network-config.ts
+++ b/packages/cli/src/lib/network-config.ts
@@ -7,6 +7,29 @@ import { isIPv4 as nodeIsIPv4, isIPv6 as nodeIsIPv6, isIP } from 'node:net';
 import type { NetworkConfig, NetworkRule } from 'rover-schemas';
 
 /**
+ * Characters that are unsafe in shell contexts (command substitution,
+ * variable expansion, statement separators, etc.).  Used to reject
+ * host values and sanitize description values before they are embedded
+ * in generated bash scripts.
+ */
+const SHELL_UNSAFE_CHARS = /[`$();&|!{}\n\r\\]/;
+
+/**
+ * Sanitize a rule description so it is safe to embed as a bash comment.
+ * Strips control characters and any characters that could break out of
+ * a comment context (e.g. newlines).
+ */
+function sanitizeDescription(description: string): string {
+  // Replace newlines, carriage returns and other control chars with spaces,
+  // then collapse multiple spaces.
+  return description
+    .replace(/[\n\r\t]/g, ' ')
+    .replace(/[`$();&|!{}\\]/g, '')
+    .replace(/ {2,}/g, ' ')
+    .trim();
+}
+
+/**
  * Merge network configurations from project and task levels.
  * Task-level config takes full precedence over project-level config.
  */
@@ -134,6 +157,14 @@ export function generateNetworkScript(
     '',
   ];
 
+  // Validate rules before embedding them in the generated script.
+  if (config.rules && config.rules.length > 0) {
+    const validation = validateNetworkRules(config.rules);
+    if (!validation.valid) {
+      throw new Error(`Invalid network rules: ${validation.errors.join('; ')}`);
+    }
+  }
+
   if (config.mode === 'allowlist') {
     lines.push(...generateAllowlistScript(config, options.serviceHostnames));
   } else if (config.mode === 'blocklist') {
@@ -204,7 +235,9 @@ function generateAllowlistScript(
   if (config.rules && config.rules.length > 0) {
     lines.push('  # Allow specific hosts');
     for (const rule of config.rules) {
-      const comment = rule.description ? ` # ${rule.description}` : '';
+      const comment = rule.description
+        ? ` # ${sanitizeDescription(rule.description)}`
+        : '';
       if (isIPOrCIDR(rule.host)) {
         // Direct IP/CIDR - no resolution needed
         if (isIPv6(rule.host)) {
@@ -217,9 +250,11 @@ function generateAllowlistScript(
           );
         }
       } else {
-        // Domain - needs resolution
-        lines.push(`  # ${rule.host}${comment}`);
-        lines.push(`  for ip in $(resolve_host "${rule.host}"); do`);
+        // Domain - needs resolution; single-quote the host to prevent
+        // shell expansion of any residual special characters.
+        const safeHost = rule.host.replace(/'/g, "'\"'\"'");
+        lines.push(`  # ${rule.host.replace(/[\n\r]/g, ' ')}${comment}`);
+        lines.push(`  for ip in $(resolve_host '${safeHost}'); do`);
         lines.push('    if [[ "$ip" =~ : ]]; then');
         lines.push(
           '      sudo ip6tables -A OUTPUT -d "$ip" -j ACCEPT 2>/dev/null || true'
@@ -255,7 +290,9 @@ function generateBlocklistScript(
   if (config.rules && config.rules.length > 0) {
     lines.push('  # Block specific hosts');
     for (const rule of config.rules) {
-      const comment = rule.description ? ` # ${rule.description}` : '';
+      const comment = rule.description
+        ? ` # ${sanitizeDescription(rule.description)}`
+        : '';
       if (isIPOrCIDR(rule.host)) {
         // Direct IP/CIDR - no resolution needed
         if (isIPv6(rule.host)) {
@@ -268,9 +305,11 @@ function generateBlocklistScript(
           );
         }
       } else {
-        // Domain - needs resolution
-        lines.push(`  # ${rule.host}${comment}`);
-        lines.push(`  for ip in $(resolve_host "${rule.host}"); do`);
+        // Domain - needs resolution; single-quote the host to prevent
+        // shell expansion of any residual special characters.
+        const safeHost = rule.host.replace(/'/g, "'\"'\"'");
+        lines.push(`  # ${rule.host.replace(/[\n\r]/g, ' ')}${comment}`);
+        lines.push(`  for ip in $(resolve_host '${safeHost}'); do`);
         lines.push('    if [[ "$ip" =~ : ]]; then');
         lines.push(
           '      sudo ip6tables -A OUTPUT -d "$ip" -j DROP 2>/dev/null || true'
@@ -299,8 +338,9 @@ function generateServiceHostnameRules(serviceHostnames: string[]): string[] {
   ];
 
   for (const hostname of uniqueHostnames) {
-    lines.push(`  # ${hostname}`);
-    lines.push(`  for ip in $(resolve_host "${hostname}"); do`);
+    const safeHostname = hostname.replace(/'/g, "'\"'\"'");
+    lines.push(`  # ${hostname.replace(/[\n\r]/g, ' ')}`);
+    lines.push(`  for ip in $(resolve_host '${safeHostname}'); do`);
     lines.push('    if [[ "$ip" =~ : ]]; then');
     lines.push(
       '      sudo ip6tables -A OUTPUT -d "$ip" -j ACCEPT 2>/dev/null || true'
@@ -341,8 +381,9 @@ export function validateNetworkRules(
 
     const host = rule.host.trim();
 
-    // Check for invalid characters
-    if (/[<>"|?*]/.test(host)) {
+    // Check for invalid characters — reject shell metacharacters that could
+    // allow command injection when the host is embedded in generated scripts.
+    if (/[<>"|?*]/.test(host) || SHELL_UNSAFE_CHARS.test(host)) {
       errors.push(`Invalid characters in host: ${host}`);
       continue;
     }

--- a/packages/cli/src/lib/network-config.ts
+++ b/packages/cli/src/lib/network-config.ts
@@ -238,22 +238,23 @@ function generateAllowlistScript(
       const comment = rule.description
         ? ` # ${sanitizeDescription(rule.description)}`
         : '';
-      if (isIPOrCIDR(rule.host)) {
+      const trimmedHost = rule.host.trim();
+      if (isIPOrCIDR(trimmedHost)) {
         // Direct IP/CIDR - no resolution needed
-        if (isIPv6(rule.host)) {
+        if (isIPv6(trimmedHost)) {
           lines.push(
-            `  sudo ip6tables -A OUTPUT -d ${rule.host} -j ACCEPT 2>/dev/null || true${comment}`
+            `  sudo ip6tables -A OUTPUT -d ${trimmedHost} -j ACCEPT 2>/dev/null || true${comment}`
           );
         } else {
           lines.push(
-            `  sudo iptables -A OUTPUT -d ${rule.host} -j ACCEPT 2>/dev/null || true${comment}`
+            `  sudo iptables -A OUTPUT -d ${trimmedHost} -j ACCEPT 2>/dev/null || true${comment}`
           );
         }
       } else {
         // Domain - needs resolution; single-quote the host to prevent
         // shell expansion of any residual special characters.
-        const safeHost = rule.host.replace(/'/g, "'\"'\"'");
-        lines.push(`  # ${rule.host.replace(/[\n\r]/g, ' ')}${comment}`);
+        const safeHost = trimmedHost.replace(/'/g, "'\"'\"'");
+        lines.push(`  # ${trimmedHost.replace(/[\n\r]/g, ' ')}${comment}`);
         lines.push(`  for ip in $(resolve_host '${safeHost}'); do`);
         lines.push('    if [[ "$ip" =~ : ]]; then');
         lines.push(
@@ -293,22 +294,23 @@ function generateBlocklistScript(
       const comment = rule.description
         ? ` # ${sanitizeDescription(rule.description)}`
         : '';
-      if (isIPOrCIDR(rule.host)) {
+      const trimmedHost = rule.host.trim();
+      if (isIPOrCIDR(trimmedHost)) {
         // Direct IP/CIDR - no resolution needed
-        if (isIPv6(rule.host)) {
+        if (isIPv6(trimmedHost)) {
           lines.push(
-            `  sudo ip6tables -A OUTPUT -d ${rule.host} -j DROP 2>/dev/null || true${comment}`
+            `  sudo ip6tables -A OUTPUT -d ${trimmedHost} -j DROP 2>/dev/null || true${comment}`
           );
         } else {
           lines.push(
-            `  sudo iptables -A OUTPUT -d ${rule.host} -j DROP 2>/dev/null || true${comment}`
+            `  sudo iptables -A OUTPUT -d ${trimmedHost} -j DROP 2>/dev/null || true${comment}`
           );
         }
       } else {
         // Domain - needs resolution; single-quote the host to prevent
         // shell expansion of any residual special characters.
-        const safeHost = rule.host.replace(/'/g, "'\"'\"'");
-        lines.push(`  # ${rule.host.replace(/[\n\r]/g, ' ')}${comment}`);
+        const safeHost = trimmedHost.replace(/'/g, "'\"'\"'");
+        lines.push(`  # ${trimmedHost.replace(/[\n\r]/g, ' ')}${comment}`);
         lines.push(`  for ip in $(resolve_host '${safeHost}'); do`);
         lines.push('    if [[ "$ip" =~ : ]]; then');
         lines.push(
@@ -331,6 +333,13 @@ function generateServiceHostnameRules(serviceHostnames: string[]): string[] {
   const uniqueHostnames = [...new Set(serviceHostnames.filter(Boolean))];
   if (uniqueHostnames.length === 0) {
     return [];
+  }
+
+  // Validate service hostnames against shell metacharacters, same as rule hosts.
+  for (const hostname of uniqueHostnames) {
+    if (SHELL_UNSAFE_CHARS.test(hostname) || /[<>"|?*]/.test(hostname)) {
+      throw new Error(`Invalid characters in service hostname: ${hostname}`);
+    }
   }
 
   const lines: string[] = [

--- a/packages/cli/src/lib/network-config.ts
+++ b/packages/cli/src/lib/network-config.ts
@@ -91,7 +91,8 @@ function isIPOrCIDR(host: string): boolean {
  * Returns empty string if network filtering is disabled.
  */
 export function generateNetworkScript(
-  config: NetworkConfig | undefined
+  config: NetworkConfig | undefined,
+  options: { serviceHostnames?: string[] } = {}
 ): string {
   if (!config || config.mode === 'allowall') {
     return '';
@@ -134,9 +135,9 @@ export function generateNetworkScript(
   ];
 
   if (config.mode === 'allowlist') {
-    lines.push(...generateAllowlistScript(config));
+    lines.push(...generateAllowlistScript(config, options.serviceHostnames));
   } else if (config.mode === 'blocklist') {
-    lines.push(...generateBlocklistScript(config));
+    lines.push(...generateBlocklistScript(config, options.serviceHostnames));
   }
 
   lines.push(
@@ -155,7 +156,11 @@ export function generateNetworkScript(
 /**
  * Generate iptables rules for allowlist mode (deny all except listed).
  */
-function generateAllowlistScript(config: NetworkConfig): string[] {
+function generateAllowlistScript(
+  config: NetworkConfig,
+  serviceHostnames: string[] = []
+): string[] {
+  const hasServiceHostnames = serviceHostnames.some(Boolean);
   const lines: string[] = [
     '  # Allowlist mode: Block all traffic except explicitly allowed',
     '',
@@ -169,18 +174,22 @@ function generateAllowlistScript(config: NetworkConfig): string[] {
     '',
   ];
 
-  if (config.allowLocalhost !== false) {
+  if (config.allowLocalhost !== false || hasServiceHostnames) {
     lines.push(
-      '  # Allow localhost/loopback traffic',
+      config.allowLocalhost === false && hasServiceHostnames
+        ? '  # Allow loopback traffic required for sidecar service discovery'
+        : '  # Allow localhost/loopback traffic',
       '  sudo iptables -A OUTPUT -o lo -j ACCEPT 2>/dev/null || true',
       '  sudo ip6tables -A OUTPUT -o lo -j ACCEPT 2>/dev/null || true',
       ''
     );
   }
 
-  if (config.allowDns !== false) {
+  if (config.allowDns !== false || hasServiceHostnames) {
     lines.push(
-      '  # Allow DNS resolution',
+      config.allowDns === false && hasServiceHostnames
+        ? '  # Allow DNS required for sidecar service discovery'
+        : '  # Allow DNS resolution',
       '  sudo iptables -A OUTPUT -p udp --dport 53 -j ACCEPT 2>/dev/null || true',
       '  sudo iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT 2>/dev/null || true',
       '  sudo ip6tables -A OUTPUT -p udp --dport 53 -j ACCEPT 2>/dev/null || true',
@@ -188,6 +197,8 @@ function generateAllowlistScript(config: NetworkConfig): string[] {
       ''
     );
   }
+
+  lines.push(...generateServiceHostnameRules(serviceHostnames));
 
   // Add rules for each allowed host
   if (config.rules && config.rules.length > 0) {
@@ -229,11 +240,16 @@ function generateAllowlistScript(config: NetworkConfig): string[] {
 /**
  * Generate iptables rules for blocklist mode (allow all except listed).
  */
-function generateBlocklistScript(config: NetworkConfig): string[] {
+function generateBlocklistScript(
+  config: NetworkConfig,
+  serviceHostnames: string[] = []
+): string[] {
   const lines: string[] = [
     '  # Blocklist mode: Allow all traffic except explicitly blocked',
     '',
   ];
+
+  lines.push(...generateServiceHostnameRules(serviceHostnames));
 
   // Add rules for each blocked host
   if (config.rules && config.rules.length > 0) {
@@ -269,6 +285,35 @@ function generateBlocklistScript(config: NetworkConfig): string[] {
     }
   }
 
+  return lines;
+}
+
+function generateServiceHostnameRules(serviceHostnames: string[]): string[] {
+  const uniqueHostnames = [...new Set(serviceHostnames.filter(Boolean))];
+  if (uniqueHostnames.length === 0) {
+    return [];
+  }
+
+  const lines: string[] = [
+    '  # Always allow service container traffic on the task network',
+  ];
+
+  for (const hostname of uniqueHostnames) {
+    lines.push(`  # ${hostname}`);
+    lines.push(`  for ip in $(resolve_host "${hostname}"); do`);
+    lines.push('    if [[ "$ip" =~ : ]]; then');
+    lines.push(
+      '      sudo ip6tables -A OUTPUT -d "$ip" -j ACCEPT 2>/dev/null || true'
+    );
+    lines.push('    else');
+    lines.push(
+      '      sudo iptables -A OUTPUT -d "$ip" -j ACCEPT 2>/dev/null || true'
+    );
+    lines.push('    fi');
+    lines.push('  done');
+  }
+
+  lines.push('');
   return lines;
 }
 

--- a/packages/cli/src/lib/orphan-detector.ts
+++ b/packages/cli/src/lib/orphan-detector.ts
@@ -119,13 +119,13 @@ export async function detectOrphanedTasks(
         }
 
         if (!state) {
-          await sandbox.teardownServices();
           // Final lock re-check after inspect returned null — another
           // process may have acquired the lock and started a replacement
-          // container between inspect() returning and this check.
+          // container after inspect() returned.
           if (isResumeLockHeld(task)) {
             return;
           }
+          await sandbox.teardownServices();
           task.markFailed(CONTAINER_EXITED_ERROR);
           warn(
             colors.yellow(

--- a/packages/cli/src/lib/orphan-detector.ts
+++ b/packages/cli/src/lib/orphan-detector.ts
@@ -111,7 +111,7 @@ export async function detectOrphanedTasks(
           return;
         }
 
-        const state = await sandbox.inspect();
+        const state = await sandbox.inspect({ teardownServices: false });
 
         // Re-check lock after inspect — another process may have acquired
         // the resume lock and started a new container during the inspect call.
@@ -159,18 +159,17 @@ export async function detectOrphanedTasks(
           return;
         }
 
-        try {
-          await sandbox.teardownServices();
-        } catch (error) {
-          const msg = error instanceof Error ? error.message : String(error);
-          warn(
-            colors.yellow(
-              `⚠ Could not tear down sidecars for task ${task.id}: ${msg}`
-            )
-          );
-        }
-
         if (!task.isInProgress() && !task.isIterating()) {
+          try {
+            await sandbox.teardownServices();
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            warn(
+              colors.yellow(
+                `⚠ Could not tear down sidecars for task ${task.id}: ${msg}`
+              )
+            );
+          }
           return;
         }
 
@@ -180,7 +179,20 @@ export async function detectOrphanedTasks(
         if (state.exitCode === AGENT_EXIT_CODE.SUCCESS) {
           task.updateStatusFromIteration();
           // If status is already terminal after refresh, nothing more to do.
-          if (task.isCompleted() || task.isFailed() || task.isPaused()) {
+          if (task.isPaused()) {
+            return;
+          }
+          try {
+            await sandbox.teardownServices();
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            warn(
+              colors.yellow(
+                `⚠ Could not tear down sidecars for task ${task.id}: ${msg}`
+              )
+            );
+          }
+          if (task.isCompleted() || task.isFailed()) {
             return;
           }
           // Exit code 0 is a clean exit — if the status file wasn't updated yet
@@ -208,6 +220,16 @@ export async function detectOrphanedTasks(
         // Try to read the agent's last error from the status file before
         // falling back to a generic message.
         task.updateStatusFromIteration();
+        try {
+          await sandbox.teardownServices();
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          warn(
+            colors.yellow(
+              `⚠ Could not tear down sidecars for task ${task.id}: ${msg}`
+            )
+          );
+        }
         if (!task.isFailed()) {
           task.markFailed(CONTAINER_EXITED_ERROR);
         }

--- a/packages/cli/src/lib/orphan-detector.ts
+++ b/packages/cli/src/lib/orphan-detector.ts
@@ -120,6 +120,10 @@ export async function detectOrphanedTasks(
         }
 
         if (!state) {
+          if (!task.isInProgress() && !task.isIterating()) {
+            return;
+          }
+
           // Final lock re-check after inspect returned null — another
           // process may have acquired the lock and started a replacement
           // container after inspect() returned.

--- a/packages/cli/src/lib/orphan-detector.ts
+++ b/packages/cli/src/lib/orphan-detector.ts
@@ -100,6 +100,7 @@ export async function detectOrphanedTasks(
         // because the sandbox type is determined at runtime and may vary per task.
         const sandbox = await createSandbox(task, undefined, {
           projectPath: project?.path ?? '',
+          sandboxMetadata: task.sandboxMetadata,
         });
 
         // Re-check lock after sandbox creation — another process may have
@@ -118,6 +119,7 @@ export async function detectOrphanedTasks(
         }
 
         if (!state) {
+          await sandbox.teardownServices();
           // Final lock re-check after inspect returned null — another
           // process may have acquired the lock and started a replacement
           // container between inspect() returning and this check.

--- a/packages/cli/src/lib/orphan-detector.ts
+++ b/packages/cli/src/lib/orphan-detector.ts
@@ -57,6 +57,7 @@ export async function detectOrphanedTasks(
   tasks: Array<{
     task: TaskDescriptionManager;
     project: ProjectManager | null;
+    forceInspect?: boolean;
   }>,
   options: { suppressWarnings?: boolean } = {}
 ): Promise<void> {
@@ -69,8 +70,8 @@ export async function detectOrphanedTasks(
   // Tasks we can reconcile either by inspecting a known container or by
   // timing out a restart/resume that never recorded replacement metadata.
   const candidates = tasks.filter(
-    ({ task, project }) =>
-      (task.isInProgress() || task.isIterating()) &&
+    ({ task, project, forceInspect }) =>
+      (task.isInProgress() || task.isIterating() || forceInspect === true) &&
       project != null &&
       !isResumeLockHeld(task) &&
       !isRestartStartupInFlight(task) &&
@@ -125,7 +126,16 @@ export async function detectOrphanedTasks(
           if (isResumeLockHeld(task)) {
             return;
           }
-          await sandbox.teardownServices();
+          try {
+            await sandbox.teardownServices();
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            warn(
+              colors.yellow(
+                `⚠ Could not tear down sidecars for task ${task.id}: ${msg}`
+              )
+            );
+          }
           task.markFailed(CONTAINER_EXITED_ERROR);
           warn(
             colors.yellow(
@@ -142,6 +152,21 @@ export async function detectOrphanedTasks(
           containerStatus === 'restarting' ||
           containerStatus === 'paused'
         ) {
+          return;
+        }
+
+        try {
+          await sandbox.teardownServices();
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          warn(
+            colors.yellow(
+              `⚠ Could not tear down sidecars for task ${task.id}: ${msg}`
+            )
+          );
+        }
+
+        if (!task.isInProgress() && !task.isIterating()) {
           return;
         }
 

--- a/packages/cli/src/lib/orphan-detector.ts
+++ b/packages/cli/src/lib/orphan-detector.ts
@@ -14,6 +14,10 @@ function hasContainerId(task: TaskDescriptionManager): boolean {
   return Boolean(task.containerId);
 }
 
+function clearTaskContainerIdentity(task: TaskDescriptionManager): void {
+  task.setContainerInfo('', '', task.sandboxMetadata);
+}
+
 /** Maximum time (ms) to consider a restart "in flight" before treating it as stale.
  *  NOTE: This is intentionally shorter than LOCK_STALENESS_TIMEOUT_MS (30 min)
  *  in resume-lock.ts. If a startup exceeds this timeout, the orphan detector
@@ -140,6 +144,7 @@ export async function detectOrphanedTasks(
               )
             );
           }
+          clearTaskContainerIdentity(task);
           task.markFailed(CONTAINER_EXITED_ERROR);
           warn(
             colors.yellow(
@@ -170,6 +175,7 @@ export async function detectOrphanedTasks(
               )
             );
           }
+          clearTaskContainerIdentity(task);
           return;
         }
 
@@ -178,6 +184,7 @@ export async function detectOrphanedTasks(
         // file should already reflect this, so just refresh from disk.
         if (state.exitCode === AGENT_EXIT_CODE.SUCCESS) {
           task.updateStatusFromIteration();
+          clearTaskContainerIdentity(task);
           // If status is already terminal after refresh, nothing more to do.
           if (task.isPaused()) {
             return;
@@ -206,6 +213,7 @@ export async function detectOrphanedTasks(
         // The iteration status file should already say "paused", so read it.
         if (state.exitCode === AGENT_EXIT_CODE.PAUSED) {
           task.updateStatusFromIteration();
+          clearTaskContainerIdentity(task);
           if (task.isPaused() || task.isFailed()) {
             return;
           }
@@ -230,6 +238,7 @@ export async function detectOrphanedTasks(
             )
           );
         }
+        clearTaskContainerIdentity(task);
         if (!task.isFailed()) {
           task.markFailed(CONTAINER_EXITED_ERROR);
         }

--- a/packages/cli/src/lib/resume-helper.ts
+++ b/packages/cli/src/lib/resume-helper.ts
@@ -572,6 +572,7 @@ async function resumeTaskLocked(
   try {
     const sandbox = await createSandbox(task, undefined, {
       projectPath: project.path,
+      sandboxMetadata: task.sandboxMetadata,
       checkpointPath: checkpointState === 'valid' ? checkpointPath : undefined,
       resumeFromCheckpoint: checkpointState === 'valid',
       iterationLogsPath: project.getTaskIterationLogsPath(

--- a/packages/cli/src/lib/resume-helper.ts
+++ b/packages/cli/src/lib/resume-helper.ts
@@ -580,15 +580,15 @@ async function resumeTaskLocked(
       ),
     });
     const containerId = await sandbox.createAndStart();
+    const sandboxMetadata =
+      typeof sandbox.getSandboxMetadata === 'function'
+        ? sandbox.getSandboxMetadata()
+        : process.env.DOCKER_HOST
+          ? { dockerHost: process.env.DOCKER_HOST }
+          : undefined;
 
     // Update task metadata with new container ID
-    task.setContainerInfo(
-      containerId,
-      'running',
-      process.env.DOCKER_HOST
-        ? { dockerHost: process.env.DOCKER_HOST }
-        : undefined
-    );
+    task.setContainerInfo(containerId, 'running', sandboxMetadata);
     // Task already marked IN_PROGRESS before container creation (under lock)
 
     return { status: 'ok' };

--- a/packages/cli/src/lib/resume-helper.ts
+++ b/packages/cli/src/lib/resume-helper.ts
@@ -182,7 +182,7 @@ export function acquireResumeLock(iterationPath: string): (() => void) | null {
 
 /** Possible outcomes of a resume attempt. */
 export type ResumeResult =
-  | { status: 'ok' }
+  | { status: 'ok'; resumedFromCheckpoint: boolean }
   | { status: 'not_resumable' }
   | { status: 'already_resuming' }
   | { status: 'failed'; error: string };
@@ -199,6 +199,69 @@ export interface ResumeOptions {
   /** Override the agent (e.g. "claude") and optionally model (e.g. "opus"). */
   agent?: string;
   agentModel?: string;
+}
+
+function checkpointHasRequiredExternalRepoState(
+  iterationPath: string,
+  projectPath: string,
+  checkpoint: Record<string, unknown>
+): boolean {
+  const workspaceDescriptionPath = join(
+    iterationPath,
+    'workspace-description.json'
+  );
+
+  const getRequiredProjectPaths = (): string[] => {
+    if (existsSync(workspaceDescriptionPath)) {
+      try {
+        const raw = readFileSync(workspaceDescriptionPath, 'utf8');
+        const parsed = JSON.parse(raw) as {
+          projects?: Array<{ path?: unknown; repository?: unknown }>;
+        };
+        return (Array.isArray(parsed.projects) ? parsed.projects : []).flatMap(
+          project =>
+            typeof project?.path === 'string' &&
+            typeof project?.repository === 'string'
+              ? [project.path]
+              : []
+        );
+      } catch {
+        return [];
+      }
+    }
+
+    return [];
+  };
+
+  try {
+    const requiredProjectPaths = getRequiredProjectPaths();
+
+    if (requiredProjectPaths.length === 0) {
+      return true;
+    }
+
+    if (!Array.isArray(checkpoint.externalRepositories)) {
+      return false;
+    }
+
+    const availablePaths = new Set(
+      checkpoint.externalRepositories.flatMap(entry =>
+        entry &&
+        typeof entry === 'object' &&
+        typeof (entry as { path?: unknown }).path === 'string' &&
+        typeof (entry as { head?: unknown }).head === 'string' &&
+        typeof (entry as { trackedDiffHash?: unknown }).trackedDiffHash ===
+          'string' &&
+        typeof (entry as { untrackedHash?: unknown }).untrackedHash === 'string'
+          ? [(entry as { path: string }).path]
+          : []
+      )
+    );
+
+    return requiredProjectPaths.every(path => availablePaths.has(path));
+  } catch {
+    return false;
+  }
 }
 
 export async function resumeTask(
@@ -318,7 +381,12 @@ async function resumeTaskLocked(
       if (
         parsed !== null &&
         typeof parsed === 'object' &&
-        Array.isArray(parsed.completedSteps)
+        Array.isArray(parsed.completedSteps) &&
+        checkpointHasRequiredExternalRepoState(
+          iterationPath,
+          project.path,
+          parsed as Record<string, unknown>
+        )
       ) {
         checkpointState = 'valid';
         // Warn about step IDs in the checkpoint that may not exist in
@@ -344,7 +412,7 @@ async function resumeTaskLocked(
         checkpointState = 'invalid';
         log(
           colors.yellow(
-            `  ⚠ Checkpoint file for task ${taskId} has invalid structure, ignoring it.`
+            `  ⚠ Checkpoint file for task ${taskId} has invalid or incomplete structure, ignoring it.`
           )
         );
       }
@@ -592,7 +660,10 @@ async function resumeTaskLocked(
     task.setContainerInfo(containerId, 'running', sandboxMetadata);
     // Task already marked IN_PROGRESS before container creation (under lock)
 
-    return { status: 'ok' };
+    return {
+      status: 'ok',
+      resumedFromCheckpoint: checkpointState === 'valid',
+    };
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     log(

--- a/packages/cli/src/lib/resume-helper.ts
+++ b/packages/cli/src/lib/resume-helper.ts
@@ -26,6 +26,7 @@ import {
   LOCK_STALENESS_TIMEOUT_MS,
 } from '../utils/resume-lock.js';
 import { isProcessAlive } from '../utils/process.js';
+import { isLocalRepositoryReference } from '../utils/repository-reference.js';
 import colors from 'ansi-colors';
 
 /**
@@ -215,7 +216,7 @@ function checkpointHasRequiredExternalRepoState(
     '.rover-workspace.json'
   );
 
-  const getRequiredProjectPaths = (): string[] => {
+  const getRequiredProjectPaths = (): string[] | null => {
     if (existsSync(workspaceDescriptionPath)) {
       try {
         const raw = readFileSync(workspaceDescriptionPath, 'utf8');
@@ -225,12 +226,13 @@ function checkpointHasRequiredExternalRepoState(
         return (Array.isArray(parsed.projects) ? parsed.projects : []).flatMap(
           project =>
             typeof project?.path === 'string' &&
-            typeof project?.repository === 'string'
+            typeof project?.repository === 'string' &&
+            !isLocalRepositoryReference(project.repository)
               ? [project.path]
               : []
         );
       } catch {
-        return [];
+        return null;
       }
     }
 
@@ -243,12 +245,13 @@ function checkpointHasRequiredExternalRepoState(
         return (Array.isArray(parsed.projects) ? parsed.projects : []).flatMap(
           project =>
             typeof project?.path === 'string' &&
-            typeof project?.repository === 'string'
+            typeof project?.repository === 'string' &&
+            !isLocalRepositoryReference(project.repository)
               ? [project.path]
               : []
         );
       } catch {
-        return [];
+        return null;
       }
     }
 
@@ -257,6 +260,10 @@ function checkpointHasRequiredExternalRepoState(
 
   try {
     const requiredProjectPaths = getRequiredProjectPaths();
+
+    if (requiredProjectPaths === null) {
+      return false;
+    }
 
     if (requiredProjectPaths.length === 0) {
       return true;

--- a/packages/cli/src/lib/resume-helper.ts
+++ b/packages/cli/src/lib/resume-helper.ts
@@ -203,18 +203,40 @@ export interface ResumeOptions {
 
 function checkpointHasRequiredExternalRepoState(
   iterationPath: string,
-  projectPath: string,
+  taskWorktreePath: string,
   checkpoint: Record<string, unknown>
 ): boolean {
   const workspaceDescriptionPath = join(
     iterationPath,
     'workspace-description.json'
   );
+  const legacyWorkspaceDescriptionPath = join(
+    taskWorktreePath,
+    '.rover-workspace.json'
+  );
 
   const getRequiredProjectPaths = (): string[] => {
     if (existsSync(workspaceDescriptionPath)) {
       try {
         const raw = readFileSync(workspaceDescriptionPath, 'utf8');
+        const parsed = JSON.parse(raw) as {
+          projects?: Array<{ path?: unknown; repository?: unknown }>;
+        };
+        return (Array.isArray(parsed.projects) ? parsed.projects : []).flatMap(
+          project =>
+            typeof project?.path === 'string' &&
+            typeof project?.repository === 'string'
+              ? [project.path]
+              : []
+        );
+      } catch {
+        return [];
+      }
+    }
+
+    if (existsSync(legacyWorkspaceDescriptionPath)) {
+      try {
+        const raw = readFileSync(legacyWorkspaceDescriptionPath, 'utf8');
         const parsed = JSON.parse(raw) as {
           projects?: Array<{ path?: unknown; repository?: unknown }>;
         };
@@ -384,7 +406,7 @@ async function resumeTaskLocked(
         Array.isArray(parsed.completedSteps) &&
         checkpointHasRequiredExternalRepoState(
           iterationPath,
-          project.path,
+          task.worktreePath,
           parsed as Record<string, unknown>
         )
       ) {

--- a/packages/cli/src/lib/resume-helper.ts
+++ b/packages/cli/src/lib/resume-helper.ts
@@ -226,8 +226,7 @@ function checkpointHasRequiredExternalRepoState(
         return (Array.isArray(parsed.projects) ? parsed.projects : []).flatMap(
           project =>
             typeof project?.path === 'string' &&
-            typeof project?.repository === 'string' &&
-            !isLocalRepositoryReference(project.repository)
+            typeof project?.repository === 'string'
               ? [project.path]
               : []
         );
@@ -245,8 +244,7 @@ function checkpointHasRequiredExternalRepoState(
         return (Array.isArray(parsed.projects) ? parsed.projects : []).flatMap(
           project =>
             typeof project?.path === 'string' &&
-            typeof project?.repository === 'string' &&
-            !isLocalRepositoryReference(project.repository)
+            typeof project?.repository === 'string'
               ? [project.path]
               : []
         );

--- a/packages/cli/src/lib/retry-scheduler.ts
+++ b/packages/cli/src/lib/retry-scheduler.ts
@@ -1,10 +1,7 @@
 import type { ProjectManager } from 'rover-core';
 import { resumeTask } from './resume-helper.js';
 import { checkClaudeUsage, invalidateUsageCache } from './claude-usage.js';
-import {
-  checkCodexUsage,
-  invalidateCodexUsageCache,
-} from './codex-usage.js';
+import { checkCodexUsage, invalidateCodexUsageCache } from './codex-usage.js';
 import colors from 'ansi-colors';
 
 /**
@@ -408,7 +405,13 @@ export class RetryScheduler {
     }
 
     // Pre-fire usage check: if still exhausted, defer without burning a retry.
-    const deferResult = await this.preFireUsageCheck(provider, task, taskKey, taskId, project);
+    const deferResult = await this.preFireUsageCheck(
+      provider,
+      task,
+      taskKey,
+      taskId,
+      project
+    );
     if (deferResult) return;
 
     this.log(

--- a/packages/cli/src/lib/retry-scheduler.ts
+++ b/packages/cli/src/lib/retry-scheduler.ts
@@ -62,6 +62,8 @@ export class RetryScheduler {
   private taskTimers: Map<string, TaskTimerEntry> = new Map();
   /** Tracks how many retry cycles each task has gone through. */
   private retryCounts: Map<string, number> = new Map();
+  /** Remembers which provider owns each retry count entry. */
+  private retryProviders: Map<string, string> = new Map();
   /** When true, suppress informational console.log messages (e.g. JSON mode). */
   private quiet: boolean;
 
@@ -93,6 +95,7 @@ export class RetryScheduler {
   private clearTaskState(taskKey: string): void {
     this.clearTimer(taskKey);
     this.retryCounts.delete(taskKey);
+    this.retryProviders.delete(taskKey);
   }
 
   /**
@@ -121,6 +124,8 @@ export class RetryScheduler {
       // retry budget (different provider = different credit pool).
       this.clearTaskState(key);
     }
+
+    this.retryProviders.set(key, provider);
 
     // Seed retry count from persisted auto-retry state if we haven't tracked
     // this task yet. Manual resumes/restarts maintain a separate restartCount.
@@ -210,8 +215,12 @@ export class RetryScheduler {
     }
     // Clean up orphaned retry counts whose timers were already removed
     for (const key of this.retryCounts.keys()) {
-      if (key.endsWith(`${RetryScheduler.KEY_SEP}${taskId}`)) {
+      if (
+        key.endsWith(`${RetryScheduler.KEY_SEP}${taskId}`) &&
+        this.retryProviders.get(key) === provider
+      ) {
         this.retryCounts.delete(key);
+        this.retryProviders.delete(key);
       }
     }
   }
@@ -259,6 +268,7 @@ export class RetryScheduler {
     }
     this.taskTimers.clear();
     this.retryCounts.clear();
+    this.retryProviders.clear();
   }
 
   /**
@@ -401,6 +411,7 @@ export class RetryScheduler {
     const task = project.getTask(taskId);
     if (!task || (!task.isPaused() && !task.isFailed())) {
       this.retryCounts.delete(taskKey);
+      this.retryProviders.delete(taskKey);
       return;
     }
 
@@ -431,6 +442,7 @@ export class RetryScheduler {
         const resumedTask = project.getTask(taskId);
         resumedTask?.setAutoRetryCount(0);
         this.retryCounts.delete(taskKey);
+        this.retryProviders.delete(taskKey);
         this.log(colors.green(`  ✓ Task ${taskId} resumed successfully`));
       } else if (result.status === 'already_resuming') {
         // Another process is handling it — don't count as a failure.
@@ -447,6 +459,8 @@ export class RetryScheduler {
             `  ℹ Task ${taskId} is no longer resumable; stopping auto-retry`
           )
         );
+        this.retryCounts.delete(taskKey);
+        this.retryProviders.delete(taskKey);
       } else {
         // Resume returned a non-success status — count this as a failed attempt.
         const attempt = previousCount + 1;

--- a/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
@@ -6,7 +6,7 @@ import {
   resolveInitScriptPath,
 } from '../container-common.js';
 import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
 describe('normalizeExtraArgs', () => {
@@ -251,6 +251,14 @@ describe('resolveInitScriptPath', () => {
 
     expect(resolveInitScriptPath(dir, 'scripts/setup.sh', 'packages/api')).toBe(
       join(dir, 'scripts', 'setup.sh')
+    );
+  });
+
+  it('resolves root init scripts outside the workspace root', () => {
+    const dir = createTmpDir();
+
+    expect(resolveInitScriptPath(dir, '../shared/setup.sh')).toBe(
+      resolve(dir, '../shared/setup.sh')
     );
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import {
+  getBuildContainerExtraArgs,
   normalizeExtraArgs,
   getWorktreeGitMounts,
   getCheckpointArgs,
@@ -71,6 +72,33 @@ describe('normalizeExtraArgs', () => {
       '--add-host',
       'host.docker.internal:host-gateway',
     ]);
+  });
+});
+
+describe('getBuildContainerExtraArgs', () => {
+  it('returns normalized args when no volume flags are present', () => {
+    expect(getBuildContainerExtraArgs('--network mynet --env FOO=bar')).toEqual(
+      ['--network', 'mynet', '--env', 'FOO=bar']
+    );
+  });
+
+  it('removes short volume flags and their values', () => {
+    expect(
+      getBuildContainerExtraArgs('--env FOO=bar -v data:/data --network mynet')
+    ).toEqual(['--env', 'FOO=bar', '--network', 'mynet']);
+  });
+
+  it('removes long volume flags and inline assignments', () => {
+    expect(
+      getBuildContainerExtraArgs([
+        '--volume',
+        'data:/data',
+        '--env',
+        'FOO=bar',
+        '--volume=/cache:/cache',
+        '-v=/tmp:/tmp',
+      ])
+    ).toEqual(['--env', 'FOO=bar']);
   });
 });
 

--- a/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
@@ -234,4 +234,15 @@ describe('resolveInitScriptPath', () => {
       rootScript
     );
   });
+
+  it('ignores unsafe project paths when resolving init scripts', () => {
+    const dir = createTmpDir();
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    const rootScript = join(dir, 'scripts', 'setup.sh');
+    writeFileSync(rootScript, '#!/bin/sh\necho root\n');
+
+    expect(resolveInitScriptPath(dir, 'scripts/setup.sh', '../../escape')).toBe(
+      rootScript
+    );
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-common.test.ts
@@ -198,7 +198,7 @@ describe('resolveInitScriptPath', () => {
     tmpDirs.length = 0;
   });
 
-  it('resolves sub-project init scripts from the workspace root first', () => {
+  it('resolves sub-project init scripts from the project path first', () => {
     const dir = createTmpDir();
     mkdirSync(join(dir, 'packages', 'api', 'scripts'), { recursive: true });
     mkdirSync(join(dir, 'scripts'), { recursive: true });
@@ -209,7 +209,7 @@ describe('resolveInitScriptPath', () => {
     writeFileSync(rootScript, '#!/bin/sh\necho root\n');
 
     expect(resolveInitScriptPath(dir, 'scripts/setup.sh', 'packages/api')).toBe(
-      rootScript
+      projectScript
     );
   });
 
@@ -243,6 +243,14 @@ describe('resolveInitScriptPath', () => {
 
     expect(resolveInitScriptPath(dir, 'scripts/setup.sh', '../../escape')).toBe(
       rootScript
+    );
+  });
+
+  it('falls back to the workspace root when neither location contains the script', () => {
+    const dir = createTmpDir();
+
+    expect(resolveInitScriptPath(dir, 'scripts/setup.sh', 'packages/api')).toBe(
+      join(dir, 'scripts', 'setup.sh')
     );
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -1379,6 +1379,48 @@ describe('checkImageCache', () => {
     );
   });
 
+  it('resolves absolute local repositories under /workspace for cache hashing', () => {
+    const projectRoot = createTmpDir();
+    const hostRepoRoot = createTmpDir();
+    const hostRepo = join(hostRepoRoot, 'sources', 'api.git');
+    mkdirSync(hostRepo, { recursive: true });
+    writeFileSync(join(hostRepo, 'README.md'), '# api\n', 'utf8');
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: hostRepo,
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', hostRepo, 'main'],
+      { reject: false }
+    );
+  });
+
   it('preserves SCP-style repository URLs for cache hashing', () => {
     mockedLaunchSync.mockReturnValueOnce({
       stdout: 'abc123\trefs/heads/main\n',

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -81,7 +81,9 @@ function hashDirectoryContents(dirPath: string): string {
       }
 
       if (entry.isSymbolicLink()) {
-        hash.update(`symlink\0${entryRelativePath}\0${readlinkSync(entryPath)}\0`);
+        hash.update(
+          `symlink\0${entryRelativePath}\0${readlinkSync(entryPath)}\0`
+        );
       }
     }
   };

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -1141,6 +1141,47 @@ describe('checkImageCache', () => {
     );
   });
 
+  it('includes root init script content from paths outside the workspace root', () => {
+    const projectRoot = createTmpDir();
+    const sharedDir = join(projectRoot, '..', 'shared');
+    mkdirSync(sharedDir, { recursive: true });
+    writeFileSync(
+      join(sharedDir, 'setup.sh'),
+      '#!/bin/sh\necho shared root init\n'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        initScript: '../shared/setup.sh',
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    const expectedHash = computeSetupHash({
+      agentImage: 'sha256:img',
+      languages: ['typescript'],
+      packageManagers: ['pnpm'],
+      taskManagers: [],
+      agent: 'claude',
+      roverVersion: '1.0.0-test',
+      initScriptPath: '../shared/setup.sh',
+      initScriptContent: '#!/bin/sh\necho shared root init\n',
+      cacheFilesContent: '',
+      mcps: [],
+    });
+
+    expect(result.cacheTag).toBe(getCacheImageTag(expectedHash));
+  });
+
   it('resolves relative local project repositories against projectRoot for cache hashing', () => {
     const projectRoot = createTmpDir();
     mkdirSync(join(projectRoot, 'repos', 'api.git'), { recursive: true });
@@ -1176,6 +1217,78 @@ describe('checkImageCache', () => {
       1,
       'git',
       ['ls-remote', join(projectRoot, 'repos', 'api.git'), 'main'],
+      { reject: false }
+    );
+  });
+
+  it('preserves absolute container repository paths for cache hashing', () => {
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: '/workspace/sources/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', '/workspace/sources/api.git', 'main'],
+      { reject: false }
+    );
+  });
+
+  it('uses absolute host repository paths for cache hashing', () => {
+    const hostRepo = createTmpDir();
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: hostRepo,
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', hostRepo, 'main'],
       { reject: false }
     );
   });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -268,6 +268,34 @@ describe('computeSetupHash', () => {
     expect(a).not.toBe(b);
   });
 
+  it('changes when project repositoryRevision changes', () => {
+    const a = computeSetupHash(
+      makeInputs({
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'https://github.com/dataforxyz/api.git',
+            repositoryRevision: 'abc123',
+          },
+        ],
+      })
+    );
+    const b = computeSetupHash(
+      makeInputs({
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'https://github.com/dataforxyz/api.git',
+            repositoryRevision: 'def456',
+          },
+        ],
+      })
+    );
+    expect(a).not.toBe(b);
+  });
+
   it('changes when project initScriptContent changes', () => {
     const a = computeSetupHash(
       makeInputs({
@@ -337,6 +365,9 @@ describe('waitForInitAndCommit', () => {
     } as any);
     mockedLaunch.mockResolvedValueOnce({} as any); // commit
     mockedLaunch.mockResolvedValueOnce({} as any); // rm -f
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup run
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup commit
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup rm -f
 
     const result = await waitForInitAndCommit(
       ContainerBackend.Docker,
@@ -345,7 +376,7 @@ describe('waitForInitAndCommit', () => {
     );
 
     expect(result).toBe(true);
-    expect(mockedLaunch).toHaveBeenCalledTimes(3);
+    expect(mockedLaunch).toHaveBeenCalledTimes(6);
     expect(mockedLaunch).toHaveBeenNthCalledWith(
       1,
       ContainerBackend.Docker,
@@ -364,6 +395,21 @@ describe('waitForInitAndCommit', () => {
       ['rm', '-f', 'test-container'],
       undefined
     );
+    expect(mockedLaunch).toHaveBeenNthCalledWith(
+      4,
+      ContainerBackend.Docker,
+      [
+        'run',
+        '--name',
+        'test-container-fixup',
+        '--entrypoint',
+        '/bin/bash',
+        'rover-cache:abc123',
+        '-c',
+        'chmod -R a+rwX /home/agent 2>/dev/null || true',
+      ],
+      undefined
+    );
   });
 
   it('includes LABEL change when projectPath is provided', async () => {
@@ -372,6 +418,9 @@ describe('waitForInitAndCommit', () => {
     } as any);
     mockedLaunch.mockResolvedValueOnce({} as any); // commit
     mockedLaunch.mockResolvedValueOnce({} as any); // rm -f
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup run
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup commit
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup rm -f
 
     const result = await waitForInitAndCommit(
       ContainerBackend.Docker,
@@ -401,6 +450,9 @@ describe('waitForInitAndCommit', () => {
     } as any);
     mockedLaunch.mockResolvedValueOnce({} as any); // commit
     mockedLaunch.mockResolvedValueOnce({} as any); // rm -f
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup run
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup commit
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup rm -f
 
     const result = await waitForInitAndCommit(
       ContainerBackend.Docker,
@@ -433,6 +485,9 @@ describe('waitForInitAndCommit', () => {
     } as any);
     mockedLaunch.mockResolvedValueOnce({} as any); // commit
     mockedLaunch.mockResolvedValueOnce({} as any); // rm -f
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup run
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup commit
+    mockedLaunch.mockResolvedValueOnce({} as any); // fixup rm -f
 
     const metadata = { dockerHost: 'tcp://remote:2375' };
     const result = await waitForInitAndCommit(
@@ -446,7 +501,7 @@ describe('waitForInitAndCommit', () => {
 
     expect(result).toBe(true);
     // Every launch call should receive { env: { DOCKER_HOST: ... } }
-    for (let i = 1; i <= 3; i++) {
+    for (let i = 1; i <= 6; i++) {
       const callOpts = mockedLaunch.mock.calls[i - 1][2] as any;
       expect(callOpts?.env?.DOCKER_HOST).toBe('tcp://remote:2375');
     }
@@ -913,5 +968,62 @@ describe('checkImageCache', () => {
     });
 
     expect(result.cacheTag).toBe(getCacheImageTag(expectedHash));
+  });
+
+  it('includes external project repository revisions in the cache hash', () => {
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'https://github.com/dataforxyz/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    const expectedHash = computeSetupHash({
+      agentImage: 'sha256:img',
+      languages: ['typescript'],
+      packageManagers: ['pnpm'],
+      taskManagers: [],
+      agent: 'claude',
+      roverVersion: '1.0.0-test',
+      initScriptContent: '',
+      cacheFilesContent: '',
+      mcps: [],
+      projects: [
+        {
+          name: 'api',
+          path: 'packages/api',
+          repository: 'https://github.com/dataforxyz/api.git',
+          ref: 'main',
+          repositoryRevision: 'abc123',
+        },
+      ],
+    });
+
+    expect(result.cacheTag).toBe(getCacheImageTag(expectedHash));
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', 'https://github.com/dataforxyz/api.git', 'main'],
+      { reject: false }
+    );
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -1,4 +1,13 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -38,6 +47,47 @@ function makeInputs(overrides: Partial<SetupHashInputs> = {}): SetupHashInputs {
     mcps: [],
     ...overrides,
   };
+}
+
+function hashDirectoryContents(dirPath: string): string {
+  const hash = createHash('sha256');
+
+  const visit = (currentPath: string, relativePath: string): void => {
+    const entries = readdirSync(currentPath, { withFileTypes: true }).sort(
+      (a, b) => a.name.localeCompare(b.name)
+    );
+
+    for (const entry of entries) {
+      if (entry.name === '.git') {
+        continue;
+      }
+
+      const entryRelativePath = relativePath
+        ? `${relativePath}/${entry.name}`
+        : entry.name;
+      const entryPath = join(currentPath, entry.name);
+
+      if (entry.isDirectory()) {
+        hash.update(`dir\0${entryRelativePath}\0`);
+        visit(entryPath, entryRelativePath);
+        continue;
+      }
+
+      if (entry.isFile()) {
+        hash.update(`file\0${entryRelativePath}\0`);
+        hash.update(readFileSync(entryPath));
+        hash.update('\0');
+        continue;
+      }
+
+      if (entry.isSymbolicLink()) {
+        hash.update(`symlink\0${entryRelativePath}\0${readlinkSync(entryPath)}\0`);
+      }
+    }
+  };
+
+  visit(dirPath, '');
+  return hash.digest('hex');
 }
 
 describe('computeSetupHash', () => {
@@ -962,6 +1012,9 @@ describe('checkImageCache', () => {
         {
           name: 'api',
           path: 'packages/api',
+          localContentHash: hashDirectoryContents(
+            join(projectRoot, 'packages', 'api')
+          ),
           initScriptContent: '#!/bin/sh\necho root\n',
         },
       ],
@@ -1025,5 +1078,53 @@ describe('checkImageCache', () => {
       ['ls-remote', 'https://github.com/dataforxyz/api.git', 'main'],
       { reject: false }
     );
+  });
+
+  it('changes when a materialized child project changes locally', () => {
+    const projectRoot = createTmpDir();
+    mkdirSync(join(projectRoot, 'packages', 'api'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, 'packages', 'api', 'package.json'),
+      '{"name":"api","version":"1.0.0"}\n'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result1 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [{ name: 'api', path: 'packages/api' }],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    writeFileSync(
+      join(projectRoot, 'packages', 'api', 'package.json'),
+      '{"name":"api","version":"2.0.0"}\n'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result2 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [{ name: 'api', path: 'packages/api' }],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(result1.cacheTag).not.toBe(result2.cacheTag);
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -42,6 +42,7 @@ function makeInputs(overrides: Partial<SetupHashInputs> = {}): SetupHashInputs {
     taskManagers: ['make'],
     agent: 'claude',
     roverVersion: '1.0.0',
+    initScriptPath: '',
     initScriptContent: '',
     cacheFilesContent: '',
     mcps: [],
@@ -145,6 +146,22 @@ describe('computeSetupHash', () => {
     const a = computeSetupHash(makeInputs({ initScriptContent: '' }));
     const b = computeSetupHash(
       makeInputs({ initScriptContent: 'apt-get install -y vim' })
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when initScriptPath changes', () => {
+    const a = computeSetupHash(
+      makeInputs({
+        initScriptPath: 'scripts/setup.sh',
+        initScriptContent: '#!/bin/sh\necho hi\n',
+      })
+    );
+    const b = computeSetupHash(
+      makeInputs({
+        initScriptPath: 'scripts/bootstrap.sh',
+        initScriptContent: '#!/bin/sh\necho hi\n',
+      })
     );
     expect(a).not.toBe(b);
   });
@@ -351,13 +368,53 @@ describe('computeSetupHash', () => {
   it('changes when project initScriptContent changes', () => {
     const a = computeSetupHash(
       makeInputs({
-        projects: [{ name: 'api', path: 'api', initScriptContent: '' }],
+        projects: [
+          {
+            name: 'api',
+            path: 'api',
+            initScriptPath: 'scripts/setup.sh',
+            initScriptContent: '',
+          },
+        ],
       })
     );
     const b = computeSetupHash(
       makeInputs({
         projects: [
-          { name: 'api', path: 'api', initScriptContent: 'npm install' },
+          {
+            name: 'api',
+            path: 'api',
+            initScriptPath: 'scripts/setup.sh',
+            initScriptContent: 'npm install',
+          },
+        ],
+      })
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when project initScriptPath changes', () => {
+    const a = computeSetupHash(
+      makeInputs({
+        projects: [
+          {
+            name: 'api',
+            path: 'api',
+            initScriptPath: 'scripts/setup.sh',
+            initScriptContent: '#!/bin/sh\necho api\n',
+          },
+        ],
+      })
+    );
+    const b = computeSetupHash(
+      makeInputs({
+        projects: [
+          {
+            name: 'api',
+            path: 'api',
+            initScriptPath: 'scripts/bootstrap.sh',
+            initScriptContent: '#!/bin/sh\necho api\n',
+          },
         ],
       })
     );
@@ -1017,6 +1074,7 @@ describe('checkImageCache', () => {
           localContentHash: hashDirectoryContents(
             join(projectRoot, 'packages', 'api')
           ),
+          initScriptPath: 'scripts/setup.sh',
           initScriptContent: '#!/bin/sh\necho subproject\n',
         },
       ],
@@ -1079,6 +1137,45 @@ describe('checkImageCache', () => {
       1,
       'git',
       ['ls-remote', 'https://github.com/dataforxyz/api.git', 'main'],
+      { reject: false }
+    );
+  });
+
+  it('resolves relative local project repositories against projectRoot for cache hashing', () => {
+    const projectRoot = createTmpDir();
+    mkdirSync(join(projectRoot, 'repos', 'api.git'), { recursive: true });
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: './repos/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', join(projectRoot, 'repos', 'api.git'), 'main'],
       { reject: false }
     );
   });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -1297,4 +1297,75 @@ describe('checkImageCache', () => {
 
     expect(result1.cacheTag).toBe(result2.cacheTag);
   });
+
+  it('ignores unsafe child projects when hashing cache inputs', () => {
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: '',
+      exitCode: 1,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projects: [
+          {
+            name: 'unsafe',
+            path: '../../escape',
+            repository: 'https://github.com/dataforxyz/unsafe.git',
+          },
+          {
+            name: 'safe',
+            path: 'packages/api',
+            repository: 'https://github.com/dataforxyz/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: '',
+      exitCode: 1,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const safeOnlyResult = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projects: [
+          {
+            name: 'safe',
+            path: 'packages/api',
+            repository: 'https://github.com/dataforxyz/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(result.cacheTag).toBe(safeOnlyResult.cacheTag);
+    expect(mockedLaunchSync).toHaveBeenCalledWith(
+      'git',
+      ['ls-remote', 'https://github.com/dataforxyz/api.git', 'main'],
+      { reject: false }
+    );
+    expect(mockedLaunchSync).not.toHaveBeenCalledWith(
+      'git',
+      ['ls-remote', 'https://github.com/dataforxyz/unsafe.git', 'HEAD'],
+      { reject: false }
+    );
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -1306,7 +1306,9 @@ describe('checkImageCache', () => {
     );
   });
 
-  it('preserves absolute container repository paths for cache hashing', () => {
+  it('maps absolute container repository paths back to the host project root for cache hashing', () => {
+    const projectRoot = createTmpDir();
+
     mockedLaunchSync.mockReturnValueOnce({
       stdout: 'abc123\trefs/heads/main\n',
       exitCode: 0,
@@ -1320,6 +1322,7 @@ describe('checkImageCache', () => {
     checkImageCache(
       ContainerBackend.Docker,
       makeProjectConfig({
+        projectRoot,
         projects: [
           {
             name: 'api',
@@ -1336,7 +1339,45 @@ describe('checkImageCache', () => {
     expect(mockedLaunchSync).toHaveBeenNthCalledWith(
       1,
       'git',
-      ['ls-remote', '/workspace/sources/api.git', 'main'],
+      ['ls-remote', join(projectRoot, 'sources', 'api.git'), 'main'],
+      { reject: false }
+    );
+  });
+
+  it('maps file URL repositories under /workspace back to the host project root for cache hashing', () => {
+    const projectRoot = createTmpDir();
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'file:///workspace/sources/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', join(projectRoot, 'sources', 'api.git'), 'main'],
       { reject: false }
     );
   });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -1069,6 +1069,7 @@ describe('checkImageCache', () => {
           repository: 'https://github.com/dataforxyz/api.git',
           ref: 'main',
           repositoryRevision: 'abc123',
+          localContentHash: '',
         },
       ],
     });
@@ -1082,7 +1083,7 @@ describe('checkImageCache', () => {
     );
   });
 
-  it('changes when a materialized child project changes locally', () => {
+  it('changes when a local materialized child project changes locally', () => {
     const projectRoot = createTmpDir();
     mkdirSync(join(projectRoot, 'packages', 'api'), { recursive: true });
     writeFileSync(
@@ -1128,5 +1129,75 @@ describe('checkImageCache', () => {
     );
 
     expect(result1.cacheTag).not.toBe(result2.cacheTag);
+  });
+
+  it('does not change when a repository-backed child project changes locally', () => {
+    const projectRoot = createTmpDir();
+    mkdirSync(join(projectRoot, 'packages', 'api'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, 'packages', 'api', 'package.json'),
+      '{"name":"api","version":"1.0.0"}\n'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result1 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'https://github.com/dataforxyz/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    writeFileSync(
+      join(projectRoot, 'packages', 'api', 'package.json'),
+      '{"name":"api","version":"2.0.0"}\n'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result2 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'https://github.com/dataforxyz/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(result1.cacheTag).toBe(result2.cacheTag);
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -42,6 +42,7 @@ function makeInputs(overrides: Partial<SetupHashInputs> = {}): SetupHashInputs {
     taskManagers: ['make'],
     agent: 'claude',
     roverVersion: '1.0.0',
+    sandboxExtraArgs: [],
     initScriptPath: '',
     initScriptContent: '',
     cacheFilesContent: '',
@@ -162,6 +163,16 @@ describe('computeSetupHash', () => {
         initScriptPath: 'scripts/bootstrap.sh',
         initScriptContent: '#!/bin/sh\necho hi\n',
       })
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when sandboxExtraArgs change', () => {
+    const a = computeSetupHash(
+      makeInputs({ sandboxExtraArgs: ['--env', 'FOO=one'] })
+    );
+    const b = computeSetupHash(
+      makeInputs({ sandboxExtraArgs: ['--env', 'FOO=two'] })
     );
     expect(a).not.toBe(b);
   });
@@ -923,6 +934,7 @@ describe('checkImageCache', () => {
       taskManagers: [],
       agent: 'claude',
       roverVersion: '1.0.0-test',
+      sandboxExtraArgs: [],
       initScriptContent: '',
       cacheFilesContent: '',
       mcps: [],
@@ -985,6 +997,7 @@ describe('checkImageCache', () => {
       taskManagers: [],
       agent: 'claude',
       roverVersion: '1.0.0-test',
+      sandboxExtraArgs: [],
       initScriptContent: '',
       cacheFilesContent: '',
       mcps: [],
@@ -1013,11 +1026,80 @@ describe('checkImageCache', () => {
       taskManagers: [],
       agent: 'claude',
       roverVersion: '1.0.0-test',
+      sandboxExtraArgs: [],
       initScriptContent: '',
       cacheFilesContent: '',
       mcps: [],
     });
     expect(result.cacheTag).toBe(getCacheImageTag(expectedHash));
+  });
+
+  it('changes when effective sandbox extra args change', () => {
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result1 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        sandboxExtraArgs: '--env API_URL=https://one.example',
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result2 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        sandboxExtraArgs: '--env API_URL=https://two.example',
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(result1.cacheTag).not.toBe(result2.cacheTag);
+  });
+
+  it('ignores volume-only sandbox extra args in the cache hash', () => {
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result1 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        sandboxExtraArgs: '--env FOO=bar -v named:/cache',
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result2 = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        sandboxExtraArgs: '--env FOO=bar --volume different:/cache',
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(result1.cacheTag).toBe(result2.cacheTag);
   });
 
   it('hashes sub-project init scripts using the project-relative path first', () => {
@@ -1064,6 +1146,7 @@ describe('checkImageCache', () => {
       taskManagers: [],
       agent: 'claude',
       roverVersion: '1.0.0-test',
+      sandboxExtraArgs: [],
       initScriptContent: '',
       cacheFilesContent: '',
       mcps: [],
@@ -1117,6 +1200,7 @@ describe('checkImageCache', () => {
       taskManagers: [],
       agent: 'claude',
       roverVersion: '1.0.0-test',
+      sandboxExtraArgs: [],
       initScriptContent: '',
       cacheFilesContent: '',
       mcps: [],
@@ -1173,6 +1257,7 @@ describe('checkImageCache', () => {
       taskManagers: [],
       agent: 'claude',
       roverVersion: '1.0.0-test',
+      sandboxExtraArgs: [],
       initScriptPath: '../shared/setup.sh',
       initScriptContent: '#!/bin/sh\necho shared root init\n',
       cacheFilesContent: '',
@@ -1291,6 +1376,105 @@ describe('checkImageCache', () => {
       ['ls-remote', hostRepo, 'main'],
       { reject: false }
     );
+  });
+
+  it('resolves file URL repositories for cache hashing', () => {
+    const hostRepo = createTmpDir();
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: `file://${hostRepo}`,
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', hostRepo, 'main'],
+      { reject: false }
+    );
+  });
+
+  it('includes local child repository working tree contents in the cache hash', () => {
+    const projectRoot = createTmpDir();
+    const hostRepo = join(projectRoot, 'repos', 'api');
+    mkdirSync(join(hostRepo, '.git'), { recursive: true });
+    writeFileSync(
+      join(hostRepo, 'package.json'),
+      '{"name":"api","version":"1.0.0"}\n'
+    );
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    const result = checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: './repos/api',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    const expectedHash = computeSetupHash({
+      agentImage: 'sha256:img',
+      languages: ['typescript'],
+      packageManagers: ['pnpm'],
+      taskManagers: [],
+      agent: 'claude',
+      roverVersion: '1.0.0-test',
+      sandboxExtraArgs: [],
+      initScriptContent: '',
+      cacheFilesContent: '',
+      mcps: [],
+      projects: [
+        {
+          name: 'api',
+          path: 'packages/api',
+          repository: './repos/api',
+          ref: 'main',
+          repositoryRevision: 'abc123',
+          localContentHash: hashDirectoryContents(hostRepo),
+        },
+      ],
+    });
+
+    expect(result.cacheTag).toBe(getCacheImageTag(expectedHash));
   });
 
   it('changes when a local materialized child project changes locally', () => {

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -1341,6 +1341,79 @@ describe('checkImageCache', () => {
     );
   });
 
+  it('resolves plain relative repositories for cache hashing', () => {
+    const projectRoot = createTmpDir();
+
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projectRoot,
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'repos/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', join(projectRoot, 'repos', 'api.git'), 'main'],
+      { reject: false }
+    );
+  });
+
+  it('preserves SCP-style repository URLs for cache hashing', () => {
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'abc123\trefs/heads/main\n',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({
+      stdout: 'sha256:img',
+      exitCode: 0,
+    } as any);
+    mockedLaunchSync.mockReturnValueOnce({ exitCode: 1 } as any);
+
+    checkImageCache(
+      ContainerBackend.Docker,
+      makeProjectConfig({
+        projects: [
+          {
+            name: 'api',
+            path: 'packages/api',
+            repository: 'git@github.com:dataforxyz/api.git',
+            ref: 'main',
+          },
+        ],
+      }),
+      'my-agent:latest',
+      'claude'
+    );
+
+    expect(mockedLaunchSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['ls-remote', 'git@github.com:dataforxyz/api.git', 'main'],
+      { reject: false }
+    );
+  });
+
   it('uses absolute host repository paths for cache hashing', () => {
     const hostRepo = createTmpDir();
 

--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -963,7 +963,7 @@ describe('checkImageCache', () => {
     expect(result.cacheTag).toBe(getCacheImageTag(expectedHash));
   });
 
-  it('hashes sub-project init scripts using the root-relative configured path', () => {
+  it('hashes sub-project init scripts using the project-relative path first', () => {
     const projectRoot = createTmpDir();
     mkdirSync(join(projectRoot, 'packages', 'api', 'scripts'), {
       recursive: true,
@@ -1017,7 +1017,7 @@ describe('checkImageCache', () => {
           localContentHash: hashDirectoryContents(
             join(projectRoot, 'packages', 'api')
           ),
-          initScriptContent: '#!/bin/sh\necho root\n',
+          initScriptContent: '#!/bin/sh\necho subproject\n',
         },
       ],
     });

--- a/packages/cli/src/lib/sandbox/__tests__/dart.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/dart.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { DartSandboxPackage } from '../languages/dart.js';
+
+describe('DartSandboxPackage', () => {
+  it('installs Linux desktop Flutter dependencies during setup', () => {
+    const script = new DartSandboxPackage().installScript();
+
+    expect(script).toContain(
+      'sudo apt-get install -y -qq cmake clang ninja-build pkg-config libgtk-3-dev'
+    );
+    expect(script).toContain('sudo userdel systemd-network');
+  });
+
+  it('pre-caches Linux Flutter artifacts during init', () => {
+    const script = new DartSandboxPackage().initScript();
+
+    expect(script).toContain('flutter precache');
+    expect(script).toContain('--no-web');
+  });
+});

--- a/packages/cli/src/lib/sandbox/__tests__/dart.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/dart.test.ts
@@ -17,4 +17,11 @@ describe('DartSandboxPackage', () => {
     expect(script).toContain('flutter precache');
     expect(script).toContain('--no-web');
   });
+
+  it('scans child project .fvmrc files when selecting Flutter versions', () => {
+    const script = new DartSandboxPackage(['apps/mobile']).installScript();
+
+    expect(script).toContain("for fvmrc_path in '/workspace/.fvmrc' '/workspace/apps/mobile/.fvmrc'; do");
+    expect(script).toContain('Using Flutter version from $fvmrc_path');
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/dart.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/dart.test.ts
@@ -21,7 +21,9 @@ describe('DartSandboxPackage', () => {
   it('scans child project .fvmrc files when selecting Flutter versions', () => {
     const script = new DartSandboxPackage(['apps/mobile']).installScript();
 
-    expect(script).toContain("for fvmrc_path in '/workspace/.fvmrc' '/workspace/apps/mobile/.fvmrc'; do");
+    expect(script).toContain(
+      "for fvmrc_path in '/workspace/.fvmrc' '/workspace/apps/mobile/.fvmrc'; do"
+    );
     expect(script).toContain('Using Flutter version from $fvmrc_path');
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/dependency-init-scripts.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/dependency-init-scripts.test.ts
@@ -24,4 +24,13 @@ describe('sandbox dependency init scripts', () => {
     expect(script).toContain('flutter precache');
     expect(script).not.toContain('flutter pub get');
   });
+
+  it('scans child project go.mod files before falling back to latest Go', () => {
+    const script = new GoSandboxPackage(['services/api']).installScript();
+
+    expect(script).toContain(
+      "for go_mod_path in '/workspace/go.mod' '/workspace/src/go.mod' '/workspace/services/api/go.mod' '/workspace/services/api/src/go.mod'; do"
+    );
+    expect(script).toContain('TC_VERSION=$(grep -oP');
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/dependency-init-scripts.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/dependency-init-scripts.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { UvSandboxPackage } from '../package-managers/uv.js';
+import { GoSandboxPackage } from '../languages/go.js';
+import { DartSandboxPackage } from '../languages/dart.js';
+
+describe('sandbox dependency init scripts', () => {
+  it('does not resolve uv workspace dependencies in the uv package init script', () => {
+    const script = new UvSandboxPackage().initScript();
+
+    expect(script).not.toContain('uv sync');
+    expect(script).not.toContain('/workspace/.venv/bin');
+  });
+
+  it('does not resolve Go workspace dependencies in the Go language init script', () => {
+    const script = new GoSandboxPackage().initScript();
+
+    expect(script).toContain('export GOPATH="$HOME/go"');
+    expect(script).not.toContain('go mod download');
+  });
+
+  it('does not resolve Flutter workspace dependencies in the Dart language init script', () => {
+    const script = new DartSandboxPackage().initScript();
+
+    expect(script).toContain('flutter precache');
+    expect(script).not.toContain('flutter pub get');
+  });
+});

--- a/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
@@ -192,6 +192,25 @@ describe('sandbox inspect', () => {
     });
   });
 
+  it('forwards DOCKER_HOST when probing docker backend availability', async () => {
+    const sandbox = new DockerSandbox(createTaskFixture(), undefined, {
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+      },
+    });
+    mockLaunch.mockResolvedValueOnce({
+      stdout: JSON.stringify({ ServerVersion: '26.1.0' }),
+    });
+
+    await expect(sandbox.isBackendAvailable()).resolves.toBe(true);
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      'docker',
+      ['info', '--format', 'json'],
+      { env: expect.objectContaining({ DOCKER_HOST: 'tcp://remote:2375' }) }
+    );
+  });
+
   it.each([
     ['docker', DockerSandbox, 'docker', undefined],
     ['podman', PodmanSandbox, 'podman', undefined],
@@ -318,6 +337,47 @@ describe('sandbox inspect', () => {
         '--network',
         'rover-services-1-1',
       ])
+    );
+  });
+
+  it('forwards DOCKER_HOST to docker create/start when resuming with persisted metadata', async () => {
+    const sandbox = new DockerSandbox(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    mockLaunch
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: 'container-1' })
+      .mockResolvedValueOnce({ stdout: '' });
+
+    await expect(sandbox.createAndStart()).resolves.toBe('container-1');
+
+    expect(mockLaunch).toHaveBeenNthCalledWith(
+      1,
+      'docker',
+      ['rm', '-f', 'rover-task-1-1'],
+      { env: expect.objectContaining({ DOCKER_HOST: 'tcp://remote:2375' }) }
+    );
+    expect(mockLaunch).toHaveBeenNthCalledWith(
+      2,
+      'docker',
+      expect.arrayContaining(['create', '--name', 'rover-task-1-1']),
+      { env: expect.objectContaining({ DOCKER_HOST: 'tcp://remote:2375' }) }
+    );
+    expect(mockLaunch).toHaveBeenNthCalledWith(
+      3,
+      'docker',
+      ['start', 'rover-task-1-1'],
+      { env: expect.objectContaining({ DOCKER_HOST: 'tcp://remote:2375' }) }
     );
   });
 

--- a/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
@@ -212,9 +212,9 @@ describe('sandbox inspect', () => {
   });
 
   it.each([
-    ['docker', DockerSandbox, 'docker', undefined],
-    ['podman', PodmanSandbox, 'podman', undefined],
-  ])('tears down services for exited %s containers', async (_label, SandboxCtor, backend, teardownEnv) => {
+    ['docker', DockerSandbox],
+    ['podman', PodmanSandbox],
+  ])('preserves services for exited %s containers until removal', async (_label, SandboxCtor) => {
     const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
       sandboxMetadata: {
         serviceContext: {
@@ -232,17 +232,15 @@ describe('sandbox inspect', () => {
       exitCode: 1,
     });
 
-    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
-      backend,
-      {
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
         networkName: 'rover-services-1-1',
         containerNames: ['rover-svc-1-1-postgres'],
         taskId: 1,
         iteration: 1,
       },
-      teardownEnv
-    );
-    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+    });
   });
 
   it.each([

--- a/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
@@ -199,4 +199,61 @@ describe('sandbox inspect', () => {
     );
     expect(sandbox.getSandboxMetadata()).toBeUndefined();
   });
+
+  it.each([
+    [
+      'docker',
+      DockerSandbox,
+      'No such object: rover-task-1-1',
+      'docker',
+      { env: expect.any(Object) },
+      undefined,
+    ],
+    [
+      'podman',
+      PodmanSandbox,
+      'no such container "rover-task-1-1"',
+      'podman',
+      { stdio: 'pipe' },
+      undefined,
+    ],
+  ])('tears down persisted services when %s inspect finds no task container', async (_label, SandboxCtor, stderr, backend, inspectOptions, teardownEnv) => {
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+    const error = new Error(stderr) as Error & { stderr: string };
+    error.stderr = stderr;
+    mockLaunch.mockRejectedValueOnce(error);
+
+    await expect(sandbox.inspect()).resolves.toBeNull();
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      backend,
+      [
+        'inspect',
+        '--format',
+        '{{.State.Status}}|{{.State.ExitCode}}',
+        'rover-task-1-1',
+      ],
+      inspectOptions
+    );
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      backend,
+      {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
+      teardownEnv
+    );
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
@@ -1,8 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockLaunch, mockTeardownServiceContainers } = vi.hoisted(() => ({
+const {
+  mockLaunch,
+  mockTeardownServiceContainers,
+  mockGetServiceNetworkArgs,
+  mockCheckImageCache,
+} = vi.hoisted(() => ({
   mockLaunch: vi.fn(),
   mockTeardownServiceContainers: vi.fn(),
+  mockGetServiceNetworkArgs: vi.fn(() => ['--network', 'rover-services-1-1']),
+  mockCheckImageCache: vi.fn(() => ({
+    hasCachedImage: true,
+    cacheTag: 'rover-cache:test',
+  })),
 }));
 
 vi.mock('rover-core', () => ({
@@ -57,10 +67,7 @@ vi.mock('../../setup.js', () => ({
 }));
 
 vi.mock('../container-image-cache.js', () => ({
-  checkImageCache: vi.fn(() => ({
-    hasCachedImage: false,
-    cacheTag: 'rover-cache:test',
-  })),
+  checkImageCache: mockCheckImageCache,
   waitForInitAndCommit: vi.fn(),
 }));
 
@@ -90,7 +97,7 @@ vi.mock('../container-common.js', () => ({
 
 vi.mock('../service-containers.js', () => ({
   createServiceNetwork: vi.fn(),
-  getServiceNetworkArgs: vi.fn(() => []),
+  getServiceNetworkArgs: mockGetServiceNetworkArgs,
   startServiceContainers: vi.fn(),
   teardownServiceContainers: mockTeardownServiceContainers,
   waitForServicesReady: vi.fn(),
@@ -255,5 +262,43 @@ describe('sandbox inspect', () => {
       teardownEnv
     );
     expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('attaches resumed %s task containers to the persisted service network', async (_label, SandboxCtor, backend) => {
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    mockLaunch
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: 'container-1' })
+      .mockResolvedValueOnce({ stdout: '' });
+
+    await expect(sandbox.createAndStart()).resolves.toBe('container-1');
+
+    expect(mockGetServiceNetworkArgs).toHaveBeenCalledWith(
+      'rover-services-1-1'
+    );
+    expect(mockLaunch.mock.calls[1]?.[0]).toBe(backend);
+    expect(mockLaunch.mock.calls[1]?.[1]).toEqual(
+      expect.arrayContaining([
+        'create',
+        '--name',
+        'rover-task-1-1',
+        '--network',
+        'rover-services-1-1',
+      ])
+    );
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
@@ -5,6 +5,7 @@ const {
   mockTeardownServiceContainers,
   mockGetServiceNetworkArgs,
   mockCheckImageCache,
+  mockGetRepositoryMounts,
 } = vi.hoisted(() => ({
   mockLaunch: vi.fn(),
   mockTeardownServiceContainers: vi.fn(),
@@ -13,6 +14,9 @@ const {
     hasCachedImage: true,
     cacheTag: 'rover-cache:test',
   })),
+  mockGetRepositoryMounts: vi.fn<
+    () => Array<{ hostPath: string; containerPath: string }>
+  >(() => []),
 }));
 
 vi.mock('rover-core', () => ({
@@ -62,6 +66,10 @@ vi.mock('../../setup.js', () => ({
 
     generateWorkspaceDescription() {
       return undefined;
+    }
+
+    getRepositoryMounts() {
+      return mockGetRepositoryMounts();
     }
   },
 }));
@@ -136,6 +144,7 @@ function createTaskFixture() {
 describe('sandbox inspect', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetRepositoryMounts.mockReturnValue([]);
   });
 
   it.each([
@@ -308,6 +317,36 @@ describe('sandbox inspect', () => {
         'rover-task-1-1',
         '--network',
         'rover-services-1-1',
+      ])
+    );
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('mounts local workspace repositories into %s task containers', async (_label, SandboxCtor, backend) => {
+    mockGetRepositoryMounts.mockReturnValue([
+      {
+        hostPath: '/repo/repos/frontend.git',
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+    });
+
+    mockLaunch
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({ stdout: 'container-1' });
+
+    await expect((sandbox as any).create()).resolves.toBe('container-1');
+
+    expect(mockLaunch.mock.calls[1]?.[0]).toBe(backend);
+    expect(mockLaunch.mock.calls[1]?.[1]).toEqual(
+      expect.arrayContaining([
+        '-v',
+        '/repo/repos/frontend.git:/workspace-repos/0:Z,ro',
       ])
     );
   });

--- a/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
@@ -96,8 +96,18 @@ vi.mock('../container-common.js', () => ({
 }));
 
 vi.mock('../service-containers.js', () => ({
+  buildServiceContainerContext: vi.fn((services, taskId, iteration) => ({
+    networkName: `rover-services-${taskId}-${iteration}`,
+    containerNames: services.map(
+      (service: { name: string }) =>
+        `rover-svc-${taskId}-${iteration}-${service.name}`
+    ),
+    taskId,
+    iteration,
+  })),
   createServiceNetwork: vi.fn(),
   getServiceNetworkArgs: mockGetServiceNetworkArgs,
+  isServiceContainerContextAvailable: vi.fn(),
   startServiceContainers: vi.fn(),
   teardownServiceContainers: mockTeardownServiceContainers,
   waitForServicesReady: vi.fn(),

--- a/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/inspect.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLaunch, mockTeardownServiceContainers } = vi.hoisted(() => ({
+  mockLaunch: vi.fn(),
+  mockTeardownServiceContainers: vi.fn(),
+}));
+
+vi.mock('rover-core', () => ({
+  generateRandomId: vi.fn(() => 'random-id'),
+  launch: mockLaunch,
+  ProcessManager: class {},
+  ProjectConfigManager: {
+    load: vi.fn(() => ({
+      services: [],
+      envs: [],
+      allInitScripts: [],
+      projectRoot: '/repo',
+    })),
+  },
+  TaskDescriptionManager: class {},
+  VERBOSE: false,
+}));
+
+vi.mock('../../agents/index.js', () => ({
+  getAIAgentTool: vi.fn(() => ({
+    getContainerMounts: () => [],
+    getEnvironmentVariables: () => [],
+  })),
+}));
+
+vi.mock('../../context.js', () => ({
+  isJsonMode: vi.fn(() => false),
+}));
+
+vi.mock('../../network-config.js', () => ({
+  mergeNetworkConfig: vi.fn(() => undefined),
+}));
+
+vi.mock('../../setup.js', () => ({
+  SetupBuilder: class {
+    generateEntrypoint() {
+      return '/tmp/entrypoint.sh';
+    }
+
+    generateInputs() {
+      return '/tmp/inputs.json';
+    }
+
+    saveWorkflow() {
+      return '/tmp/workflow.yml';
+    }
+
+    generateWorkspaceDescription() {
+      return undefined;
+    }
+  },
+}));
+
+vi.mock('../container-image-cache.js', () => ({
+  checkImageCache: vi.fn(() => ({
+    hasCachedImage: false,
+    cacheTag: 'rover-cache:test',
+  })),
+  waitForInitAndCommit: vi.fn(),
+}));
+
+vi.mock('../download-cache.js', () => ({
+  ensureDownloadCacheVolumes: vi.fn(),
+  getDownloadCacheMounts: vi.fn(() => []),
+}));
+
+vi.mock('../container-common.js', () => ({
+  ContainerBackend: {
+    Docker: 'docker',
+    Podman: 'podman',
+  },
+  getCheckpointArgs: vi.fn(() => []),
+  getWorktreeGitMounts: vi.fn(() => []),
+  normalizeExtraArgs: vi.fn(() => []),
+  resolveAgentImage: vi.fn(() => 'agent:latest'),
+  resolveInitScriptPath: vi.fn(() => '/tmp/init-script.sh'),
+  getInitScriptMounts: vi.fn(() => []),
+  tmpUserGroupFiles: vi.fn(async () => ({
+    etcPasswd: '/tmp/passwd',
+    etcGroup: '/tmp/group',
+    cleanup: vi.fn(),
+  })),
+  warnIfCustomImage: vi.fn(),
+}));
+
+vi.mock('../service-containers.js', () => ({
+  createServiceNetwork: vi.fn(),
+  getServiceNetworkArgs: vi.fn(() => []),
+  startServiceContainers: vi.fn(),
+  teardownServiceContainers: mockTeardownServiceContainers,
+  waitForServicesReady: vi.fn(),
+}));
+
+vi.mock('../worktree-path.js', () => ({
+  validateSandboxWorktreePath: vi.fn(),
+}));
+
+import { DockerSandbox } from '../docker.js';
+import { PodmanSandbox } from '../podman.js';
+
+function createTaskFixture() {
+  return {
+    id: 1,
+    iterations: 1,
+    agent: 'claude',
+    worktreePath: '/tmp/worktree',
+    getLastIteration: () => ({
+      iterationPath: '/tmp/iteration',
+      fileDescriptionPath: '/tmp/iteration/description.json',
+    }),
+  } as any;
+}
+
+describe('sandbox inspect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker', { env: expect.any(Object) }],
+    ['podman', PodmanSandbox, 'podman', { stdio: 'pipe' }],
+  ])('does not tear down services for live %s statuses', async (_label, SandboxCtor, backend, inspectOptions) => {
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    for (const status of ['created', 'restarting', 'paused']) {
+      mockLaunch.mockResolvedValueOnce({ stdout: `${status}|0` });
+
+      await expect(sandbox.inspect()).resolves.toEqual({
+        status,
+        exitCode: 0,
+      });
+    }
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      backend,
+      [
+        'inspect',
+        '--format',
+        '{{.State.Status}}|{{.State.ExitCode}}',
+        'rover-task-1-1',
+      ],
+      inspectOptions
+    );
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
+    });
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker', undefined],
+    ['podman', PodmanSandbox, 'podman', undefined],
+  ])('tears down services for exited %s containers', async (_label, SandboxCtor, backend, teardownEnv) => {
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+    mockLaunch.mockResolvedValueOnce({ stdout: 'exited|1' });
+
+    await expect(sandbox.inspect()).resolves.toEqual({
+      status: 'exited',
+      exitCode: 1,
+    });
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      backend,
+      {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
+      teardownEnv
+    );
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -233,4 +233,21 @@ describe('interactive sandbox cleanup', () => {
     }
     expect((sandbox as any).serviceContext).toBeUndefined();
   });
+
+  it.each([
+    ['docker', DockerSandbox],
+    ['podman', PodmanSandbox],
+  ])('preserves the interactive failure when %s sidecar cleanup also fails', async (_label, SandboxCtor) => {
+    mockLaunch.mockRejectedValueOnce(new Error('interactive run failed'));
+    mockTeardownServiceContainers.mockRejectedValueOnce(
+      new Error('cleanup failed')
+    );
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+    });
+
+    await expect(sandbox.runInteractive()).rejects.toThrow(
+      'interactive run failed'
+    );
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -1,0 +1,235 @@
+import { mkdtempSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockLaunch,
+  mockProjectConfigLoad,
+  mockCreateServiceNetwork,
+  mockStartServiceContainers,
+  mockWaitForServicesReady,
+  mockTeardownServiceContainers,
+  mockTmpUserGroupFiles,
+  mockEnsureDownloadCacheVolumes,
+  mockGetDownloadCacheMounts,
+  mockGetServiceNetworkArgs,
+  mockValidateSandboxWorktreePath,
+} = vi.hoisted(() => ({
+  mockLaunch: vi.fn(),
+  mockProjectConfigLoad: vi.fn(),
+  mockCreateServiceNetwork: vi.fn(),
+  mockStartServiceContainers: vi.fn(),
+  mockWaitForServicesReady: vi.fn(),
+  mockTeardownServiceContainers: vi.fn(),
+  mockTmpUserGroupFiles: vi.fn(),
+  mockEnsureDownloadCacheVolumes: vi.fn(),
+  mockGetDownloadCacheMounts: vi.fn(),
+  mockGetServiceNetworkArgs: vi.fn(),
+  mockValidateSandboxWorktreePath: vi.fn(),
+}));
+
+vi.mock('rover-core', () => ({
+  generateRandomId: vi.fn(() => 'random-id'),
+  launch: mockLaunch,
+  ProcessManager: class {},
+  ProjectConfigManager: {
+    load: mockProjectConfigLoad,
+  },
+  TaskDescriptionManager: class {},
+  VERBOSE: false,
+}));
+
+vi.mock('../../agents/index.js', () => ({
+  getAIAgentTool: vi.fn(() => ({
+    getContainerMounts: () => [],
+    getEnvironmentVariables: () => [],
+  })),
+}));
+
+vi.mock('../../context.js', () => ({
+  isJsonMode: vi.fn(() => false),
+}));
+
+vi.mock('../../network-config.js', () => ({
+  mergeNetworkConfig: vi.fn(() => undefined),
+}));
+
+vi.mock('../../setup.js', () => ({
+  SetupBuilder: class {
+    generateEntrypoint() {
+      return '/tmp/entrypoint.sh';
+    }
+
+    generateWorkspaceDescription() {
+      return undefined;
+    }
+  },
+}));
+
+vi.mock('../container-image-cache.js', () => ({
+  checkImageCache: vi.fn(() => ({
+    hasCachedImage: false,
+    cacheTag: 'rover-cache:test',
+  })),
+}));
+
+vi.mock('../download-cache.js', () => ({
+  ensureDownloadCacheVolumes: mockEnsureDownloadCacheVolumes,
+  getDownloadCacheMounts: mockGetDownloadCacheMounts,
+}));
+
+vi.mock('../container-common.js', () => ({
+  ContainerBackend: {
+    Docker: 'docker',
+    Podman: 'podman',
+  },
+  getCheckpointArgs: vi.fn(() => []),
+  getWorktreeGitMounts: vi.fn(() => []),
+  normalizeExtraArgs: vi.fn(() => []),
+  resolveAgentImage: vi.fn(() => 'agent:latest'),
+  resolveInitScriptPath: vi.fn(() => '/tmp/init-script.sh'),
+  tmpUserGroupFiles: mockTmpUserGroupFiles,
+  warnIfCustomImage: vi.fn(),
+}));
+
+vi.mock('../service-containers.js', () => ({
+  createServiceNetwork: mockCreateServiceNetwork,
+  getServiceNetworkArgs: mockGetServiceNetworkArgs,
+  startServiceContainers: mockStartServiceContainers,
+  teardownServiceContainers: mockTeardownServiceContainers,
+  waitForServicesReady: mockWaitForServicesReady,
+}));
+
+vi.mock('../worktree-path.js', () => ({
+  validateSandboxWorktreePath: mockValidateSandboxWorktreePath,
+}));
+
+import { DockerSandbox } from '../docker.js';
+import { PodmanSandbox } from '../podman.js';
+
+function createTaskFixture() {
+  const baseDir = mkdtempSync(join(tmpdir(), 'rover-interactive-cleanup-'));
+  const worktreePath = join(baseDir, 'worktree');
+  const iterationPath = join(baseDir, 'iteration');
+  mkdirSync(worktreePath, { recursive: true });
+  mkdirSync(iterationPath, { recursive: true });
+
+  return {
+    id: 1,
+    iterations: 1,
+    agent: 'claude',
+    worktreePath,
+    getLastIteration: () => ({
+      iterationPath,
+    }),
+  } as any;
+}
+
+describe('interactive sandbox cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLaunch.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+    mockProjectConfigLoad.mockReturnValue({
+      services: [{ name: 'postgres' }],
+      envs: [],
+      allInitScripts: [],
+      projectRoot: '/repo',
+    });
+    mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockStartServiceContainers.mockResolvedValue(['rover-svc-1-1-postgres']);
+    mockWaitForServicesReady.mockResolvedValue(undefined);
+    mockTmpUserGroupFiles.mockResolvedValue({
+      etcPasswd: '/tmp/passwd',
+      etcGroup: '/tmp/group',
+      cleanup: vi.fn(),
+    });
+    mockGetDownloadCacheMounts.mockReturnValue([]);
+    mockGetServiceNetworkArgs.mockReturnValue([
+      '--network',
+      'rover-services-1-1',
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('tears down %s sidecars after interactive exit', async (_label, SandboxCtor, backend) => {
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+    });
+
+    await sandbox.runInteractive('fix the bug');
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      backend,
+      expect.arrayContaining(['run', '--rm']),
+      expect.objectContaining({
+        detached: false,
+        reject: false,
+        stdio: 'inherit',
+      })
+    );
+    if (backend === 'docker') {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+        expect.any(Object)
+      );
+    } else {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(backend, {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      });
+    }
+    expect((sandbox as any).serviceContext).toBeUndefined();
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('tears down %s sidecars if interactive startup fails after creating the network', async (_label, SandboxCtor, backend) => {
+    mockStartServiceContainers.mockRejectedValueOnce(
+      new Error('service startup failed')
+    );
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+    });
+
+    await expect(sandbox.runInteractive()).rejects.toThrow(
+      'service startup failed'
+    );
+
+    if (backend === 'docker') {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: [],
+          taskId: 1,
+          iteration: 1,
+        },
+        expect.any(Object)
+      );
+    } else {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(backend, {
+        networkName: 'rover-services-1-1',
+        containerNames: [],
+        taskId: 1,
+        iteration: 1,
+      });
+    }
+    expect((sandbox as any).serviceContext).toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -16,6 +16,7 @@ const {
   mockGetDownloadCacheMounts,
   mockGetServiceNetworkArgs,
   mockValidateSandboxWorktreePath,
+  mockGetRepositoryMounts,
 } = vi.hoisted(() => ({
   mockLaunch: vi.fn(),
   mockProjectConfigLoad: vi.fn(),
@@ -29,6 +30,9 @@ const {
   mockGetDownloadCacheMounts: vi.fn(),
   mockGetServiceNetworkArgs: vi.fn(),
   mockValidateSandboxWorktreePath: vi.fn(),
+  mockGetRepositoryMounts: vi.fn<
+    () => Array<{ hostPath: string; containerPath: string }>
+  >(() => []),
 }));
 
 vi.mock('rover-core', () => ({
@@ -65,6 +69,10 @@ vi.mock('../../setup.js', () => ({
 
     generateWorkspaceDescription() {
       return undefined;
+    }
+
+    getRepositoryMounts() {
+      return mockGetRepositoryMounts();
     }
   },
 }));
@@ -163,6 +171,7 @@ describe('interactive sandbox cleanup', () => {
       '--network',
       'rover-services-1-1',
     ]);
+    mockGetRepositoryMounts.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -208,6 +217,37 @@ describe('interactive sandbox cleanup', () => {
       });
     }
     expect((sandbox as any).serviceContext).toBeUndefined();
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('mounts local workspace repositories for interactive %s sessions', async (_label, SandboxCtor, backend) => {
+    mockGetRepositoryMounts.mockReturnValue([
+      {
+        hostPath: '/repo/repos/frontend.git',
+        containerPath: '/workspace-repos/0',
+      },
+    ]);
+
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+    });
+
+    await sandbox.runInteractive('fix the bug');
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      backend,
+      expect.arrayContaining([
+        '-v',
+        '/repo/repos/frontend.git:/workspace-repos/0:Z,ro',
+      ]),
+      expect.objectContaining({
+        detached: false,
+        reject: false,
+        stdio: 'inherit',
+      })
+    );
   });
 
   it.each([

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { mkdtempSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -132,6 +133,30 @@ vi.mock('../worktree-path.js', () => ({
 import { DockerSandbox } from '../docker.js';
 import { PodmanSandbox } from '../podman.js';
 
+function hashServices(services: unknown): string {
+  const stableSerialize = (value: unknown): string => {
+    if (Array.isArray(value)) {
+      return `[${value.map(item => stableSerialize(item)).join(',')}]`;
+    }
+
+    if (value && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>).sort(
+        ([left], [right]) => left.localeCompare(right)
+      );
+      return `{${entries
+        .map(
+          ([key, nestedValue]) =>
+            `${JSON.stringify(key)}:${stableSerialize(nestedValue)}`
+        )
+        .join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+  };
+
+  return createHash('sha256').update(stableSerialize(services)).digest('hex');
+}
+
 function createTaskFixture() {
   const baseDir = mkdtempSync(join(tmpdir(), 'rover-interactive-cleanup-'));
   const worktreePath = join(baseDir, 'worktree');
@@ -204,21 +229,24 @@ describe('interactive sandbox cleanup', () => {
     if (backend === 'docker') {
       expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
         backend,
-        {
+        expect.objectContaining({
           networkName: 'rover-services-1-1',
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
-        },
+        }),
         expect.any(Object)
       );
     } else {
-      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(backend, {
-        networkName: 'rover-services-1-1',
-        containerNames: ['rover-svc-1-1-postgres'],
-        taskId: 1,
-        iteration: 1,
-      });
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        expect.objectContaining({
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      );
     }
     expect((sandbox as any).serviceContext).toBeUndefined();
   });
@@ -272,23 +300,23 @@ describe('interactive sandbox cleanup', () => {
     if (backend === 'docker') {
       expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
         backend,
-        {
+        expect.objectContaining({
           networkName: 'rover-services-1-1',
           containerNames: [],
           taskId: 1,
           iteration: 1,
-        },
+        }),
         undefined
       );
     } else {
       expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
         backend,
-        {
+        expect.objectContaining({
           networkName: 'rover-services-1-1',
           containerNames: [],
           taskId: 1,
           iteration: 1,
-        },
+        }),
         undefined
       );
     }
@@ -326,6 +354,7 @@ describe('interactive sandbox cleanup', () => {
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
+          serviceConfigHash: hashServices([{ name: 'postgres' }]),
         },
       },
     });
@@ -345,6 +374,7 @@ describe('interactive sandbox cleanup', () => {
         containerNames: ['rover-svc-1-1-postgres'],
         taskId: 1,
         iteration: 1,
+        serviceConfigHash: hashServices([{ name: 'postgres' }]),
       },
     });
   });
@@ -361,6 +391,7 @@ describe('interactive sandbox cleanup', () => {
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
+          serviceConfigHash: hashServices([{ name: 'postgres' }]),
         },
       },
     });
@@ -405,6 +436,7 @@ describe('interactive sandbox cleanup', () => {
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
+          serviceConfigHash: hashServices([{ name: 'postgres' }]),
         },
       },
     });
@@ -453,21 +485,25 @@ describe('interactive sandbox cleanup', () => {
     if (backend === 'docker') {
       expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
         backend,
-        {
+        expect.objectContaining({
           networkName: 'rover-services-1-1',
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
-        },
+        }),
         undefined
       );
     } else {
-      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(backend, {
-        networkName: 'rover-services-1-1',
-        containerNames: ['rover-svc-1-1-postgres'],
-        taskId: 1,
-        iteration: 1,
-      });
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        expect.objectContaining({
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        }),
+        undefined
+      );
     }
     expect(mockCreateServiceNetwork).toHaveBeenCalled();
     expect(mockStartServiceContainers).toHaveBeenCalled();

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -285,4 +285,41 @@ describe('interactive sandbox cleanup', () => {
       },
     });
   });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('attaches %s workspace shells to the persisted service network', async (_label, SandboxCtor, backend) => {
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    await sandbox.openShellAtWorktree();
+
+    expect(mockGetServiceNetworkArgs).toHaveBeenCalledWith(
+      'rover-services-1-1'
+    );
+    expect(mockLaunch).toHaveBeenCalledWith(
+      backend,
+      expect.arrayContaining([
+        'run',
+        '--rm',
+        '--network',
+        'rover-services-1-1',
+      ]),
+      expect.objectContaining({
+        detached: false,
+        reject: false,
+        stdio: 'inherit',
+      })
+    );
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -97,6 +97,15 @@ vi.mock('../container-common.js', () => ({
 }));
 
 vi.mock('../service-containers.js', () => ({
+  buildServiceContainerContext: vi.fn((services, taskId, iteration) => ({
+    networkName: `rover-services-${taskId}-${iteration}`,
+    containerNames: services.map(
+      (service: { name: string }) =>
+        `rover-svc-${taskId}-${iteration}-${service.name}`
+    ),
+    taskId,
+    iteration,
+  })),
   createServiceNetwork: mockCreateServiceNetwork,
   getServiceNetworkArgs: mockGetServiceNetworkArgs,
   isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -9,6 +9,7 @@ const {
   mockCreateServiceNetwork,
   mockStartServiceContainers,
   mockWaitForServicesReady,
+  mockIsServiceContainerContextAvailable,
   mockTeardownServiceContainers,
   mockTmpUserGroupFiles,
   mockEnsureDownloadCacheVolumes,
@@ -21,6 +22,7 @@ const {
   mockCreateServiceNetwork: vi.fn(),
   mockStartServiceContainers: vi.fn(),
   mockWaitForServicesReady: vi.fn(),
+  mockIsServiceContainerContextAvailable: vi.fn(),
   mockTeardownServiceContainers: vi.fn(),
   mockTmpUserGroupFiles: vi.fn(),
   mockEnsureDownloadCacheVolumes: vi.fn(),
@@ -97,6 +99,7 @@ vi.mock('../container-common.js', () => ({
 vi.mock('../service-containers.js', () => ({
   createServiceNetwork: mockCreateServiceNetwork,
   getServiceNetworkArgs: mockGetServiceNetworkArgs,
+  isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,
   startServiceContainers: mockStartServiceContainers,
   teardownServiceContainers: mockTeardownServiceContainers,
   waitForServicesReady: mockWaitForServicesReady,
@@ -138,6 +141,7 @@ describe('interactive sandbox cleanup', () => {
       projectRoot: '/repo',
     });
     mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockIsServiceContainerContextAvailable.mockResolvedValue(false);
     mockStartServiceContainers.mockResolvedValue(['rover-svc-1-1-postgres']);
     mockWaitForServicesReady.mockResolvedValue(undefined);
     mockTmpUserGroupFiles.mockResolvedValue({
@@ -221,15 +225,19 @@ describe('interactive sandbox cleanup', () => {
           taskId: 1,
           iteration: 1,
         },
-        expect.any(Object)
+        undefined
       );
     } else {
-      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(backend, {
-        networkName: 'rover-services-1-1',
-        containerNames: [],
-        taskId: 1,
-        iteration: 1,
-      });
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: [],
+          taskId: 1,
+          iteration: 1,
+        },
+        undefined
+      );
     }
     expect((sandbox as any).serviceContext).toBeUndefined();
   });
@@ -255,6 +263,8 @@ describe('interactive sandbox cleanup', () => {
     ['docker', DockerSandbox],
     ['podman', PodmanSandbox],
   ])('reuses persisted %s sidecars for interactive sessions', async (_label, SandboxCtor) => {
+    mockIsServiceContainerContextAvailable.mockResolvedValueOnce(true);
+
     const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
       projectPath: '/repo',
       sandboxMetadata: {
@@ -290,6 +300,8 @@ describe('interactive sandbox cleanup', () => {
     ['docker', DockerSandbox, 'docker'],
     ['podman', PodmanSandbox, 'podman'],
   ])('attaches %s workspace shells to the persisted service network', async (_label, SandboxCtor, backend) => {
+    mockIsServiceContainerContextAvailable.mockResolvedValueOnce(true);
+
     const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
       projectPath: '/repo',
       sandboxMetadata: {
@@ -321,5 +333,49 @@ describe('interactive sandbox cleanup', () => {
         stdio: 'inherit',
       })
     );
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('recreates stale %s sidecars for workspace shells', async (_label, SandboxCtor, backend) => {
+    mockIsServiceContainerContextAvailable.mockResolvedValueOnce(false);
+
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    await sandbox.openShellAtWorktree();
+
+    if (backend === 'docker') {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+        expect.any(Object)
+      );
+    } else {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(backend, {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      });
+    }
+    expect(mockCreateServiceNetwork).toHaveBeenCalled();
+    expect(mockStartServiceContainers).toHaveBeenCalled();
+    expect(mockWaitForServicesReady).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -7,6 +7,7 @@ const {
   mockLaunch,
   mockProjectConfigLoad,
   mockCreateServiceNetwork,
+  mockHasAnyServiceContainerResources,
   mockStartServiceContainers,
   mockWaitForServicesReady,
   mockIsServiceContainerContextAvailable,
@@ -21,6 +22,7 @@ const {
   mockLaunch: vi.fn(),
   mockProjectConfigLoad: vi.fn(),
   mockCreateServiceNetwork: vi.fn(),
+  mockHasAnyServiceContainerResources: vi.fn(),
   mockStartServiceContainers: vi.fn(),
   mockWaitForServicesReady: vi.fn(),
   mockIsServiceContainerContextAvailable: vi.fn(),
@@ -116,6 +118,7 @@ vi.mock('../service-containers.js', () => ({
   })),
   createServiceNetwork: mockCreateServiceNetwork,
   getServiceNetworkArgs: mockGetServiceNetworkArgs,
+  hasAnyServiceContainerResources: mockHasAnyServiceContainerResources,
   isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,
   startServiceContainers: mockStartServiceContainers,
   teardownServiceContainers: mockTeardownServiceContainers,
@@ -158,6 +161,7 @@ describe('interactive sandbox cleanup', () => {
       projectRoot: '/repo',
     });
     mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockHasAnyServiceContainerResources.mockResolvedValue(false);
     mockIsServiceContainerContextAvailable.mockResolvedValue(false);
     mockStartServiceContainers.mockResolvedValue(['rover-svc-1-1-postgres']);
     mockWaitForServicesReady.mockResolvedValue(undefined);
@@ -343,6 +347,48 @@ describe('interactive sandbox cleanup', () => {
         iteration: 1,
       },
     });
+  });
+
+  it('forwards DOCKER_HOST to docker interactive runs and shells', async () => {
+    mockIsServiceContainerContextAvailable.mockResolvedValue(true);
+
+    const sandbox = new DockerSandbox(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        dockerHost: 'tcp://remote:2375',
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    await sandbox.runInteractive('fix the bug');
+    await sandbox.openShellAtWorktree();
+
+    expect(mockLaunch).toHaveBeenNthCalledWith(
+      1,
+      'docker',
+      expect.arrayContaining(['run', '--name', 'rover-task-1-1-i']),
+      expect.objectContaining({
+        env: expect.objectContaining({ DOCKER_HOST: 'tcp://remote:2375' }),
+      })
+    );
+    expect(mockLaunch).toHaveBeenNthCalledWith(
+      2,
+      'docker',
+      expect.arrayContaining([
+        'run',
+        '--rm',
+        '--name',
+        'rover-shell-1-random-id',
+      ]),
+      expect.objectContaining({
+        env: expect.objectContaining({ DOCKER_HOST: 'tcp://remote:2375' }),
+      })
+    );
   });
 
   it.each([

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -89,6 +89,7 @@ vi.mock('../container-common.js', () => ({
   normalizeExtraArgs: vi.fn(() => []),
   resolveAgentImage: vi.fn(() => 'agent:latest'),
   resolveInitScriptPath: vi.fn(() => '/tmp/init-script.sh'),
+  getInitScriptMounts: vi.fn(() => []),
   tmpUserGroupFiles: mockTmpUserGroupFiles,
   warnIfCustomImage: vi.fn(),
 }));

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -250,4 +250,39 @@ describe('interactive sandbox cleanup', () => {
       'interactive run failed'
     );
   });
+
+  it.each([
+    ['docker', DockerSandbox],
+    ['podman', PodmanSandbox],
+  ])('reuses persisted %s sidecars for interactive sessions', async (_label, SandboxCtor) => {
+    const sandbox = new SandboxCtor(createTaskFixture(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    await sandbox.runInteractive('fix the bug');
+
+    expect(mockCreateServiceNetwork).not.toHaveBeenCalled();
+    expect(mockStartServiceContainers).not.toHaveBeenCalled();
+    expect(mockWaitForServicesReady).not.toHaveBeenCalled();
+    expect(mockGetServiceNetworkArgs).toHaveBeenCalledWith(
+      'rover-services-1-1'
+    );
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
+    });
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/interactive-cleanup.test.ts
@@ -364,7 +364,7 @@ describe('interactive sandbox cleanup', () => {
           taskId: 1,
           iteration: 1,
         },
-        expect.any(Object)
+        undefined
       );
     } else {
       expect(mockTeardownServiceContainers).toHaveBeenCalledWith(backend, {

--- a/packages/cli/src/lib/sandbox/__tests__/packages.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/packages.test.ts
@@ -1,0 +1,55 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { ProjectConfigManager } from 'rover-core';
+import { getPackagesFromConfig } from '../packages.js';
+
+function createProjectConfig(
+  projectRoot: string,
+  projects: Array<{ path: string }>
+): ProjectConfigManager {
+  return {
+    version: '1.2',
+    projectRoot,
+    language: 'go',
+    languages: ['go', 'dart'],
+    packageManagers: [],
+    taskManagers: [],
+    allLanguages: ['go', 'dart'],
+    allPackageManagers: [],
+    allTaskManagers: [],
+    projects,
+    mcps: [],
+    attribution: true,
+    allInitScripts: [],
+  } as unknown as ProjectConfigManager;
+}
+
+describe('getPackagesFromConfig', () => {
+  it('ignores subproject paths that escape the workspace through symlinks', () => {
+    const root = mkdtempSync(join(tmpdir(), 'rover-packages-root-'));
+    const outside = mkdtempSync(join(tmpdir(), 'rover-packages-outside-'));
+
+    try {
+      mkdirSync(join(outside, 'api'), { recursive: true });
+      symlinkSync(outside, join(root, 'services'));
+
+      const packages = getPackagesFromConfig(
+        createProjectConfig(root, [{ path: 'services/api' }])
+      );
+
+      const goScript =
+        packages.find(pkg => pkg.name === 'Go')?.installScript() ?? '';
+      const dartScript =
+        packages.find(pkg => pkg.name === 'Dart')?.installScript() ?? '';
+
+      expect(goScript).not.toContain('/workspace/services/api/go.mod');
+      expect(goScript).not.toContain('/workspace/services/api/src/go.mod');
+      expect(dartScript).not.toContain('/workspace/services/api/.fvmrc');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -16,6 +16,15 @@ const {
 }));
 
 vi.mock('../service-containers.js', () => ({
+  buildServiceContainerContext: vi.fn((services, taskId, iteration) => ({
+    networkName: `rover-services-${taskId}-${iteration}`,
+    containerNames: services.map(
+      (service: { name: string }) =>
+        `rover-svc-${taskId}-${iteration}-${service.name}`
+    ),
+    taskId,
+    iteration,
+  })),
   createServiceNetwork: mockCreateServiceNetwork,
   getServiceNetworkArgs: vi.fn(() => []),
   isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -1,4 +1,37 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const {
+  mockCreateServiceNetwork,
+  mockStartServiceContainers,
+  mockWaitForServicesReady,
+  mockTeardownServiceContainers,
+  mockProjectConfigLoad,
+} = vi.hoisted(() => ({
+  mockCreateServiceNetwork: vi.fn(),
+  mockStartServiceContainers: vi.fn(),
+  mockWaitForServicesReady: vi.fn(),
+  mockTeardownServiceContainers: vi.fn(),
+  mockProjectConfigLoad: vi.fn(),
+}));
+
+vi.mock('../service-containers.js', () => ({
+  createServiceNetwork: mockCreateServiceNetwork,
+  getServiceNetworkArgs: vi.fn(() => []),
+  startServiceContainers: mockStartServiceContainers,
+  teardownServiceContainers: mockTeardownServiceContainers,
+  waitForServicesReady: mockWaitForServicesReady,
+}));
+
+vi.mock('rover-core', async () => {
+  const actual = await vi.importActual<typeof import('rover-core')>('rover-core');
+  return {
+    ...actual,
+    ProjectConfigManager: {
+      ...actual.ProjectConfigManager,
+      load: mockProjectConfigLoad,
+    },
+  };
+});
+
 import { DockerSandbox } from '../docker.js';
 import { PodmanSandbox } from '../podman.js';
 
@@ -10,6 +43,11 @@ function createFakeTask() {
 }
 
 describe('sandbox startup cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProjectConfigLoad.mockReturnValue({ services: [] });
+  });
+
   it('cleans temporary files when Docker startup fails', async () => {
     const sandbox = new DockerSandbox(createFakeTask());
     const cleanup = vi.fn();
@@ -46,5 +84,100 @@ describe('sandbox startup cleanup', () => {
     );
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect((sandbox as any)._tmpCleanups).toEqual([]);
+  });
+
+  it('tears down Docker service containers when task container startup fails', async () => {
+    mockProjectConfigLoad.mockReturnValue({ services: [{ name: 'postgres' }] });
+    mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockStartServiceContainers.mockResolvedValue(['rover-svc-1-1-postgres']);
+    mockWaitForServicesReady.mockResolvedValue(undefined);
+
+    const sandbox = new DockerSandbox(createFakeTask(), undefined, {
+      projectPath: '/repo',
+    });
+
+    (sandbox as any).checkCacheState = vi.fn().mockImplementation(() => {
+      (sandbox as any).shouldCommitCache = false;
+    });
+    (sandbox as any).create = vi
+      .fn()
+      .mockRejectedValue(new Error('docker create failed'));
+
+    await expect(sandbox.createAndStart()).rejects.toThrow(
+      'docker create failed'
+    );
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      },
+      expect.any(Object)
+    );
+    expect((sandbox as any).serviceContext).toBeUndefined();
+  });
+
+  it('tears down Podman service containers when task container startup fails', async () => {
+    mockProjectConfigLoad.mockReturnValue({ services: [{ name: 'postgres' }] });
+    mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockStartServiceContainers.mockResolvedValue(['rover-svc-1-1-postgres']);
+    mockWaitForServicesReady.mockResolvedValue(undefined);
+
+    const sandbox = new PodmanSandbox(createFakeTask(), undefined, {
+      projectPath: '/repo',
+    });
+
+    (sandbox as any).checkCacheState = vi.fn().mockImplementation(() => {
+      (sandbox as any).shouldCommitCache = false;
+    });
+    (sandbox as any).create = vi
+      .fn()
+      .mockRejectedValue(new Error('podman create failed'));
+
+    await expect(sandbox.createAndStart()).rejects.toThrow(
+      'podman create failed'
+    );
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'podman',
+      {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      }
+    );
+    expect((sandbox as any).serviceContext).toBeUndefined();
+  });
+
+  it('tears down a Docker service network if startup fails before containers are recorded', async () => {
+    mockProjectConfigLoad.mockReturnValue({ services: [{ name: 'postgres' }] });
+    mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockStartServiceContainers.mockRejectedValue(
+      new Error('service startup failed')
+    );
+
+    const sandbox = new DockerSandbox(createFakeTask(), undefined, {
+      projectPath: '/repo',
+    });
+
+    (sandbox as any).checkCacheState = vi.fn().mockImplementation(() => {
+      (sandbox as any).shouldCommitCache = false;
+    });
+
+    await expect(sandbox.createAndStart()).rejects.toThrow(
+      'service startup failed'
+    );
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      {
+        networkName: 'rover-services-1-1',
+        containerNames: [],
+        taskId: 1,
+        iteration: 1,
+      },
+      expect.any(Object)
+    );
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockCreateServiceNetwork,
+  mockIsServiceContainerContextAvailable,
   mockStartServiceContainers,
   mockWaitForServicesReady,
   mockTeardownServiceContainers,
   mockProjectConfigLoad,
 } = vi.hoisted(() => ({
   mockCreateServiceNetwork: vi.fn(),
+  mockIsServiceContainerContextAvailable: vi.fn(),
   mockStartServiceContainers: vi.fn(),
   mockWaitForServicesReady: vi.fn(),
   mockTeardownServiceContainers: vi.fn(),
@@ -16,6 +18,7 @@ const {
 vi.mock('../service-containers.js', () => ({
   createServiceNetwork: mockCreateServiceNetwork,
   getServiceNetworkArgs: vi.fn(() => []),
+  isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,
   startServiceContainers: mockStartServiceContainers,
   teardownServiceContainers: mockTeardownServiceContainers,
   waitForServicesReady: mockWaitForServicesReady,
@@ -47,6 +50,8 @@ describe('sandbox startup cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProjectConfigLoad.mockReturnValue({ services: [] });
+    mockIsServiceContainerContextAvailable.mockResolvedValue(false);
+    mockTeardownServiceContainers.mockResolvedValue(undefined);
   });
 
   it('cleans temporary files when Docker startup fails', async () => {
@@ -175,7 +180,7 @@ describe('sandbox startup cleanup', () => {
         taskId: 1,
         iteration: 1,
       },
-      expect.any(Object)
+      undefined
     );
   });
 
@@ -207,6 +212,7 @@ describe('sandbox startup cleanup', () => {
     ['podman', PodmanSandbox],
   ])('reuses persisted %s service context during createAndStart', async (_label, SandboxCtor) => {
     mockProjectConfigLoad.mockReturnValue({ services: [{ name: 'postgres' }] });
+    mockIsServiceContainerContextAvailable.mockResolvedValueOnce(true);
 
     const sandbox = new SandboxCtor(createFakeTask(), undefined, {
       projectPath: '/repo',
@@ -230,5 +236,65 @@ describe('sandbox startup cleanup', () => {
     expect(mockCreateServiceNetwork).not.toHaveBeenCalled();
     expect(mockStartServiceContainers).not.toHaveBeenCalled();
     expect(mockWaitForServicesReady).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['docker', DockerSandbox, 'docker'],
+    ['podman', PodmanSandbox, 'podman'],
+  ])('recreates stale persisted %s service context during createAndStart', async (_label, SandboxCtor, backend) => {
+    mockProjectConfigLoad.mockReturnValue({
+      services: [{ name: 'postgres' }],
+    });
+    mockIsServiceContainerContextAvailable.mockResolvedValueOnce(false);
+    mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockStartServiceContainers.mockResolvedValue(['rover-svc-1-1-postgres']);
+    mockWaitForServicesReady.mockResolvedValue(undefined);
+
+    const sandbox = new SandboxCtor(createFakeTask(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    (sandbox as any).checkCacheState = vi.fn().mockImplementation(() => {
+      (sandbox as any).shouldCommitCache = false;
+    });
+    (sandbox as any).create = vi.fn().mockResolvedValue('sandbox-id');
+    (sandbox as any).start = vi.fn().mockResolvedValue('sandbox-id');
+
+    await expect(sandbox.createAndStart()).resolves.toBe('sandbox-id');
+
+    if (backend === 'docker') {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+        undefined
+      );
+    } else {
+      expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+        backend,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+        undefined
+      );
+    }
+    expect(mockCreateServiceNetwork).toHaveBeenCalled();
+    expect(mockStartServiceContainers).toHaveBeenCalled();
+    expect(mockWaitForServicesReady).toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockCreateServiceNetwork,
@@ -50,6 +51,30 @@ vi.mock('rover-core', async () => {
 
 import { DockerSandbox } from '../docker.js';
 import { PodmanSandbox } from '../podman.js';
+
+function hashServices(services: unknown): string {
+  const stableSerialize = (value: unknown): string => {
+    if (Array.isArray(value)) {
+      return `[${value.map(item => stableSerialize(item)).join(',')}]`;
+    }
+
+    if (value && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>).sort(
+        ([left], [right]) => left.localeCompare(right)
+      );
+      return `{${entries
+        .map(
+          ([key, nestedValue]) =>
+            `${JSON.stringify(key)}:${stableSerialize(nestedValue)}`
+        )
+        .join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+  };
+
+  return createHash('sha256').update(stableSerialize(services)).digest('hex');
+}
 
 function createFakeTask() {
   return {
@@ -127,12 +152,12 @@ describe('sandbox startup cleanup', () => {
     );
     expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
       'docker',
-      {
+      expect.objectContaining({
         networkName: 'rover-services-1-1',
         containerNames: ['rover-svc-1-1-postgres'],
         taskId: 1,
         iteration: 1,
-      },
+      }),
       expect.any(Object)
     );
     expect((sandbox as any).serviceContext).toBeUndefined();
@@ -158,12 +183,15 @@ describe('sandbox startup cleanup', () => {
     await expect(sandbox.createAndStart()).rejects.toThrow(
       'podman create failed'
     );
-    expect(mockTeardownServiceContainers).toHaveBeenCalledWith('podman', {
-      networkName: 'rover-services-1-1',
-      containerNames: ['rover-svc-1-1-postgres'],
-      taskId: 1,
-      iteration: 1,
-    });
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'podman',
+      expect.objectContaining({
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-postgres'],
+        taskId: 1,
+        iteration: 1,
+      })
+    );
     expect((sandbox as any).serviceContext).toBeUndefined();
   });
 
@@ -187,12 +215,12 @@ describe('sandbox startup cleanup', () => {
     );
     expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
       'docker',
-      {
+      expect.objectContaining({
         networkName: 'rover-services-1-1',
         containerNames: [],
         taskId: 1,
         iteration: 1,
-      },
+      }),
       undefined
     );
   });
@@ -235,6 +263,7 @@ describe('sandbox startup cleanup', () => {
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
+          serviceConfigHash: hashServices([{ name: 'postgres' }]),
         },
       },
     });
@@ -271,6 +300,7 @@ describe('sandbox startup cleanup', () => {
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
+          serviceConfigHash: 'outdated-hash',
         },
       },
     });
@@ -286,23 +316,23 @@ describe('sandbox startup cleanup', () => {
     if (backend === 'docker') {
       expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
         backend,
-        {
+        expect.objectContaining({
           networkName: 'rover-services-1-1',
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
-        },
+        }),
         undefined
       );
     } else {
       expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
         backend,
-        {
+        expect.objectContaining({
           networkName: 'rover-services-1-1',
           containerNames: ['rover-svc-1-1-postgres'],
           taskId: 1,
           iteration: 1,
-        },
+        }),
         undefined
       );
     }

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -178,4 +178,27 @@ describe('sandbox startup cleanup', () => {
       expect.any(Object)
     );
   });
+
+  it('preserves the original Docker service startup error when teardown also fails', async () => {
+    mockProjectConfigLoad.mockReturnValue({ services: [{ name: 'postgres' }] });
+    mockCreateServiceNetwork.mockResolvedValue('rover-services-1-1');
+    mockStartServiceContainers.mockRejectedValue(
+      new Error('service startup failed')
+    );
+    mockTeardownServiceContainers.mockRejectedValue(
+      new Error('cleanup failed')
+    );
+
+    const sandbox = new DockerSandbox(createFakeTask(), undefined, {
+      projectPath: '/repo',
+    });
+
+    (sandbox as any).checkCacheState = vi.fn().mockImplementation(() => {
+      (sandbox as any).shouldCommitCache = false;
+    });
+
+    await expect(sandbox.createAndStart()).rejects.toThrow(
+      'service startup failed'
+    );
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -201,4 +201,34 @@ describe('sandbox startup cleanup', () => {
       'service startup failed'
     );
   });
+
+  it.each([
+    ['docker', DockerSandbox],
+    ['podman', PodmanSandbox],
+  ])('reuses persisted %s service context during createAndStart', async (_label, SandboxCtor) => {
+    mockProjectConfigLoad.mockReturnValue({ services: [{ name: 'postgres' }] });
+
+    const sandbox = new SandboxCtor(createFakeTask(), undefined, {
+      projectPath: '/repo',
+      sandboxMetadata: {
+        serviceContext: {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        },
+      },
+    });
+
+    (sandbox as any).checkCacheState = vi.fn().mockImplementation(() => {
+      (sandbox as any).shouldCommitCache = false;
+    });
+    (sandbox as any).create = vi.fn().mockResolvedValue('sandbox-id');
+    (sandbox as any).start = vi.fn().mockResolvedValue('sandbox-id');
+
+    await expect(sandbox.createAndStart()).resolves.toBe('sandbox-id');
+    expect(mockCreateServiceNetwork).not.toHaveBeenCalled();
+    expect(mockStartServiceContainers).not.toHaveBeenCalled();
+    expect(mockWaitForServicesReady).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -22,7 +22,8 @@ vi.mock('../service-containers.js', () => ({
 }));
 
 vi.mock('rover-core', async () => {
-  const actual = await vi.importActual<typeof import('rover-core')>('rover-core');
+  const actual =
+    await vi.importActual<typeof import('rover-core')>('rover-core');
   return {
     ...actual,
     ProjectConfigManager: {
@@ -139,15 +140,12 @@ describe('sandbox startup cleanup', () => {
     await expect(sandbox.createAndStart()).rejects.toThrow(
       'podman create failed'
     );
-    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
-      'podman',
-      {
-        networkName: 'rover-services-1-1',
-        containerNames: ['rover-svc-1-1-postgres'],
-        taskId: 1,
-        iteration: 1,
-      }
-    );
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith('podman', {
+      networkName: 'rover-services-1-1',
+      containerNames: ['rover-svc-1-1-postgres'],
+      taskId: 1,
+      iteration: 1,
+    });
     expect((sandbox as any).serviceContext).toBeUndefined();
   });
 

--- a/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/sandbox-startup-cleanup.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 const {
   mockCreateServiceNetwork,
+  mockHasAnyServiceContainerResources,
   mockIsServiceContainerContextAvailable,
   mockStartServiceContainers,
   mockWaitForServicesReady,
@@ -8,6 +9,7 @@ const {
   mockProjectConfigLoad,
 } = vi.hoisted(() => ({
   mockCreateServiceNetwork: vi.fn(),
+  mockHasAnyServiceContainerResources: vi.fn(),
   mockIsServiceContainerContextAvailable: vi.fn(),
   mockStartServiceContainers: vi.fn(),
   mockWaitForServicesReady: vi.fn(),
@@ -27,6 +29,7 @@ vi.mock('../service-containers.js', () => ({
   })),
   createServiceNetwork: mockCreateServiceNetwork,
   getServiceNetworkArgs: vi.fn(() => []),
+  hasAnyServiceContainerResources: mockHasAnyServiceContainerResources,
   isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,
   startServiceContainers: mockStartServiceContainers,
   teardownServiceContainers: mockTeardownServiceContainers,
@@ -59,6 +62,7 @@ describe('sandbox startup cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProjectConfigLoad.mockReturnValue({ services: [] });
+    mockHasAnyServiceContainerResources.mockResolvedValue(false);
     mockIsServiceContainerContextAvailable.mockResolvedValue(false);
     mockTeardownServiceContainers.mockResolvedValue(undefined);
   });

--- a/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
@@ -11,6 +11,7 @@ import {
   buildServiceContainerContext,
   createServiceNetwork,
   getServiceNetworkArgs,
+  hasAnyServiceContainerResources,
   isServiceContainerContextAvailable,
   startServiceContainers,
   teardownServiceContainers,
@@ -781,6 +782,53 @@ describe('service-containers', () => {
         ['inspect', '--format', '{{json .State}}', 'rover-svc-1-1-pg'],
         { env, reject: false }
       );
+    });
+  });
+
+  describe('hasAnyServiceContainerResources', () => {
+    it('returns true when the service network already exists', async () => {
+      mockedLaunch.mockResolvedValueOnce({ exitCode: 0, stdout: '[]' });
+
+      await expect(
+        hasAnyServiceContainerResources(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(true);
+
+      expect(mockedLaunch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns true when a deterministic sidecar container exists without the network', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 1, stdout: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'container-id' });
+
+      await expect(
+        hasAnyServiceContainerResources(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(true);
+    });
+
+    it('returns false when neither the network nor expected containers exist', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 1, stdout: '' })
+        .mockResolvedValueOnce({ exitCode: 1, stdout: '' });
+
+      await expect(
+        hasAnyServiceContainerResources(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(false);
     });
   });
 

--- a/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
@@ -8,6 +8,7 @@ vi.mock('rover-core', () => ({
 }));
 
 import {
+  buildServiceContainerContext,
   createServiceNetwork,
   getServiceNetworkArgs,
   isServiceContainerContextAvailable,
@@ -89,6 +90,15 @@ describe('service-containers', () => {
         ['network', 'create', 'rover-services-8-4'],
         undefined
       );
+    });
+
+    it('re-throws non-race-condition errors from network create', async () => {
+      mockedLaunch.mockResolvedValueOnce({ stdout: '', exitCode: 1 });
+      mockedLaunch.mockRejectedValueOnce(new Error('permission denied'));
+
+      await expect(
+        createServiceNetwork(ContainerBackend.Docker, 1, 1)
+      ).rejects.toThrow('permission denied');
     });
   });
 
@@ -236,6 +246,59 @@ describe('service-containers', () => {
       );
     });
 
+    it('forwards env to create and start calls', async () => {
+      const env = { DOCKER_HOST: 'tcp://remote:2375' } as NodeJS.ProcessEnv;
+      const services: ServiceContainer[] = [
+        { name: 'redis', image: 'redis:7', readyTimeout: 60 },
+      ];
+
+      await startServiceContainers(
+        ContainerBackend.Docker,
+        services,
+        'net',
+        1,
+        1,
+        env
+      );
+
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        1,
+        ContainerBackend.Docker,
+        expect.arrayContaining(['create', '--name', 'rover-svc-1-1-redis']),
+        { env }
+      );
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        2,
+        ContainerBackend.Docker,
+        ['start', 'rover-svc-1-1-redis'],
+        { env }
+      );
+    });
+
+    it('creates containers with port mappings', async () => {
+      const services: ServiceContainer[] = [
+        {
+          name: 'postgres',
+          image: 'postgres:16',
+          ports: [5432],
+          readyTimeout: 60,
+        },
+      ];
+
+      await startServiceContainers(
+        ContainerBackend.Docker,
+        services,
+        'net',
+        2,
+        1
+      );
+
+      // ports are not mapped to host — they're accessible via the service
+      // network by alias, so no -p flags should appear
+      const createArgs = mockedLaunch.mock.calls[0][1];
+      expect(createArgs).not.toContain('-p');
+    });
+
     it('reports partially started containers before failing mid-loop', async () => {
       const onContainerStarted = vi.fn();
       const services: ServiceContainer[] = [
@@ -263,6 +326,41 @@ describe('service-containers', () => {
       expect(onContainerStarted).toHaveBeenCalledTimes(1);
       expect(onContainerStarted).toHaveBeenCalledWith([
         'rover-svc-1-1-postgres',
+      ]);
+    });
+
+    it('tracks newly created containers before failing to start a later service', async () => {
+      const onContainerStarted = vi.fn();
+      const services: ServiceContainer[] = [
+        { name: 'postgres', image: 'postgres:16', readyTimeout: 60 },
+        { name: 'redis', image: 'redis:7', readyTimeout: 60 },
+      ];
+
+      mockedLaunch
+        .mockResolvedValueOnce({ stdout: '' })
+        .mockResolvedValueOnce({ stdout: '' })
+        .mockResolvedValueOnce({ stdout: '' })
+        .mockRejectedValueOnce(new Error('failed to start redis'));
+
+      await expect(
+        startServiceContainers(
+          ContainerBackend.Docker,
+          services,
+          'net',
+          1,
+          1,
+          undefined,
+          onContainerStarted
+        )
+      ).rejects.toThrow('failed to start redis');
+
+      expect(onContainerStarted).toHaveBeenCalledTimes(2);
+      expect(onContainerStarted).toHaveBeenNthCalledWith(1, [
+        'rover-svc-1-1-postgres',
+      ]);
+      expect(onContainerStarted).toHaveBeenNthCalledWith(2, [
+        'rover-svc-1-1-postgres',
+        'rover-svc-1-1-redis',
       ]);
     });
   });
@@ -335,6 +433,151 @@ describe('service-containers', () => {
         ])
       ).rejects.toThrow('reported unhealthy');
     });
+
+    it('throws timeout error when service does not become healthy in time', async () => {
+      // Always return 'starting' so it never becomes healthy
+      mockedLaunch.mockResolvedValue({ stdout: 'starting' });
+
+      const services: ServiceContainer[] = [
+        {
+          name: 'slow',
+          image: 'postgres:16',
+          // Use a tiny timeout so the test completes quickly
+          readyTimeout: 0,
+          healthcheck: {
+            cmd: 'pg_isready',
+            interval: 1,
+            timeout: 1,
+            retries: 1,
+            startPeriod: 0,
+          },
+        },
+      ];
+
+      await expect(
+        waitForServicesReady(ContainerBackend.Docker, services, [
+          'rover-svc-1-1-slow',
+        ])
+      ).rejects.toThrow('did not become healthy within 0s');
+    });
+
+    it('retries on transient inspect failures then succeeds', async () => {
+      mockedLaunch
+        .mockRejectedValueOnce(new Error('container is restarting'))
+        .mockResolvedValueOnce({ stdout: 'healthy' });
+
+      const services: ServiceContainer[] = [
+        {
+          name: 'pg',
+          image: 'postgres:16',
+          readyTimeout: 30,
+          healthcheck: {
+            cmd: 'pg_isready',
+            interval: 5,
+            timeout: 5,
+            retries: 3,
+            startPeriod: 0,
+          },
+        },
+      ];
+
+      await waitForServicesReady(ContainerBackend.Docker, services, [
+        'rover-svc-1-1-pg',
+      ]);
+
+      expect(mockedLaunch).toHaveBeenCalledTimes(2);
+    });
+
+    it('waits for multiple services independently', async () => {
+      // First service (no healthcheck) — no calls
+      // Second service (with healthcheck) — polls once, gets healthy
+      mockedLaunch.mockResolvedValueOnce({ stdout: 'healthy' });
+
+      const services: ServiceContainer[] = [
+        { name: 'redis', image: 'redis:7', readyTimeout: 10 },
+        {
+          name: 'pg',
+          image: 'postgres:16',
+          readyTimeout: 10,
+          healthcheck: {
+            cmd: 'pg_isready',
+            interval: 5,
+            timeout: 5,
+            retries: 3,
+            startPeriod: 0,
+          },
+        },
+      ];
+
+      await waitForServicesReady(ContainerBackend.Docker, services, [
+        'rover-svc-1-1-redis',
+        'rover-svc-1-1-pg',
+      ]);
+
+      // Only the pg service should have triggered an inspect
+      expect(mockedLaunch).toHaveBeenCalledTimes(1);
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['inspect', '--format', '{{.State.Health.Status}}', 'rover-svc-1-1-pg'],
+        undefined
+      );
+    });
+
+    it('forwards env to health inspect calls', async () => {
+      const env = { DOCKER_HOST: 'tcp://remote:2375' } as NodeJS.ProcessEnv;
+      mockedLaunch.mockResolvedValueOnce({ stdout: 'healthy' });
+
+      const services: ServiceContainer[] = [
+        {
+          name: 'pg',
+          image: 'postgres:16',
+          readyTimeout: 10,
+          healthcheck: {
+            cmd: 'pg_isready',
+            interval: 5,
+            timeout: 5,
+            retries: 3,
+            startPeriod: 0,
+          },
+        },
+      ];
+
+      await waitForServicesReady(
+        ContainerBackend.Docker,
+        services,
+        ['rover-svc-1-1-pg'],
+        env
+      );
+
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['inspect', '--format', '{{.State.Health.Status}}', 'rover-svc-1-1-pg'],
+        { env }
+      );
+    });
+  });
+
+  describe('buildServiceContainerContext', () => {
+    it('builds context with correct network name and container names', () => {
+      const ctx = buildServiceContainerContext(
+        [{ name: 'postgres' }, { name: 'redis' }],
+        5,
+        3
+      );
+
+      expect(ctx).toEqual({
+        networkName: 'rover-services-5-3',
+        containerNames: ['rover-svc-5-3-postgres', 'rover-svc-5-3-redis'],
+        taskId: 5,
+        iteration: 3,
+      });
+    });
+
+    it('returns empty containerNames for empty services array', () => {
+      const ctx = buildServiceContainerContext([], 1, 1);
+      expect(ctx.containerNames).toEqual([]);
+      expect(ctx.networkName).toBe('rover-services-1-1');
+    });
   });
 
   describe('getServiceNetworkArgs', () => {
@@ -403,6 +646,142 @@ describe('service-containers', () => {
         })
       ).resolves.toBe(false);
     });
+
+    it('returns false when a running health-checked container is still starting', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({
+            Running: true,
+            Health: { Status: 'starting' },
+          }),
+        });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(false);
+    });
+
+    it('returns false when the network does not exist', async () => {
+      mockedLaunch.mockResolvedValueOnce({ exitCode: 1, stdout: '' });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(false);
+
+      // Should not inspect containers if network is missing
+      expect(mockedLaunch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false when container inspect returns malformed JSON', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        .mockResolvedValueOnce({ exitCode: 0, stdout: 'not json {{' });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(false);
+    });
+
+    it('returns false if any container in a multi-container context is stopped', async () => {
+      mockedLaunch
+        // network inspect
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        // first container — running
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({ Running: true }),
+        })
+        // second container — stopped
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({ Running: false }),
+        });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres', 'rover-svc-1-1-redis'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(false);
+    });
+
+    it('returns true when all containers in a multi-container context are running', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({ Running: true }),
+        })
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({
+            Running: true,
+            Health: { Status: 'healthy' },
+          }),
+        });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-redis', 'rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(true);
+    });
+
+    it('forwards env to inspect calls', async () => {
+      const env = { DOCKER_HOST: 'tcp://remote:2375' } as NodeJS.ProcessEnv;
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({ Running: true }),
+        });
+
+      await isServiceContainerContextAvailable(
+        ContainerBackend.Docker,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-pg'],
+          taskId: 1,
+          iteration: 1,
+        },
+        env
+      );
+
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        1,
+        ContainerBackend.Docker,
+        ['network', 'inspect', 'rover-services-1-1'],
+        { env, reject: false }
+      );
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        2,
+        ContainerBackend.Docker,
+        ['inspect', '--format', '{{json .State}}', 'rover-svc-1-1-pg'],
+        { env, reject: false }
+      );
+    });
   });
 
   describe('teardownServiceContainers', () => {
@@ -442,6 +821,57 @@ describe('service-containers', () => {
           iteration: 1,
         })
       ).resolves.toBeUndefined();
+    });
+
+    it('forwards env to rm and network rm calls', async () => {
+      const env = { DOCKER_HOST: 'tcp://remote:2375' } as NodeJS.ProcessEnv;
+
+      await teardownServiceContainers(
+        ContainerBackend.Docker,
+        {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-pg'],
+          taskId: 1,
+          iteration: 1,
+        },
+        env
+      );
+
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['rm', '-f', 'rover-svc-1-1-pg'],
+        { env }
+      );
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['network', 'rm', 'rover-services-1-1'],
+        { env }
+      );
+    });
+
+    it('continues removing remaining containers even if one fails', async () => {
+      mockedLaunch
+        .mockRejectedValueOnce(new Error('container not found'))
+        .mockResolvedValueOnce({ stdout: '' })
+        .mockResolvedValueOnce({ stdout: '' });
+
+      await teardownServiceContainers(ContainerBackend.Docker, {
+        networkName: 'net',
+        containerNames: ['c1', 'c2'],
+        taskId: 1,
+        iteration: 1,
+      });
+
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['rm', '-f', 'c2'],
+        undefined
+      );
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['network', 'rm', 'net'],
+        undefined
+      );
     });
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockedLaunch = vi.hoisted(() => vi.fn());
+
+vi.mock('rover-core', () => ({
+  launch: mockedLaunch,
+  VERBOSE: false,
+}));
+
+import {
+  createServiceNetwork,
+  startServiceContainers,
+  waitForServicesReady,
+  getServiceNetworkArgs,
+  teardownServiceContainers,
+} from '../service-containers.js';
+import { ContainerBackend } from '../container-common.js';
+import type { ServiceContainer } from 'rover-schemas';
+
+describe('service-containers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedLaunch.mockResolvedValue({ stdout: '' });
+  });
+
+  describe('createServiceNetwork', () => {
+    it('creates a docker network with the expected name', async () => {
+      const name = await createServiceNetwork(ContainerBackend.Docker, 5, 2);
+
+      expect(name).toBe('rover-services-5-2');
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['network', 'create', 'rover-services-5-2'],
+        undefined
+      );
+    });
+
+    it('passes env for DOCKER_HOST forwarding', async () => {
+      const env = { DOCKER_HOST: 'tcp://remote:2375' } as NodeJS.ProcessEnv;
+      await createServiceNetwork(ContainerBackend.Docker, 1, 1, env);
+
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        expect.any(Array),
+        { env }
+      );
+    });
+  });
+
+  describe('startServiceContainers', () => {
+    it('creates and starts containers with correct args', async () => {
+      const services: ServiceContainer[] = [
+        {
+          name: 'postgres',
+          image: 'postgres:16',
+          env: ['POSTGRES_PASSWORD=test'],
+          ports: [5432],
+          readyTimeout: 60,
+          healthcheck: {
+            cmd: 'pg_isready',
+            interval: 5,
+            timeout: 5,
+            retries: 3,
+            startPeriod: 10,
+          },
+        },
+      ];
+
+      const names = await startServiceContainers(
+        ContainerBackend.Docker,
+        services,
+        'rover-services-1-1',
+        1,
+        1
+      );
+
+      expect(names).toEqual(['rover-svc-1-1-postgres']);
+
+      // First call: docker create
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        1,
+        ContainerBackend.Docker,
+        [
+          'create',
+          '--name',
+          'rover-svc-1-1-postgres',
+          '--network',
+          'rover-services-1-1',
+          '--network-alias',
+          'postgres',
+          '-e',
+          'POSTGRES_PASSWORD=test',
+          '--health-cmd',
+          'pg_isready',
+          '--health-interval',
+          '5s',
+          '--health-timeout',
+          '5s',
+          '--health-retries',
+          '3',
+          '--health-start-period',
+          '10s',
+          'postgres:16',
+        ],
+        undefined
+      );
+
+      // Second call: docker start
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        2,
+        ContainerBackend.Docker,
+        ['start', 'rover-svc-1-1-postgres'],
+        undefined
+      );
+    });
+
+    it('handles services with volumes and command override', async () => {
+      const services: ServiceContainer[] = [
+        {
+          name: 'redis',
+          image: 'redis:7',
+          volumes: ['redis-data:/data'],
+          command: ['redis-server', '--maxmemory', '256mb'],
+          readyTimeout: 60,
+        },
+      ];
+
+      await startServiceContainers(
+        ContainerBackend.Docker,
+        services,
+        'net',
+        1,
+        1
+      );
+
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        1,
+        ContainerBackend.Docker,
+        [
+          'create',
+          '--name',
+          'rover-svc-1-1-redis',
+          '--network',
+          'net',
+          '--network-alias',
+          'redis',
+          '-v',
+          'redis-data:/data',
+          'redis:7',
+          'redis-server',
+          '--maxmemory',
+          '256mb',
+        ],
+        undefined
+      );
+    });
+
+    it('splits string command overrides into argv entries', async () => {
+      const services: ServiceContainer[] = [
+        {
+          name: 'redis',
+          image: 'redis:7',
+          command: 'redis-server --appendonly yes',
+          readyTimeout: 60,
+        },
+      ];
+
+      await startServiceContainers(
+        ContainerBackend.Docker,
+        services,
+        'net',
+        1,
+        1
+      );
+
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        1,
+        ContainerBackend.Docker,
+        [
+          'create',
+          '--name',
+          'rover-svc-1-1-redis',
+          '--network',
+          'net',
+          '--network-alias',
+          'redis',
+          'redis:7',
+          'redis-server',
+          '--appendonly',
+          'yes',
+        ],
+        undefined
+      );
+    });
+  });
+
+  describe('waitForServicesReady', () => {
+    it('skips services without healthcheck', async () => {
+      const services: ServiceContainer[] = [
+        { name: 'redis', image: 'redis:7', readyTimeout: 30 },
+      ];
+
+      await waitForServicesReady(ContainerBackend.Docker, services, [
+        'rover-svc-1-1-redis',
+      ]);
+
+      // No inspect calls should be made
+      expect(mockedLaunch).not.toHaveBeenCalled();
+    });
+
+    it('polls until healthy', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ stdout: 'starting' })
+        .mockResolvedValueOnce({ stdout: 'healthy' });
+
+      const services: ServiceContainer[] = [
+        {
+          name: 'pg',
+          image: 'postgres:16',
+          readyTimeout: 10,
+          healthcheck: {
+            cmd: 'pg_isready',
+            interval: 5,
+            timeout: 5,
+            retries: 3,
+            startPeriod: 0,
+          },
+        },
+      ];
+
+      await waitForServicesReady(ContainerBackend.Docker, services, [
+        'rover-svc-1-1-pg',
+      ]);
+
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['inspect', '--format', '{{.State.Health.Status}}', 'rover-svc-1-1-pg'],
+        undefined
+      );
+    });
+
+    it('throws on unhealthy status', async () => {
+      mockedLaunch.mockResolvedValueOnce({ stdout: 'unhealthy' });
+
+      const services: ServiceContainer[] = [
+        {
+          name: 'pg',
+          image: 'postgres:16',
+          readyTimeout: 10,
+          healthcheck: {
+            cmd: 'pg_isready',
+            interval: 5,
+            timeout: 5,
+            retries: 3,
+            startPeriod: 0,
+          },
+        },
+      ];
+
+      await expect(
+        waitForServicesReady(ContainerBackend.Docker, services, [
+          'rover-svc-1-1-pg',
+        ])
+      ).rejects.toThrow('reported unhealthy');
+    });
+  });
+
+  describe('getServiceNetworkArgs', () => {
+    it('returns correct network args', () => {
+      expect(getServiceNetworkArgs('rover-services-1-1')).toEqual([
+        '--network',
+        'rover-services-1-1',
+      ]);
+    });
+  });
+
+  describe('teardownServiceContainers', () => {
+    it('removes containers and network (best-effort)', async () => {
+      await teardownServiceContainers(ContainerBackend.Docker, {
+        networkName: 'rover-services-1-1',
+        containerNames: ['rover-svc-1-1-pg', 'rover-svc-1-1-redis'],
+        taskId: 1,
+        iteration: 1,
+      });
+
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['rm', '-f', 'rover-svc-1-1-pg'],
+        undefined
+      );
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['rm', '-f', 'rover-svc-1-1-redis'],
+        undefined
+      );
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['network', 'rm', 'rover-services-1-1'],
+        undefined
+      );
+    });
+
+    it('does not throw if container removal fails', async () => {
+      mockedLaunch.mockRejectedValue(new Error('container not found'));
+
+      await expect(
+        teardownServiceContainers(ContainerBackend.Docker, {
+          networkName: 'net',
+          containerNames: ['c1'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
@@ -25,9 +25,17 @@ describe('service-containers', () => {
 
   describe('createServiceNetwork', () => {
     it('creates a docker network with the expected name', async () => {
+      mockedLaunch.mockResolvedValueOnce({ stdout: '', exitCode: 1 });
+      mockedLaunch.mockResolvedValueOnce({ stdout: '' });
+
       const name = await createServiceNetwork(ContainerBackend.Docker, 5, 2);
 
       expect(name).toBe('rover-services-5-2');
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['network', 'inspect', 'rover-services-5-2'],
+        { reject: false }
+      );
       expect(mockedLaunch).toHaveBeenCalledWith(
         ContainerBackend.Docker,
         ['network', 'create', 'rover-services-5-2'],
@@ -37,12 +45,48 @@ describe('service-containers', () => {
 
     it('passes env for DOCKER_HOST forwarding', async () => {
       const env = { DOCKER_HOST: 'tcp://remote:2375' } as NodeJS.ProcessEnv;
+      mockedLaunch.mockResolvedValueOnce({ stdout: '', exitCode: 1 });
+      mockedLaunch.mockResolvedValueOnce({ stdout: '' });
       await createServiceNetwork(ContainerBackend.Docker, 1, 1, env);
 
       expect(mockedLaunch).toHaveBeenCalledWith(
         ContainerBackend.Docker,
-        expect.any(Array),
+        ['network', 'inspect', 'rover-services-1-1'],
+        { env, reject: false }
+      );
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['network', 'create', 'rover-services-1-1'],
         { env }
+      );
+    });
+
+    it('reuses an existing network instead of recreating it', async () => {
+      mockedLaunch.mockResolvedValueOnce({ stdout: '[]', exitCode: 0 });
+
+      const name = await createServiceNetwork(ContainerBackend.Docker, 7, 3);
+
+      expect(name).toBe('rover-services-7-3');
+      expect(mockedLaunch).toHaveBeenCalledTimes(1);
+      expect(mockedLaunch).toHaveBeenCalledWith(
+        ContainerBackend.Docker,
+        ['network', 'inspect', 'rover-services-7-3'],
+        { reject: false }
+      );
+    });
+
+    it('reuses a network when create races with another creator', async () => {
+      mockedLaunch.mockResolvedValueOnce({ stdout: '', exitCode: 1 });
+      mockedLaunch.mockRejectedValueOnce(new Error('network already exists'));
+
+      const name = await createServiceNetwork(ContainerBackend.Docker, 8, 4);
+
+      expect(name).toBe('rover-services-8-4');
+      expect(mockedLaunch).toHaveBeenNthCalledWith(
+        2,
+        ContainerBackend.Docker,
+        ['network', 'create', 'rover-services-8-4'],
+        undefined
       );
     });
   });

--- a/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockedLaunch = vi.hoisted(() => vi.fn());
 
@@ -9,10 +9,11 @@ vi.mock('rover-core', () => ({
 
 import {
   createServiceNetwork,
-  startServiceContainers,
-  waitForServicesReady,
   getServiceNetworkArgs,
+  isServiceContainerContextAvailable,
+  startServiceContainers,
   teardownServiceContainers,
+  waitForServicesReady,
 } from '../service-containers.js';
 import { ContainerBackend } from '../container-common.js';
 import type { ServiceContainer } from 'rover-schemas';
@@ -120,7 +121,6 @@ describe('service-containers', () => {
 
       expect(names).toEqual(['rover-svc-1-1-postgres']);
 
-      // First call: docker create
       expect(mockedLaunch).toHaveBeenNthCalledWith(
         1,
         ContainerBackend.Docker,
@@ -149,7 +149,6 @@ describe('service-containers', () => {
         undefined
       );
 
-      // Second call: docker start
       expect(mockedLaunch).toHaveBeenNthCalledWith(
         2,
         ContainerBackend.Docker,
@@ -278,7 +277,6 @@ describe('service-containers', () => {
         'rover-svc-1-1-redis',
       ]);
 
-      // No inspect calls should be made
       expect(mockedLaunch).not.toHaveBeenCalled();
     });
 
@@ -345,6 +343,65 @@ describe('service-containers', () => {
         '--network',
         'rover-services-1-1',
       ]);
+    });
+  });
+
+  describe('isServiceContainerContextAvailable', () => {
+    it('returns true when the network exists and all containers are running', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({ Running: true }),
+        });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(true);
+    });
+
+    it('returns false when a container exists but is stopped', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({ Running: false }),
+        });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(false);
+    });
+
+    it('returns false when a health-checked container is unhealthy', async () => {
+      mockedLaunch
+        .mockResolvedValueOnce({ exitCode: 0, stdout: '' })
+        .mockResolvedValueOnce({
+          exitCode: 0,
+          stdout: JSON.stringify({
+            Running: true,
+            Health: { Status: 'unhealthy' },
+          }),
+        });
+
+      await expect(
+        isServiceContainerContextAvailable(ContainerBackend.Docker, {
+          networkName: 'rover-services-1-1',
+          containerNames: ['rover-svc-1-1-postgres'],
+          taskId: 1,
+          iteration: 1,
+        })
+      ).resolves.toBe(false);
     });
   });
 

--- a/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/service-containers.test.ts
@@ -192,6 +192,36 @@ describe('service-containers', () => {
         undefined
       );
     });
+
+    it('reports partially started containers before failing mid-loop', async () => {
+      const onContainerStarted = vi.fn();
+      const services: ServiceContainer[] = [
+        { name: 'postgres', image: 'postgres:16', readyTimeout: 60 },
+        { name: 'redis', image: 'redis:7', readyTimeout: 60 },
+      ];
+
+      mockedLaunch
+        .mockResolvedValueOnce({ stdout: '' })
+        .mockResolvedValueOnce({ stdout: '' })
+        .mockRejectedValueOnce(new Error('name already in use'));
+
+      await expect(
+        startServiceContainers(
+          ContainerBackend.Docker,
+          services,
+          'net',
+          1,
+          1,
+          undefined,
+          onContainerStarted
+        )
+      ).rejects.toThrow('name already in use');
+
+      expect(onContainerStarted).toHaveBeenCalledTimes(1);
+      expect(onContainerStarted).toHaveBeenCalledWith([
+        'rover-svc-1-1-postgres',
+      ]);
+    });
   });
 
   describe('waitForServicesReady', () => {

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -9,7 +9,11 @@ const { mockTeardownServiceContainers, mockProjectConfigLoad } = vi.hoisted(
 );
 
 vi.mock('../service-containers.js', () => ({
+  createServiceNetwork: vi.fn(),
+  isServiceContainerContextAvailable: vi.fn(),
+  startServiceContainers: vi.fn(),
   teardownServiceContainers: mockTeardownServiceContainers,
+  waitForServicesReady: vi.fn(),
 }));
 
 vi.mock('rover-core', () => ({

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -193,6 +193,41 @@ describe('Sandbox service cleanup', () => {
     });
   });
 
+  it('does not tear down services when stopAndRemove fails to remove the task container', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+    vi.spyOn(sandbox as any, 'remove').mockRejectedValue(
+      new Error('remove failed')
+    );
+
+    await sandbox.stopAndRemove();
+
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
+  });
+
   it('does not reconstruct service names from the current project config', async () => {
     mockProjectConfigLoad.mockReturnValue({
       services: [{ name: 'renamed-postgres' }],

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -69,6 +69,10 @@ class TestSandbox extends Sandbox {
   async runInteractive(): Promise<any> {
     return {};
   }
+
+  async cleanupServicesForTest(): Promise<void> {
+    await this.teardownServicesIfConfigured();
+  }
 }
 
 describe('Sandbox service cleanup', () => {
@@ -145,5 +149,37 @@ describe('Sandbox service cleanup', () => {
         DOCKER_HOST: 'tcp://remote:2375',
       })
     );
+  });
+
+  it('reuses an existing service context without reloading project config', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      { projectPath: '/repo' }
+    );
+    (sandbox as any).serviceContext = {
+      networkName: 'rover-services-12-3',
+      containerNames: ['rover-svc-12-3-postgres'],
+      taskId: 12,
+      iteration: 3,
+    };
+
+    await sandbox.cleanupServicesForTest();
+
+    expect(mockProjectConfigLoad).not.toHaveBeenCalled();
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+      undefined
+    );
+    expect((sandbox as any).serviceContext).toBeUndefined();
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -157,6 +157,42 @@ describe('Sandbox service cleanup', () => {
     );
   });
 
+  it('does not tear down services when stopGracefully fails to stop the task container', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+    vi.spyOn(sandbox as any, 'stop').mockRejectedValue(
+      new Error('stop failed')
+    );
+
+    await sandbox.stopGracefully();
+
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect((sandbox as any).serviceContext).toBeUndefined();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
+  });
+
   it('does not reconstruct service names from the current project config', async () => {
     mockProjectConfigLoad.mockReturnValue({
       services: [{ name: 'renamed-postgres' }],

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -92,12 +92,16 @@ describe('Sandbox service cleanup', () => {
     await sandbox.stopAndRemove();
 
     expect(mockProjectConfigLoad).toHaveBeenCalledWith('/repo');
-    expect(mockTeardownServiceContainers).toHaveBeenCalledWith('docker', {
-      networkName: 'rover-services-12-3',
-      containerNames: ['rover-svc-12-3-postgres', 'rover-svc-12-3-redis'],
-      taskId: 12,
-      iteration: 3,
-    });
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres', 'rover-svc-12-3-redis'],
+        taskId: 12,
+        iteration: 3,
+      },
+      undefined
+    );
   });
 
   it('skips teardown when no services are configured', async () => {
@@ -115,5 +119,31 @@ describe('Sandbox service cleanup', () => {
     await sandbox.stopGracefully();
 
     expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+  });
+
+  it('forwards DOCKER_HOST when tearing down services', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        projectPath: '/repo',
+        sandboxMetadata: { dockerHost: 'tcp://remote:2375' },
+      }
+    );
+
+    await sandbox.stopGracefully();
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      expect.objectContaining({
+        networkName: 'rover-services-12-3',
+      }),
+      expect.objectContaining({
+        DOCKER_HOST: 'tcp://remote:2375',
+      })
+    );
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -28,7 +28,9 @@ class TestSandbox extends Sandbox {
     return true;
   }
 
-  async openShellAtWorktree(): Promise<void> {}
+  async openShellAtWorktree(): Promise<{ exitCode?: number }> {
+    return { exitCode: 0 };
+  }
 
   async inspect(): Promise<{ status: string; exitCode?: number } | null> {
     return null;

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Sandbox } from '../types.js';
+
+const { mockTeardownServiceContainers, mockProjectConfigLoad } = vi.hoisted(
+  () => ({
+    mockTeardownServiceContainers: vi.fn(),
+    mockProjectConfigLoad: vi.fn(),
+  })
+);
+
+vi.mock('../service-containers.js', () => ({
+  buildServiceContainerContext: vi.fn(
+    (services: Array<{ name: string }>, taskId: number, iteration: number) => ({
+      networkName: `rover-services-${taskId}-${iteration}`,
+      containerNames: services.map(
+        service => `rover-svc-${taskId}-${iteration}-${service.name}`
+      ),
+      taskId,
+      iteration,
+    })
+  ),
+  teardownServiceContainers: mockTeardownServiceContainers,
+}));
+
+vi.mock('rover-core', () => ({
+  launch: vi.fn(),
+  ProcessManager: class {},
+  ProjectConfigManager: {
+    load: mockProjectConfigLoad,
+  },
+  TaskDescriptionManager: class {},
+}));
+
+class TestSandbox extends Sandbox {
+  backend = 'docker';
+
+  async isBackendAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async openShellAtWorktree(): Promise<void> {}
+
+  async inspect(): Promise<{ status: string; exitCode?: number } | null> {
+    return null;
+  }
+
+  protected async create(): Promise<string> {
+    return 'created';
+  }
+
+  protected async start(): Promise<string> {
+    return 'started';
+  }
+
+  protected async remove(): Promise<string> {
+    return 'removed';
+  }
+
+  protected async stop(): Promise<string> {
+    return 'stopped';
+  }
+
+  protected async logs(): Promise<string> {
+    return '';
+  }
+
+  protected async *followLogs(): AsyncIterable<string> {}
+
+  async runInteractive(): Promise<any> {
+    return {};
+  }
+}
+
+describe('Sandbox service cleanup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProjectConfigLoad.mockReturnValue({
+      services: [{ name: 'postgres' }, { name: 'redis' }],
+    });
+  });
+
+  it('tears down configured services during stop on a fresh sandbox instance', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      { projectPath: '/repo' }
+    );
+
+    await sandbox.stopAndRemove();
+
+    expect(mockProjectConfigLoad).toHaveBeenCalledWith('/repo');
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith('docker', {
+      networkName: 'rover-services-12-3',
+      containerNames: ['rover-svc-12-3-postgres', 'rover-svc-12-3-redis'],
+      taskId: 12,
+      iteration: 3,
+    });
+  });
+
+  it('skips teardown when no services are configured', async () => {
+    mockProjectConfigLoad.mockReturnValue({ services: [] });
+
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      { projectPath: '/repo' }
+    );
+
+    await sandbox.stopGracefully();
+
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -3,6 +3,7 @@ import { Sandbox } from '../types.js';
 
 const {
   mockCreateServiceNetwork,
+  mockHasAnyServiceContainerResources,
   mockIsServiceContainerContextAvailable,
   mockStartServiceContainers,
   mockTeardownServiceContainers,
@@ -10,6 +11,7 @@ const {
   mockProjectConfigLoad,
 } = vi.hoisted(() => ({
   mockCreateServiceNetwork: vi.fn(),
+  mockHasAnyServiceContainerResources: vi.fn(),
   mockIsServiceContainerContextAvailable: vi.fn(),
   mockStartServiceContainers: vi.fn(),
   mockTeardownServiceContainers: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock('../service-containers.js', () => ({
     iteration,
   })),
   createServiceNetwork: mockCreateServiceNetwork,
+  hasAnyServiceContainerResources: mockHasAnyServiceContainerResources,
   isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,
   startServiceContainers: mockStartServiceContainers,
   teardownServiceContainers: mockTeardownServiceContainers,
@@ -98,6 +101,7 @@ describe('Sandbox service cleanup', () => {
     vi.clearAllMocks();
     mockProjectConfigLoad.mockReturnValue({ services: [] });
     mockCreateServiceNetwork.mockResolvedValue('rover-services-12-3');
+    mockHasAnyServiceContainerResources.mockResolvedValue(false);
     mockIsServiceContainerContextAvailable.mockResolvedValue(false);
     mockStartServiceContainers.mockResolvedValue(['rover-svc-12-3-postgres']);
     mockWaitForServicesReady.mockResolvedValue(undefined);
@@ -155,7 +159,7 @@ describe('Sandbox service cleanup', () => {
     expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
   });
 
-  it('forwards DOCKER_HOST when tearing down services', async () => {
+  it('does not tear down services on graceful stop used for pause flows', async () => {
     const sandbox = new TestSandbox(
       {
         id: 12,
@@ -178,18 +182,19 @@ describe('Sandbox service cleanup', () => {
 
     await sandbox.stopGracefully();
 
-    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
-      'docker',
-      expect.objectContaining({
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      dockerHost: 'tcp://remote:2375',
+      serviceContext: {
         networkName: 'rover-services-12-3',
-      }),
-      expect.objectContaining({
-        DOCKER_HOST: 'tcp://remote:2375',
-      })
-    );
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
   });
 
-  it('tears down services when stopGracefully finds the task container already missing', async () => {
+  it('does not tear down services when stopGracefully finds the task container already missing', async () => {
     const sandbox = new TestSandbox(
       {
         id: 12,
@@ -213,9 +218,15 @@ describe('Sandbox service cleanup', () => {
 
     await sandbox.stopGracefully();
 
-    expect(mockTeardownServiceContainers).toHaveBeenCalledTimes(1);
-    expect((sandbox as any).serviceContext).toBeUndefined();
-    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
   });
 
   it('does not tear down services when stopGracefully fails for a non-missing container error', async () => {
@@ -347,7 +358,7 @@ describe('Sandbox service cleanup', () => {
     expect(sandbox.getSandboxMetadata()).toBeUndefined();
   });
 
-  it('does not reconstruct service names from the current project config', async () => {
+  it('preserves persisted service names on graceful stop without reconstructing from current config', async () => {
     mockProjectConfigLoad.mockReturnValue({
       services: [{ name: 'renamed-postgres' }],
     });
@@ -374,13 +385,15 @@ describe('Sandbox service cleanup', () => {
     await sandbox.stopGracefully();
 
     expect(mockProjectConfigLoad).not.toHaveBeenCalled();
-    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
-      'docker',
-      expect.objectContaining({
+    expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
+        networkName: 'rover-services-12-3',
         containerNames: ['rover-svc-12-3-postgres'],
-      }),
-      undefined
-    );
+        taskId: 12,
+        iteration: 3,
+      },
+    });
   });
 
   it('reuses an existing service context without reloading project config', async () => {
@@ -681,5 +694,49 @@ describe('Sandbox service cleanup', () => {
         iteration: 3,
       },
     });
+  });
+
+  it('cleans up orphaned deterministic service resources before recreating services', async () => {
+    mockHasAnyServiceContainerResources.mockResolvedValueOnce(true);
+
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      { projectPath: '/repo' }
+    );
+
+    await expect(
+      sandbox.ensureServicesForTest([
+        { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+      ])
+    ).resolves.toEqual({
+      started: true,
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+      undefined
+    );
+    expect(mockCreateServiceNetwork).toHaveBeenCalledWith(
+      'docker',
+      12,
+      3,
+      undefined
+    );
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -9,16 +9,6 @@ const { mockTeardownServiceContainers, mockProjectConfigLoad } = vi.hoisted(
 );
 
 vi.mock('../service-containers.js', () => ({
-  buildServiceContainerContext: vi.fn(
-    (services: Array<{ name: string }>, taskId: number, iteration: number) => ({
-      networkName: `rover-services-${taskId}-${iteration}`,
-      containerNames: services.map(
-        service => `rover-svc-${taskId}-${iteration}-${service.name}`
-      ),
-      taskId,
-      iteration,
-    })
-  ),
   teardownServiceContainers: mockTeardownServiceContainers,
 }));
 
@@ -78,24 +68,32 @@ class TestSandbox extends Sandbox {
 describe('Sandbox service cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockProjectConfigLoad.mockReturnValue({
-      services: [{ name: 'postgres' }, { name: 'redis' }],
-    });
+    mockProjectConfigLoad.mockReturnValue({ services: [] });
   });
 
-  it('tears down configured services during stop on a fresh sandbox instance', async () => {
+  it('tears down persisted services during stop on a fresh sandbox instance', async () => {
     const sandbox = new TestSandbox(
       {
         id: 12,
         iterations: 3,
       } as any,
       undefined,
-      { projectPath: '/repo' }
+      {
+        projectPath: '/repo',
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres', 'rover-svc-12-3-redis'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
     );
 
     await sandbox.stopAndRemove();
 
-    expect(mockProjectConfigLoad).toHaveBeenCalledWith('/repo');
+    expect(mockProjectConfigLoad).not.toHaveBeenCalled();
     expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
       'docker',
       {
@@ -134,7 +132,15 @@ describe('Sandbox service cleanup', () => {
       undefined,
       {
         projectPath: '/repo',
-        sandboxMetadata: { dockerHost: 'tcp://remote:2375' },
+        sandboxMetadata: {
+          dockerHost: 'tcp://remote:2375',
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
       }
     );
 
@@ -148,6 +154,42 @@ describe('Sandbox service cleanup', () => {
       expect.objectContaining({
         DOCKER_HOST: 'tcp://remote:2375',
       })
+    );
+  });
+
+  it('does not reconstruct service names from the current project config', async () => {
+    mockProjectConfigLoad.mockReturnValue({
+      services: [{ name: 'renamed-postgres' }],
+    });
+
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        projectPath: '/repo',
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+
+    await sandbox.stopGracefully();
+
+    expect(mockProjectConfigLoad).not.toHaveBeenCalled();
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      expect.objectContaining({
+        containerNames: ['rover-svc-12-3-postgres'],
+      }),
+      undefined
     );
   });
 
@@ -181,5 +223,34 @@ describe('Sandbox service cleanup', () => {
       undefined
     );
     expect((sandbox as any).serviceContext).toBeUndefined();
+  });
+
+  it('includes service context in persisted sandbox metadata', () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: { dockerHost: 'tcp://remote:2375' },
+      }
+    );
+    (sandbox as any).serviceContext = {
+      networkName: 'rover-services-12-3',
+      containerNames: ['rover-svc-12-3-postgres'],
+      taskId: 12,
+      iteration: 3,
+    };
+
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      dockerHost: 'tcp://remote:2375',
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Sandbox } from '../types.js';
 
@@ -18,6 +19,30 @@ const {
   mockWaitForServicesReady: vi.fn(),
   mockProjectConfigLoad: vi.fn(),
 }));
+
+function hashServices(services: unknown): string {
+  const stableSerialize = (value: unknown): string => {
+    if (Array.isArray(value)) {
+      return `[${value.map(item => stableSerialize(item)).join(',')}]`;
+    }
+
+    if (value && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>).sort(
+        ([left], [right]) => left.localeCompare(right)
+      );
+      return `{${entries
+        .map(
+          ([key, nestedValue]) =>
+            `${JSON.stringify(key)}:${stableSerialize(nestedValue)}`
+        )
+        .join(',')}}`;
+    }
+
+    return JSON.stringify(value);
+  };
+
+  return createHash('sha256').update(stableSerialize(services)).digest('hex');
+}
 
 vi.mock('../service-containers.js', () => ({
   buildServiceContainerContext: vi.fn((services, taskId, iteration) => ({
@@ -444,6 +469,7 @@ describe('Sandbox service cleanup', () => {
       containerNames: ['rover-svc-12-3-postgres'],
       taskId: 12,
       iteration: 3,
+      serviceConfigHash: 'service-hash',
     };
 
     expect(sandbox.getSandboxMetadata()).toEqual({
@@ -453,6 +479,7 @@ describe('Sandbox service cleanup', () => {
         containerNames: ['rover-svc-12-3-postgres'],
         taskId: 12,
         iteration: 3,
+        serviceConfigHash: 'service-hash',
       },
     });
   });
@@ -595,25 +622,27 @@ describe('Sandbox service cleanup', () => {
         sandboxMetadata: {
           serviceContext: {
             networkName: 'rover-services-12-3',
-            containerNames: ['rover-svc-12-3-old-postgres'],
+            containerNames: ['rover-svc-12-3-postgres'],
             taskId: 12,
             iteration: 3,
+            serviceConfigHash: 'outdated-hash',
           },
         },
       }
     );
 
-    await expect(
-      sandbox.ensureServicesForTest([
-        { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
-      ])
-    ).resolves.toEqual({
+    const services = [
+      { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+    ];
+
+    await expect(sandbox.ensureServicesForTest(services)).resolves.toEqual({
       started: true,
       serviceContext: {
         networkName: 'rover-services-12-3',
         containerNames: ['rover-svc-12-3-postgres'],
         taskId: 12,
         iteration: 3,
+        serviceConfigHash: hashServices(services),
       },
     });
 
@@ -622,9 +651,10 @@ describe('Sandbox service cleanup', () => {
       'docker',
       {
         networkName: 'rover-services-12-3',
-        containerNames: ['rover-svc-12-3-old-postgres'],
+        containerNames: ['rover-svc-12-3-postgres'],
         taskId: 12,
         iteration: 3,
+        serviceConfigHash: 'outdated-hash',
       },
       undefined
     );
@@ -636,7 +666,7 @@ describe('Sandbox service cleanup', () => {
     );
     expect(mockStartServiceContainers).toHaveBeenCalledWith(
       'docker',
-      [{ name: 'postgres', image: 'postgres:16', readyTimeout: 30 }],
+      services,
       'rover-services-12-3',
       12,
       3,
@@ -645,7 +675,7 @@ describe('Sandbox service cleanup', () => {
     );
     expect(mockWaitForServicesReady).toHaveBeenCalledWith(
       'docker',
-      [{ name: 'postgres', image: 'postgres:16', readyTimeout: 30 }],
+      services,
       ['rover-svc-12-3-postgres'],
       undefined
     );
@@ -683,6 +713,9 @@ describe('Sandbox service cleanup', () => {
         containerNames: ['rover-svc-12-3-postgres'],
         taskId: 12,
         iteration: 3,
+        serviceConfigHash: hashServices([
+          { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+        ]),
       },
     });
 
@@ -692,6 +725,9 @@ describe('Sandbox service cleanup', () => {
         containerNames: ['rover-svc-12-3-postgres'],
         taskId: 12,
         iteration: 3,
+        serviceConfigHash: hashServices([
+          { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+        ]),
       },
     });
   });
@@ -719,6 +755,9 @@ describe('Sandbox service cleanup', () => {
         containerNames: ['rover-svc-12-3-postgres'],
         taskId: 12,
         iteration: 3,
+        serviceConfigHash: hashServices([
+          { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+        ]),
       },
     });
 
@@ -729,6 +768,9 @@ describe('Sandbox service cleanup', () => {
         containerNames: ['rover-svc-12-3-postgres'],
         taskId: 12,
         iteration: 3,
+        serviceConfigHash: hashServices([
+          { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+        ]),
       },
       undefined
     );

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -1,19 +1,37 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Sandbox } from '../types.js';
 
-const { mockTeardownServiceContainers, mockProjectConfigLoad } = vi.hoisted(
-  () => ({
-    mockTeardownServiceContainers: vi.fn(),
-    mockProjectConfigLoad: vi.fn(),
-  })
-);
+const {
+  mockCreateServiceNetwork,
+  mockIsServiceContainerContextAvailable,
+  mockStartServiceContainers,
+  mockTeardownServiceContainers,
+  mockWaitForServicesReady,
+  mockProjectConfigLoad,
+} = vi.hoisted(() => ({
+  mockCreateServiceNetwork: vi.fn(),
+  mockIsServiceContainerContextAvailable: vi.fn(),
+  mockStartServiceContainers: vi.fn(),
+  mockTeardownServiceContainers: vi.fn(),
+  mockWaitForServicesReady: vi.fn(),
+  mockProjectConfigLoad: vi.fn(),
+}));
 
 vi.mock('../service-containers.js', () => ({
-  createServiceNetwork: vi.fn(),
-  isServiceContainerContextAvailable: vi.fn(),
-  startServiceContainers: vi.fn(),
+  buildServiceContainerContext: vi.fn((services, taskId, iteration) => ({
+    networkName: `rover-services-${taskId}-${iteration}`,
+    containerNames: services.map(
+      (service: { name: string }) =>
+        `rover-svc-${taskId}-${iteration}-${service.name}`
+    ),
+    taskId,
+    iteration,
+  })),
+  createServiceNetwork: mockCreateServiceNetwork,
+  isServiceContainerContextAvailable: mockIsServiceContainerContextAvailable,
+  startServiceContainers: mockStartServiceContainers,
   teardownServiceContainers: mockTeardownServiceContainers,
-  waitForServicesReady: vi.fn(),
+  waitForServicesReady: mockWaitForServicesReady,
 }));
 
 vi.mock('rover-core', () => ({
@@ -69,12 +87,20 @@ class TestSandbox extends Sandbox {
   async cleanupServicesForTest(): Promise<void> {
     await this.teardownServicesIfConfigured();
   }
+
+  async ensureServicesForTest(services: any): Promise<any> {
+    return await this.ensureServiceContext(services);
+  }
 }
 
 describe('Sandbox service cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProjectConfigLoad.mockReturnValue({ services: [] });
+    mockCreateServiceNetwork.mockResolvedValue('rover-services-12-3');
+    mockIsServiceContainerContextAvailable.mockResolvedValue(false);
+    mockStartServiceContainers.mockResolvedValue(['rover-svc-12-3-postgres']);
+    mockWaitForServicesReady.mockResolvedValue(undefined);
   });
 
   it('tears down persisted services during stop on a fresh sandbox instance', async () => {
@@ -163,7 +189,36 @@ describe('Sandbox service cleanup', () => {
     );
   });
 
-  it('does not tear down services when stopGracefully fails to stop the task container', async () => {
+  it('tears down services when stopGracefully finds the task container already missing', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+    vi.spyOn(sandbox as any, 'stop').mockRejectedValue(
+      new Error('Error: No such object: rover-task-12-3')
+    );
+
+    await sandbox.stopGracefully();
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledTimes(1);
+    expect((sandbox as any).serviceContext).toBeUndefined();
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
+
+  it('does not tear down services when stopGracefully fails for a non-missing container error', async () => {
     const sandbox = new TestSandbox(
       {
         id: 12,
@@ -185,10 +240,9 @@ describe('Sandbox service cleanup', () => {
       new Error('stop failed')
     );
 
-    await sandbox.stopGracefully();
+    await expect(sandbox.stopGracefully()).rejects.toThrow('stop failed');
 
     expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
-    expect((sandbox as any).serviceContext).toBeUndefined();
     expect(sandbox.getSandboxMetadata()).toEqual({
       serviceContext: {
         networkName: 'rover-services-12-3',
@@ -199,7 +253,38 @@ describe('Sandbox service cleanup', () => {
     });
   });
 
-  it('does not tear down services when stopAndRemove fails to remove the task container', async () => {
+  it('tears down services when stopAndRemove finds the task container already missing', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+    vi.spyOn(sandbox as any, 'stop').mockRejectedValue(
+      new Error('Error: No such object: rover-task-12-3')
+    );
+    vi.spyOn(sandbox as any, 'remove').mockRejectedValue(
+      new Error('Error: No such object: rover-task-12-3')
+    );
+
+    await sandbox.stopAndRemove();
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledTimes(1);
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
+
+  it('does not tear down services when stopAndRemove fails to remove the task container for a non-missing error', async () => {
     const sandbox = new TestSandbox(
       {
         id: 12,
@@ -221,7 +306,7 @@ describe('Sandbox service cleanup', () => {
       new Error('remove failed')
     );
 
-    await sandbox.stopAndRemove();
+    await expect(sandbox.stopAndRemove()).rejects.toThrow('remove failed');
 
     expect(mockTeardownServiceContainers).not.toHaveBeenCalled();
     expect(sandbox.getSandboxMetadata()).toEqual({
@@ -232,6 +317,34 @@ describe('Sandbox service cleanup', () => {
         iteration: 3,
       },
     });
+  });
+
+  it('returns success from stopAndRemove when stop fails but remove succeeds', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+    vi.spyOn(sandbox as any, 'stop').mockRejectedValue(
+      new Error('stop failed')
+    );
+    vi.spyOn(sandbox as any, 'remove').mockResolvedValue('removed');
+
+    await expect(sandbox.stopAndRemove()).resolves.toBe('removed');
+    expect(mockTeardownServiceContainers).toHaveBeenCalledTimes(1);
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
   });
 
   it('does not reconstruct service names from the current project config', async () => {
@@ -354,5 +467,219 @@ describe('Sandbox service cleanup', () => {
 
     expect(mockTeardownServiceContainers).toHaveBeenCalledTimes(1);
     expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
+
+  it('tears down persisted service context when services are no longer configured', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+
+    await expect(sandbox.ensureServicesForTest([])).resolves.toEqual({
+      started: false,
+      serviceContext: undefined,
+    });
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+      undefined
+    );
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
+
+  it('forwards DOCKER_HOST when tearing down removed service configurations', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          dockerHost: 'tcp://remote:2375',
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+
+    await sandbox.ensureServicesForTest(undefined);
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      expect.objectContaining({
+        networkName: 'rover-services-12-3',
+      }),
+      expect.objectContaining({
+        DOCKER_HOST: 'tcp://remote:2375',
+      })
+    );
+  });
+
+  it('ignores stale cleanup failures when services are no longer configured', async () => {
+    mockTeardownServiceContainers.mockRejectedValueOnce(
+      new Error('cleanup failed')
+    );
+
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+
+    await expect(sandbox.ensureServicesForTest([])).resolves.toEqual({
+      started: false,
+      serviceContext: undefined,
+    });
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
+
+  it('recreates services when the persisted context does not match the current service config', async () => {
+    mockIsServiceContainerContextAvailable.mockResolvedValue(true);
+
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-old-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+
+    await expect(
+      sandbox.ensureServicesForTest([
+        { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+      ])
+    ).resolves.toEqual({
+      started: true,
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
+
+    expect(mockIsServiceContainerContextAvailable).not.toHaveBeenCalled();
+    expect(mockTeardownServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-old-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+      undefined
+    );
+    expect(mockCreateServiceNetwork).toHaveBeenCalledWith(
+      'docker',
+      12,
+      3,
+      undefined
+    );
+    expect(mockStartServiceContainers).toHaveBeenCalledWith(
+      'docker',
+      [{ name: 'postgres', image: 'postgres:16', readyTimeout: 30 }],
+      'rover-services-12-3',
+      12,
+      3,
+      undefined,
+      expect.any(Function)
+    );
+    expect(mockWaitForServicesReady).toHaveBeenCalledWith(
+      'docker',
+      [{ name: 'postgres', image: 'postgres:16', readyTimeout: 30 }],
+      ['rover-svc-12-3-postgres'],
+      undefined
+    );
+  });
+
+  it('uses newly started services even after services were previously torn down on the same sandbox instance', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-old-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+
+    await sandbox.teardownServices();
+
+    await expect(
+      sandbox.ensureServicesForTest([
+        { name: 'postgres', image: 'postgres:16', readyTimeout: 30 },
+      ])
+    ).resolves.toEqual({
+      started: true,
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
+
+    expect(sandbox.getSandboxMetadata()).toEqual({
+      serviceContext: {
+        networkName: 'rover-services-12-3',
+        containerNames: ['rover-svc-12-3-postgres'],
+        taskId: 12,
+        iteration: 3,
+      },
+    });
   });
 });

--- a/packages/cli/src/lib/sandbox/__tests__/types.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/types.test.ts
@@ -253,4 +253,29 @@ describe('Sandbox service cleanup', () => {
       },
     });
   });
+
+  it('does not return persisted service context after teardown has run', async () => {
+    const sandbox = new TestSandbox(
+      {
+        id: 12,
+        iterations: 3,
+      } as any,
+      undefined,
+      {
+        sandboxMetadata: {
+          serviceContext: {
+            networkName: 'rover-services-12-3',
+            containerNames: ['rover-svc-12-3-postgres'],
+            taskId: 12,
+            iteration: 3,
+          },
+        },
+      }
+    );
+
+    await sandbox.teardownServices();
+
+    expect(mockTeardownServiceContainers).toHaveBeenCalledTimes(1);
+    expect(sandbox.getSandboxMetadata()).toBeUndefined();
+  });
 });

--- a/packages/cli/src/lib/sandbox/container-common.ts
+++ b/packages/cli/src/lib/sandbox/container-common.ts
@@ -121,20 +121,15 @@ export function warnIfCustomImage(projectConfig?: ProjectConfigManager): void {
 }
 
 /**
- * Resolve the path of an init script from the workspace root first.
- * If the root-relative file is missing, fall back to the sub-project path
- * to preserve compatibility with older configs.
+ * Resolve the path of an init script from the sub-project first when one is
+ * provided. If the project-relative file is missing, fall back to the
+ * workspace root to preserve compatibility with older configs.
  */
 export function resolveInitScriptPath(
   projectRoot: string,
   scriptPath: string,
   projectPath?: string
 ): string {
-  const rootRelative = join(projectRoot, scriptPath);
-  if (existsSync(rootRelative)) {
-    return rootRelative;
-  }
-
   if (
     projectPath &&
     isSafeRelativePath(projectPath) &&
@@ -144,7 +139,11 @@ export function resolveInitScriptPath(
     if (existsSync(projectRelative)) {
       return projectRelative;
     }
-    return projectRelative;
+  }
+
+  const rootRelative = join(projectRoot, scriptPath);
+  if (existsSync(rootRelative)) {
+    return rootRelative;
   }
 
   return rootRelative;

--- a/packages/cli/src/lib/sandbox/container-common.ts
+++ b/packages/cli/src/lib/sandbox/container-common.ts
@@ -8,7 +8,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname, resolve, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir, UserInfo } from 'node:os';
 import {
@@ -130,14 +130,29 @@ export function resolveInitScriptPath(
   scriptPath: string,
   projectPath?: string
 ): string {
+  if (!projectPath) {
+    return isAbsolute(scriptPath)
+      ? scriptPath
+      : resolve(projectRoot, scriptPath);
+  }
+
+  // Validate scriptPath to prevent path traversal
+  if (!isSafeRelativePath(scriptPath)) {
+    throw new Error(`Unsafe init script path: ${scriptPath}`);
+  }
+
   if (
     projectPath &&
     isSafeRelativePath(projectPath) &&
     resolvePathWithinRoot(projectRoot, projectPath) !== null
   ) {
-    const projectRelative = join(projectRoot, projectPath, scriptPath);
-    if (existsSync(projectRelative)) {
-      return projectRelative;
+    // Validate the combined project + script path stays within root
+    const combinedRelative = join(projectPath, scriptPath);
+    if (isSafeRelativePath(combinedRelative)) {
+      const projectRelative = join(projectRoot, combinedRelative);
+      if (existsSync(projectRelative)) {
+        return projectRelative;
+      }
     }
   }
 
@@ -147,6 +162,15 @@ export function resolveInitScriptPath(
   }
 
   return rootRelative;
+}
+
+export function getRootInitScriptMountPath(
+  allInitScripts: Array<{ path?: string; script: string }>,
+  index: number
+): string {
+  return allInitScripts.length === 1
+    ? '/init-script.sh'
+    : `/init-script-${index}.sh`;
 }
 
 /**
@@ -171,10 +195,7 @@ export function getInitScriptMounts(
       entry.path
     );
     if (existsSync(initScriptAbsPath)) {
-      const mountPath =
-        allInitScripts.length === 1 && !entry.path
-          ? '/init-script.sh'
-          : `/init-script-${i}.sh`;
+      const mountPath = getRootInitScriptMountPath(allInitScripts, i);
       mounts.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
     } else if (opts?.warnMissing) {
       console.log(

--- a/packages/cli/src/lib/sandbox/container-common.ts
+++ b/packages/cli/src/lib/sandbox/container-common.ts
@@ -475,3 +475,29 @@ export function normalizeExtraArgs(
   // Split string by whitespace, respecting quoted strings
   return extraArgs.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) || [];
 }
+
+/**
+ * Return the effective extra args used for cache-image builds.
+ * Volume mounts are excluded because cache builds intentionally bake
+ * installed artifacts into the image filesystem rather than external volumes.
+ */
+export function getBuildContainerExtraArgs(
+  extraArgs: string | string[] | undefined
+): string[] {
+  const normalized = normalizeExtraArgs(extraArgs);
+  const filtered: string[] = [];
+
+  for (let i = 0; i < normalized.length; i++) {
+    const arg = normalized[i];
+    if (arg === '-v' || arg === '--volume') {
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--volume=') || arg.startsWith('-v=')) {
+      continue;
+    }
+    filtered.push(arg);
+  }
+
+  return filtered;
+}

--- a/packages/cli/src/lib/sandbox/container-common.ts
+++ b/packages/cli/src/lib/sandbox/container-common.ts
@@ -11,6 +11,10 @@ import {
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir, UserInfo } from 'node:os';
+import {
+  isSafeRelativePath,
+  resolvePathWithinRoot,
+} from '../../utils/path-safety.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -131,16 +135,19 @@ export function resolveInitScriptPath(
     return rootRelative;
   }
 
-  if (projectPath) {
+  if (
+    projectPath &&
+    isSafeRelativePath(projectPath) &&
+    resolvePathWithinRoot(projectRoot, projectPath) !== null
+  ) {
     const projectRelative = join(projectRoot, projectPath, scriptPath);
     if (existsSync(projectRelative)) {
       return projectRelative;
     }
+    return projectRelative;
   }
 
-  return projectPath
-    ? join(projectRoot, projectPath, scriptPath)
-    : rootRelative;
+  return rootRelative;
 }
 
 /**

--- a/packages/cli/src/lib/sandbox/container-common.ts
+++ b/packages/cli/src/lib/sandbox/container-common.ts
@@ -143,6 +143,42 @@ export function resolveInitScriptPath(
     : rootRelative;
 }
 
+/**
+ * Compute volume mount args for root-only init scripts.
+ * Project-scoped init scripts (those with `entry.path`) are skipped because
+ * they run from the cloned workspace path instead of being host-mounted.
+ */
+export function getInitScriptMounts(
+  projectConfig: ProjectConfigManager,
+  opts?: { warnMissing?: boolean }
+): string[] {
+  const mounts: string[] = [];
+  const allInitScripts = projectConfig.allInitScripts;
+  for (let i = 0; i < allInitScripts.length; i++) {
+    const entry = allInitScripts[i];
+    if (entry.path) {
+      continue;
+    }
+    const initScriptAbsPath = resolveInitScriptPath(
+      projectConfig.projectRoot,
+      entry.script,
+      entry.path
+    );
+    if (existsSync(initScriptAbsPath)) {
+      const mountPath =
+        allInitScripts.length === 1 && !entry.path
+          ? '/init-script.sh'
+          : `/init-script-${i}.sh`;
+      mounts.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
+    } else if (opts?.warnMissing) {
+      console.log(
+        colors.yellow(`⚠ Warning: initScript '${entry.script}' does not exist`)
+      );
+    }
+  }
+  return mounts;
+}
+
 export type CurrentUser = string;
 export type CurrentGroup = string;
 

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readdirSync, readFileSync, readlinkSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, readlinkSync } from 'node:fs';
 import { join, isAbsolute, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -9,7 +9,11 @@ import {
   ProjectConfigManager,
   VERBOSE,
 } from 'rover-core';
-import { ContainerBackend, resolveInitScriptPath } from './container-common.js';
+import {
+  ContainerBackend,
+  getBuildContainerExtraArgs,
+  resolveInitScriptPath,
+} from './container-common.js';
 import {
   isSafeRelativePath,
   resolvePathWithinRoot,
@@ -45,6 +49,7 @@ export interface SetupHashInputs {
   taskManagers: string[];
   agent: string;
   roverVersion: string;
+  sandboxExtraArgs: string[];
   initScriptPath?: string;
   initScriptContent: string;
   cacheFilesContent: string;
@@ -83,6 +88,7 @@ export function computeSetupHash(inputs: SetupHashInputs): string {
     taskManagers: [...inputs.taskManagers].sort(),
     agent: inputs.agent,
     roverVersion: inputs.roverVersion,
+    sandboxExtraArgs: [...inputs.sandboxExtraArgs],
     initScriptPath: inputs.initScriptPath || '',
     initScriptContent: inputs.initScriptContent,
     cacheFilesContent: inputs.cacheFilesContent,
@@ -294,6 +300,40 @@ function resolveRepositoryForLookup(
   return repository;
 }
 
+function isLocalRepositoryReference(repository: string): boolean {
+  return (
+    repository.startsWith('file://') ||
+    (isAbsolute(repository) && !repository.startsWith('/workspace/')) ||
+    repository === '.' ||
+    repository === '..' ||
+    repository.startsWith('./') ||
+    repository.startsWith('../')
+  );
+}
+
+function resolveLocalRepositoryContentHash(
+  projectRoot: string,
+  repository: string
+): string {
+  if (!isLocalRepositoryReference(repository)) {
+    return '';
+  }
+
+  const hostRepositoryPath = resolveRepositoryForLookup(
+    projectRoot,
+    repository
+  );
+
+  // Only hash local working trees. Bare repos do not have materialized files
+  // that can change outside of commits, so hashing their internals would add
+  // noise without improving cache correctness.
+  if (!existsSync(join(hostRepositoryPath, '.git'))) {
+    return '';
+  }
+
+  return hashMaterializedProjectContents(hostRepositoryPath);
+}
+
 function resolveRepositoryRevision(
   projectRoot: string,
   repository: string,
@@ -466,7 +506,10 @@ export function checkImageCache(
               : '',
           localContentHash:
             typeof p.repository === 'string'
-              ? ''
+              ? resolveLocalRepositoryContentHash(
+                  projectConfig.projectRoot,
+                  p.repository
+                )
               : hashMaterializedProjectContents(
                   join(projectConfig.projectRoot, p.path)
                 ),
@@ -488,6 +531,9 @@ export function checkImageCache(
     taskManagers,
     agent,
     roverVersion: getVersion(),
+    sandboxExtraArgs: getBuildContainerExtraArgs(
+      projectConfig.sandboxExtraArgs
+    ),
     initScriptPath,
     initScriptContent,
     cacheFilesContent,

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync, readlinkSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   launch,
   launchSync,
@@ -18,7 +17,10 @@ import {
   isSafeRelativePath,
   resolvePathWithinRoot,
 } from '../../utils/path-safety.js';
-import { isLocalRepositoryReference } from '../../utils/repository-reference.js';
+import {
+  isLocalRepositoryReference,
+  resolveLocalRepositoryReference,
+} from '../../utils/repository-reference.js';
 
 /**
  * Build a process env with DOCKER_HOST set when the sandbox metadata
@@ -281,12 +283,8 @@ function resolveRepositoryForLookup(
   projectRoot: string,
   repository: string
 ): string {
-  if (repository.startsWith('file://')) {
-    return fileURLToPath(repository);
-  }
-
   if (isLocalRepositoryReference(repository)) {
-    return resolve(projectRoot, repository);
+    return resolveLocalRepositoryReference(repository, projectRoot);
   }
 
   return repository;

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync, readlinkSync } from 'node:fs';
-import { join, isAbsolute, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   launch,
@@ -18,6 +18,7 @@ import {
   isSafeRelativePath,
   resolvePathWithinRoot,
 } from '../../utils/path-safety.js';
+import { isLocalRepositoryReference } from '../../utils/repository-reference.js';
 
 /**
  * Build a process env with DOCKER_HOST set when the sandbox metadata
@@ -284,31 +285,11 @@ function resolveRepositoryForLookup(
     return fileURLToPath(repository);
   }
 
-  if (isAbsolute(repository) && !repository.startsWith('/workspace/')) {
-    return repository;
-  }
-
-  if (
-    repository === '.' ||
-    repository === '..' ||
-    repository.startsWith('./') ||
-    repository.startsWith('../')
-  ) {
+  if (isLocalRepositoryReference(repository)) {
     return resolve(projectRoot, repository);
   }
 
   return repository;
-}
-
-function isLocalRepositoryReference(repository: string): boolean {
-  return (
-    repository.startsWith('file://') ||
-    (isAbsolute(repository) && !repository.startsWith('/workspace/')) ||
-    repository === '.' ||
-    repository === '..' ||
-    repository.startsWith('./') ||
-    repository.startsWith('../')
-  );
 }
 
 function resolveLocalRepositoryContentHash(

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -172,15 +172,26 @@ export async function waitForInitAndCommit(
       // Run a quick fixup container (without volumes) to set correct permissions.
       const fixupName = `${containerName}-fixup`;
       try {
-        await launch(backend, [
-          'run', '--name', fixupName,
-          '--entrypoint', '/bin/bash',
-          cacheTag,
-          '-c', 'chmod -R a+rwX /home/agent 2>/dev/null || true',
-        ], opts);
+        await launch(
+          backend,
+          [
+            'run',
+            '--name',
+            fixupName,
+            '--entrypoint',
+            '/bin/bash',
+            cacheTag,
+            '-c',
+            'chmod -R a+rwX /home/agent 2>/dev/null || true',
+          ],
+          opts
+        );
         const fixupCommitArgs = ['commit'];
         if (projectPath) {
-          fixupCommitArgs.push('--change', `LABEL rover.project.path=${projectPath}`);
+          fixupCommitArgs.push(
+            '--change',
+            `LABEL rover.project.path=${projectPath}`
+          );
         }
         if (agent) {
           fixupCommitArgs.push('--change', `LABEL rover.agent=${agent}`);
@@ -301,7 +312,9 @@ function hashMaterializedProjectContents(projectPath: string): string {
         }
 
         if (entry.isSymbolicLink()) {
-          hash.update(`symlink\0${entryRelativePath}\0${readlinkSync(entryPath)}\0`);
+          hash.update(
+            `symlink\0${entryRelativePath}\0${readlinkSync(entryPath)}\0`
+          );
         }
       }
     };

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -54,6 +54,7 @@ export interface SetupHashInputs {
     path: string;
     repository?: string;
     ref?: string;
+    repositoryRevision?: string;
     languages?: string[];
     packageManagers?: string[];
     taskManagers?: string[];
@@ -93,6 +94,7 @@ export function computeSetupHash(inputs: SetupHashInputs): string {
       path: p.path,
       repository: p.repository || '',
       ref: p.ref || '',
+      repositoryRevision: p.repositoryRevision || '',
       languages: [...(p.languages || [])].sort(),
       packageManagers: [...(p.packageManagers || [])].sort(),
       taskManagers: [...(p.taskManagers || [])].sort(),
@@ -144,6 +146,7 @@ export async function waitForInitAndCommit(
 ): Promise<boolean> {
   const env = envFromSandboxMetadata(sandboxMetadata);
   const opts = env ? { env } : undefined;
+  const keepFailedContainer = process.env.ROVER_DEBUG_KEEP_FAILED_BUILD === '1';
   try {
     // `docker/podman wait` prints the exit code to stdout
     const waitResult = await launch(backend, ['wait', containerName], opts);
@@ -196,14 +199,32 @@ export async function waitForInitAndCommit(
     }
 
     // Container exited with an unexpected code — don't commit
-    await launch(backend, ['rm', '-f', containerName], opts);
-    return false;
-  } catch {
-    // Best-effort cleanup
-    try {
+    if (!keepFailedContainer) {
       await launch(backend, ['rm', '-f', containerName], opts);
-    } catch {
-      // ignore cleanup errors
+    } else if (VERBOSE) {
+      console.error(
+        `[rover] keeping failed build container for debugging: ${containerName}`
+      );
+    }
+    return false;
+  } catch (error) {
+    if (VERBOSE) {
+      console.error(
+        `[rover] waitForInitAndCommit failed for ${containerName}:`,
+        error
+      );
+    }
+    // Best-effort cleanup
+    if (!keepFailedContainer) {
+      try {
+        await launch(backend, ['rm', '-f', containerName], opts);
+      } catch {
+        // ignore cleanup errors
+      }
+    } else if (VERBOSE) {
+      console.error(
+        `[rover] preserving build container after failure: ${containerName}`
+      );
     }
     return false;
   }
@@ -224,6 +245,24 @@ function resolveImageId(backend: ContainerBackend, imageTag: string): string {
     return id || imageTag;
   } catch {
     return imageTag;
+  }
+}
+
+function resolveRepositoryRevision(repository: string, ref?: string): string {
+  try {
+    const target = ref || 'HEAD';
+    const result = launchSync('git', ['ls-remote', repository, target], {
+      reject: false,
+    });
+    const line = result.stdout?.toString().trim().split('\n')[0]?.trim();
+    if (!line) {
+      return '';
+    }
+
+    const [sha] = line.split(/\s+/);
+    return sha || '';
+  } catch {
+    return '';
   }
 }
 
@@ -294,6 +333,10 @@ export function checkImageCache(
         path: p.path,
         repository: p.repository,
         ref: p.ref,
+        repositoryRevision:
+          typeof p.repository === 'string'
+            ? resolveRepositoryRevision(p.repository, p.ref)
+            : '',
         languages: p.languages,
         packageManagers: p.packageManagers,
         taskManagers: p.taskManagers,

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -10,6 +10,10 @@ import {
   VERBOSE,
 } from 'rover-core';
 import { ContainerBackend, resolveInitScriptPath } from './container-common.js';
+import {
+  isSafeRelativePath,
+  resolvePathWithinRoot,
+} from '../../utils/path-safety.js';
 
 /**
  * Build a process env with DOCKER_HOST set when the sandbox metadata
@@ -420,7 +424,16 @@ export function checkImageCache(
   // Read per-project init script contents for hashing
   let projects: SetupHashInputs['projects'];
   if (projectConfig.projects && projectConfig.projects.length > 0) {
-    projects = projectConfig.projects.map(p => {
+    projects = projectConfig.projects.flatMap(p => {
+      const projectPathIsSafe =
+        typeof p.path === 'string' &&
+        (typeof projectConfig.projectRoot !== 'string'
+          ? isSafeRelativePath(p.path)
+          : resolvePathWithinRoot(projectConfig.projectRoot, p.path) !== null);
+      if (!projectPathIsSafe) {
+        return [];
+      }
+
       let projectInitContent = '';
       if (p.initScript) {
         try {
@@ -434,31 +447,33 @@ export function checkImageCache(
           // treat as empty
         }
       }
-      return {
-        name: p.name,
-        path: p.path,
-        repository: p.repository,
-        ref: p.ref,
-        repositoryRevision:
-          typeof p.repository === 'string'
-            ? resolveRepositoryRevision(
-                projectConfig.projectRoot,
-                p.repository,
-                p.ref
-              )
-            : '',
-        localContentHash:
-          typeof p.repository === 'string'
-            ? ''
-            : hashMaterializedProjectContents(
-                join(projectConfig.projectRoot, p.path)
-              ),
-        languages: p.languages,
-        packageManagers: p.packageManagers,
-        taskManagers: p.taskManagers,
-        initScriptPath: p.initScript,
-        initScriptContent: projectInitContent,
-      };
+      return [
+        {
+          name: p.name,
+          path: p.path,
+          repository: p.repository,
+          ref: p.ref,
+          repositoryRevision:
+            typeof p.repository === 'string'
+              ? resolveRepositoryRevision(
+                  projectConfig.projectRoot,
+                  p.repository,
+                  p.ref
+                )
+              : '',
+          localContentHash:
+            typeof p.repository === 'string'
+              ? ''
+              : hashMaterializedProjectContents(
+                  join(projectConfig.projectRoot, p.path)
+                ),
+          languages: p.languages,
+          packageManagers: p.packageManagers,
+          taskManagers: p.taskManagers,
+          initScriptPath: p.initScript,
+          initScriptContent: projectInitContent,
+        },
+      ];
     });
   }
 

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { readdirSync, readFileSync, readlinkSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   launch,
   launchSync,
@@ -40,6 +41,7 @@ export interface SetupHashInputs {
   taskManagers: string[];
   agent: string;
   roverVersion: string;
+  initScriptPath?: string;
   initScriptContent: string;
   cacheFilesContent: string;
   mcps: Array<{
@@ -59,6 +61,7 @@ export interface SetupHashInputs {
     languages?: string[];
     packageManagers?: string[];
     taskManagers?: string[];
+    initScriptPath?: string;
     initScriptContent?: string;
   }>;
 }
@@ -76,6 +79,7 @@ export function computeSetupHash(inputs: SetupHashInputs): string {
     taskManagers: [...inputs.taskManagers].sort(),
     agent: inputs.agent,
     roverVersion: inputs.roverVersion,
+    initScriptPath: inputs.initScriptPath || '',
     initScriptContent: inputs.initScriptContent,
     cacheFilesContent: inputs.cacheFilesContent,
     mcps: [...inputs.mcps]
@@ -100,6 +104,7 @@ export function computeSetupHash(inputs: SetupHashInputs): string {
       languages: [...(p.languages || [])].sort(),
       packageManagers: [...(p.packageManagers || [])].sort(),
       taskManagers: [...(p.taskManagers || [])].sort(),
+      initScriptPath: p.initScriptPath || '',
       initScriptContent: p.initScriptContent || '',
     }));
   }
@@ -261,17 +266,46 @@ function resolveImageId(backend: ContainerBackend, imageTag: string): string {
   }
 }
 
-function resolveRepositoryRevision(repository: string, ref?: string): string {
+function resolveRepositoryForLookup(
+  projectRoot: string,
+  repository: string
+): string {
+  if (repository.startsWith('file://')) {
+    return fileURLToPath(repository);
+  }
+
+  if (
+    isAbsolute(repository) ||
+    repository === '.' ||
+    repository === '..' ||
+    repository.startsWith('./') ||
+    repository.startsWith('../')
+  ) {
+    return resolve(projectRoot, repository);
+  }
+
+  return repository;
+}
+
+function resolveRepositoryRevision(
+  projectRoot: string,
+  repository: string,
+  ref?: string
+): string {
   try {
     const target = ref || 'HEAD';
-    const result = launchSync('git', ['ls-remote', repository, target], {
+    const lookupRepository = resolveRepositoryForLookup(
+      projectRoot,
+      repository
+    );
+    const result = launchSync('git', ['ls-remote', lookupRepository, target], {
       reject: false,
     });
     const line = result.stdout?.toString().trim().split('\n')[0]?.trim();
     if (!line) {
       if (VERBOSE) {
         console.warn(
-          `[rover] git ls-remote returned no output for ${repository} ref=${target} — cache hash will not include this repo's revision`
+          `[rover] git ls-remote returned no output for ${lookupRepository} ref=${target} — cache hash will not include this repo's revision`
         );
       }
       return '';
@@ -353,7 +387,9 @@ export function checkImageCache(
     projectConfig.allTaskManagers ?? projectConfig.taskManagers ?? [];
 
   let initScriptContent = '';
+  let initScriptPath = '';
   if (projectConfig.initScript) {
+    initScriptPath = projectConfig.initScript;
     try {
       const initScriptAbsPath = join(
         projectConfig.projectRoot,
@@ -405,7 +441,11 @@ export function checkImageCache(
         ref: p.ref,
         repositoryRevision:
           typeof p.repository === 'string'
-            ? resolveRepositoryRevision(p.repository, p.ref)
+            ? resolveRepositoryRevision(
+                projectConfig.projectRoot,
+                p.repository,
+                p.ref
+              )
             : '',
         localContentHash:
           typeof p.repository === 'string'
@@ -416,6 +456,7 @@ export function checkImageCache(
         languages: p.languages,
         packageManagers: p.packageManagers,
         taskManagers: p.taskManagers,
+        initScriptPath: p.initScript,
         initScriptContent: projectInitContent,
       };
     });
@@ -429,6 +470,7 @@ export function checkImageCache(
     taskManagers,
     agent,
     roverVersion: getVersion(),
+    initScriptPath,
     initScriptContent,
     cacheFilesContent,
     mcps: projectConfig.mcps,

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -269,12 +269,22 @@ function resolveRepositoryRevision(repository: string, ref?: string): string {
     });
     const line = result.stdout?.toString().trim().split('\n')[0]?.trim();
     if (!line) {
+      if (VERBOSE) {
+        console.warn(
+          `[rover] git ls-remote returned no output for ${repository} ref=${target} — cache hash will not include this repo's revision`
+        );
+      }
       return '';
     }
 
     const [sha] = line.split(/\s+/);
     return sha || '';
-  } catch {
+  } catch (error) {
+    if (VERBOSE) {
+      console.warn(
+        `[rover] Warning: failed to resolve revision for ${repository}${ref ? ` ref=${ref}` : ''} — cache may not invalidate when this repo changes. ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
     return '';
   }
 }
@@ -397,9 +407,12 @@ export function checkImageCache(
           typeof p.repository === 'string'
             ? resolveRepositoryRevision(p.repository, p.ref)
             : '',
-        localContentHash: hashMaterializedProjectContents(
-          join(projectConfig.projectRoot, p.path)
-        ),
+        localContentHash:
+          typeof p.repository === 'string'
+            ? ''
+            : hashMaterializedProjectContents(
+                join(projectConfig.projectRoot, p.path)
+              ),
         languages: p.languages,
         packageManagers: p.packageManagers,
         taskManagers: p.taskManagers,

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -278,8 +278,11 @@ function resolveRepositoryForLookup(
     return fileURLToPath(repository);
   }
 
+  if (isAbsolute(repository) && !repository.startsWith('/workspace/')) {
+    return repository;
+  }
+
   if (
-    isAbsolute(repository) ||
     repository === '.' ||
     repository === '..' ||
     repository.startsWith('./') ||
@@ -395,7 +398,7 @@ export function checkImageCache(
   if (projectConfig.initScript) {
     initScriptPath = projectConfig.initScript;
     try {
-      const initScriptAbsPath = join(
+      const initScriptAbsPath = resolveInitScriptPath(
         projectConfig.projectRoot,
         projectConfig.initScript
       );

--- a/packages/cli/src/lib/sandbox/container-image-cache.ts
+++ b/packages/cli/src/lib/sandbox/container-image-cache.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync, readlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   launch,
@@ -55,6 +55,7 @@ export interface SetupHashInputs {
     repository?: string;
     ref?: string;
     repositoryRevision?: string;
+    localContentHash?: string;
     languages?: string[];
     packageManagers?: string[];
     taskManagers?: string[];
@@ -95,6 +96,7 @@ export function computeSetupHash(inputs: SetupHashInputs): string {
       repository: p.repository || '',
       ref: p.ref || '',
       repositoryRevision: p.repositoryRevision || '',
+      localContentHash: p.localContentHash || '',
       languages: [...(p.languages || [])].sort(),
       packageManagers: [...(p.packageManagers || [])].sort(),
       taskManagers: [...(p.taskManagers || [])].sort(),
@@ -266,6 +268,51 @@ function resolveRepositoryRevision(repository: string, ref?: string): string {
   }
 }
 
+function hashMaterializedProjectContents(projectPath: string): string {
+  const hash = createHash('sha256');
+
+  try {
+    const visit = (currentPath: string, relativePath: string): void => {
+      const entries = readdirSync(currentPath, { withFileTypes: true }).sort(
+        (a, b) => a.name.localeCompare(b.name)
+      );
+
+      for (const entry of entries) {
+        if (entry.name === '.git') {
+          continue;
+        }
+
+        const entryRelativePath = relativePath
+          ? `${relativePath}/${entry.name}`
+          : entry.name;
+        const entryPath = join(currentPath, entry.name);
+
+        if (entry.isDirectory()) {
+          hash.update(`dir\0${entryRelativePath}\0`);
+          visit(entryPath, entryRelativePath);
+          continue;
+        }
+
+        if (entry.isFile()) {
+          hash.update(`file\0${entryRelativePath}\0`);
+          hash.update(readFileSync(entryPath));
+          hash.update('\0');
+          continue;
+        }
+
+        if (entry.isSymbolicLink()) {
+          hash.update(`symlink\0${entryRelativePath}\0${readlinkSync(entryPath)}\0`);
+        }
+      }
+    };
+
+    visit(projectPath, '');
+    return hash.digest('hex');
+  } catch {
+    return '';
+  }
+}
+
 /**
  * Convenience function: compute hash, build tag, check existence.
  * Returns the cache tag and whether a cached image already exists.
@@ -337,6 +384,9 @@ export function checkImageCache(
           typeof p.repository === 'string'
             ? resolveRepositoryRevision(p.repository, p.ref)
             : '',
+        localContentHash: hashMaterializedProjectContents(
+          join(projectConfig.projectRoot, p.path)
+        ),
         languages: p.languages,
         packageManagers: p.packageManagers,
         taskManagers: p.taskManagers,

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -539,53 +539,10 @@ export class DockerSandbox extends Sandbox {
     let startedInteractiveServices = false;
 
     try {
-      // Start service containers for interactive mode
-      const services = projectConfig.services;
-      const existingServiceContext = this.resolveServiceContext();
-      if (services && services.length > 0 && !existingServiceContext) {
-        const dockerEnv = this.getDockerEnv();
-        const networkName = await createServiceNetwork(
-          ContainerBackend.Docker,
-          this.task.id,
-          this.task.iterations,
-          dockerEnv
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames: [],
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        startedInteractiveServices = true;
-        const containerNames = await startServiceContainers(
-          ContainerBackend.Docker,
-          services,
-          networkName,
-          this.task.id,
-          this.task.iterations,
-          dockerEnv,
-          startedContainerNames => {
-            this.serviceContext = {
-              networkName,
-              containerNames: startedContainerNames,
-              taskId: this.task.id,
-              iteration: this.task.iterations,
-            };
-          }
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames,
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        await waitForServicesReady(
-          ContainerBackend.Docker,
-          services,
-          containerNames,
-          dockerEnv
-        );
-      }
+      const ensuredServiceContext = await this.ensureServiceContext(
+        projectConfig.services
+      );
+      startedInteractiveServices = ensuredServiceContext.started;
 
       const interactiveName = `${this.sandboxName}-i`;
       const dockerArgs = ['run', '--name', interactiveName, '-it', '--rm'];
@@ -872,6 +829,11 @@ export class DockerSandbox extends Sandbox {
       '/bin/bash',
     ];
 
+    const ensuredServiceContext = await this.ensureServiceContext(
+      projectConfig.services
+    );
+    const startedShellServices = ensuredServiceContext.started;
+
     const serviceContext = this.resolveServiceContext();
     if (serviceContext) {
       dockerArgs.splice(
@@ -881,12 +843,27 @@ export class DockerSandbox extends Sandbox {
       );
     }
 
-    // Start Docker container with direct stdio inheritance for true interactivity
-    // Use detached: false to ensure proper TTY signal handling and job control
-    return await launch('docker', dockerArgs, {
-      reject: false,
-      stdio: 'inherit', // This gives full control to the user
-      detached: false,
-    });
+    try {
+      // Start Docker container with direct stdio inheritance for true interactivity
+      // Use detached: false to ensure proper TTY signal handling and job control
+      return await launch('docker', dockerArgs, {
+        reject: false,
+        stdio: 'inherit', // This gives full control to the user
+        detached: false,
+      });
+    } finally {
+      if (startedShellServices && this.serviceContext) {
+        try {
+          await teardownServiceContainers(
+            ContainerBackend.Docker,
+            this.serviceContext,
+            this.getDockerEnv()
+          );
+        } catch {
+          // Shell exit status takes precedence over sidecar cleanup.
+        }
+        this.serviceContext = undefined;
+      }
+    }
   }
 }

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -428,11 +428,15 @@ export class DockerSandbox extends Sandbox {
         this.processManager?.failLastItem();
         // Best-effort cleanup of any partially started services
         if (this.serviceContext) {
-          await teardownServiceContainers(
-            ContainerBackend.Docker,
-            this.serviceContext,
-            dockerEnv
-          );
+          try {
+            await teardownServiceContainers(
+              ContainerBackend.Docker,
+              this.serviceContext,
+              dockerEnv
+            );
+          } catch {
+            // Don't mask the original service startup error with cleanup failures.
+          }
           this.serviceContext = undefined;
         }
         this.processManager?.finish();
@@ -714,11 +718,15 @@ export class DockerSandbox extends Sandbox {
       });
     } finally {
       if (startedInteractiveServices && this.serviceContext) {
-        await teardownServiceContainers(
-          ContainerBackend.Docker,
-          this.serviceContext,
-          this.getDockerEnv()
-        );
+        try {
+          await teardownServiceContainers(
+            ContainerBackend.Docker,
+            this.serviceContext,
+            this.getDockerEnv()
+          );
+        } catch {
+          // Interactive session result takes precedence over sidecar cleanup.
+        }
         this.serviceContext = undefined;
       }
     }

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -125,6 +125,7 @@ export class DockerSandbox extends Sandbox {
     );
     const inputsPath = setupBuilder.generateInputs();
     const workflowPath = setupBuilder.saveWorkflow(this.task.workflowName);
+    const repositoryMounts = setupBuilder.getRepositoryMounts();
 
     // Get agent-specific Docker mounts and environment variables
     const agent = getAIAgentTool(this.task.agent!);
@@ -210,6 +211,13 @@ export class DockerSandbox extends Sandbox {
       '-v',
       `${iteration.fileDescriptionPath}:/task/description.json:Z,ro`
     );
+
+    for (const repositoryMount of repositoryMounts) {
+      dockerArgs.push(
+        '-v',
+        `${repositoryMount.hostPath}:${repositoryMount.containerPath}:Z,ro`
+      );
+    }
 
     // Mount context directory if available (read-only)
     const contextDir = join(iteration.iterationPath, 'context');
@@ -364,6 +372,9 @@ export class DockerSandbox extends Sandbox {
         throw err;
       }
 
+      // Clean up Phase 1 temp files before entering Phase 2
+      this.runTmpCleanups();
+
       // Phase 2: create + start the real container from cached image
       this.initMode = false;
       this.shouldCommitCache = false;
@@ -471,6 +482,7 @@ export class DockerSandbox extends Sandbox {
       'entrypoint-iterate.sh',
       hasCachedImage
     );
+    const repositoryMounts = setupBuilder.getRepositoryMounts();
     // Get agent-specific Docker mounts and environment variables
     const agent = getAIAgentTool(this.task.agent!);
     const dockerMounts: string[] = agent.getContainerMounts();
@@ -548,6 +560,13 @@ export class DockerSandbox extends Sandbox {
         `${entrypointScriptPath}:/entrypoint.sh:Z,ro`
       );
 
+      for (const repositoryMount of repositoryMounts) {
+        dockerArgs.push(
+          '-v',
+          `${repositoryMount.hostPath}:${repositoryMount.containerPath}:Z,ro`
+        );
+      }
+
       // Mount context directory if available (read-only)
       const contextDir = join(iteration.iterationPath, 'context');
       const hasContext = existsSync(contextDir);
@@ -617,6 +636,7 @@ export class DockerSandbox extends Sandbox {
         detached: false,
       });
     } finally {
+      this.runTmpCleanups();
       if (startedInteractiveServices && this.serviceContext) {
         try {
           await teardownServiceContainers(
@@ -779,8 +799,14 @@ export class DockerSandbox extends Sandbox {
 
     const serviceContext = this.resolveServiceContext();
     if (serviceContext) {
+      // Insert network args before the first '-v' flag so they don't land
+      // between '-v' and its volume argument. Using indexOf is resilient to
+      // extraArgs shifting earlier positions.
+      const volumeFlagIndex = dockerArgs.indexOf('-v');
+      const insertAt =
+        volumeFlagIndex !== -1 ? volumeFlagIndex : dockerArgs.length;
       dockerArgs.splice(
-        6,
+        insertAt,
         0,
         ...getServiceNetworkArgs(serviceContext.networkName)
       );

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -206,6 +206,9 @@ export class DockerSandbox extends Sandbox {
     const allInitScripts = projectConfig.allInitScripts;
     for (let i = 0; i < allInitScripts.length; i++) {
       const entry = allInitScripts[i];
+      if (entry.path) {
+        continue;
+      }
       const initScriptAbsPath = resolveInitScriptPath(
         projectConfig.projectRoot,
         entry.script,
@@ -519,6 +522,9 @@ export class DockerSandbox extends Sandbox {
     const allInitScripts = projectConfig.allInitScripts;
     for (let i = 0; i < allInitScripts.length; i++) {
       const entry = allInitScripts[i];
+      if (entry.path) {
+        continue;
+      }
       const initScriptAbsPath = resolveInitScriptPath(
         projectConfig.projectRoot,
         entry.script,

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -872,6 +872,15 @@ export class DockerSandbox extends Sandbox {
       '/bin/bash',
     ];
 
+    const serviceContext = this.resolveServiceContext();
+    if (serviceContext) {
+      dockerArgs.splice(
+        6,
+        0,
+        ...getServiceNetworkArgs(serviceContext.networkName)
+      );
+    }
+
     // Start Docker container with direct stdio inheritance for true interactivity
     // Use detached: false to ensure proper TTY signal handling and job control
     await launch('docker', dockerArgs, {

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -146,11 +146,10 @@ export class DockerSandbox extends Sandbox {
 
     const dockerArgs = ['create', '--name', this.sandboxName];
 
-    // Attach to the service network if services are running
-    if (this.serviceContext) {
-      dockerArgs.push(
-        ...getServiceNetworkArgs(this.serviceContext.networkName)
-      );
+    // Attach to the persisted or newly created service network when sidecars exist.
+    const serviceContext = this.resolveServiceContext();
+    if (serviceContext) {
+      dockerArgs.push(...getServiceNetworkArgs(serviceContext.networkName));
     }
 
     const rawUserInfo = userInfo();
@@ -379,7 +378,8 @@ export class DockerSandbox extends Sandbox {
       this.options?.projectPath ?? process.cwd()
     );
     const services = projectConfig.services;
-    if (services && services.length > 0) {
+    const existingServiceContext = this.resolveServiceContext();
+    if (services && services.length > 0 && !existingServiceContext) {
       this.processManager?.addItem('Starting service containers...');
       const dockerEnv = this.getDockerEnv();
       try {
@@ -839,7 +839,7 @@ export class DockerSandbox extends Sandbox {
     }
   }
 
-  async openShellAtWorktree(): Promise<void> {
+  async openShellAtWorktree(): Promise<{ exitCode?: number }> {
     // Check if worktree exists
     if (!this.task.worktreePath || !existsSync(this.task.worktreePath)) {
       throw new Error('No worktree found for this task');
@@ -883,7 +883,7 @@ export class DockerSandbox extends Sandbox {
 
     // Start Docker container with direct stdio inheritance for true interactivity
     // Use detached: false to ensure proper TTY signal handling and job control
-    await launch('docker', dockerArgs, {
+    return await launch('docker', dockerArgs, {
       reject: false,
       stdio: 'inherit', // This gives full control to the user
       detached: false,

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -34,11 +34,8 @@ import {
 } from './download-cache.js';
 import { isContainerMissingInspectError } from './inspect-errors.js';
 import {
-  createServiceNetwork,
   getServiceNetworkArgs,
-  startServiceContainers,
   teardownServiceContainers,
-  waitForServicesReady,
 } from './service-containers.js';
 import { Sandbox, SandboxOptions } from './types.js';
 import { validateSandboxWorktreePath } from './worktree-path.js';
@@ -378,67 +375,13 @@ export class DockerSandbox extends Sandbox {
       this.options?.projectPath ?? process.cwd()
     );
     const services = projectConfig.services;
-    const existingServiceContext = this.resolveServiceContext();
-    if (services && services.length > 0 && !existingServiceContext) {
-      this.processManager?.addItem('Starting service containers...');
-      const dockerEnv = this.getDockerEnv();
+    if (services && services.length > 0) {
+      this.processManager?.addItem('Ensuring service containers...');
       try {
-        const networkName = await createServiceNetwork(
-          ContainerBackend.Docker,
-          this.task.id,
-          this.task.iterations,
-          dockerEnv
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames: [],
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        const containerNames = await startServiceContainers(
-          ContainerBackend.Docker,
-          services,
-          networkName,
-          this.task.id,
-          this.task.iterations,
-          dockerEnv,
-          startedContainerNames => {
-            this.serviceContext = {
-              networkName,
-              containerNames: startedContainerNames,
-              taskId: this.task.id,
-              iteration: this.task.iterations,
-            };
-          }
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames,
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        await waitForServicesReady(
-          ContainerBackend.Docker,
-          services,
-          containerNames,
-          dockerEnv
-        );
+        await this.ensureServiceContext(services);
         this.processManager?.completeLastItem();
       } catch (err) {
         this.processManager?.failLastItem();
-        // Best-effort cleanup of any partially started services
-        if (this.serviceContext) {
-          try {
-            await teardownServiceContainers(
-              ContainerBackend.Docker,
-              this.serviceContext,
-              dockerEnv
-            );
-          } catch {
-            // Don't mask the original service startup error with cleanup failures.
-          }
-          this.serviceContext = undefined;
-        }
         this.processManager?.finish();
         throw err;
       }

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -20,7 +20,7 @@ import {
   getWorktreeGitMounts,
   normalizeExtraArgs,
   resolveAgentImage,
-  resolveInitScriptPath,
+  getInitScriptMounts,
   tmpUserGroupFiles,
   warnIfCustomImage,
 } from './container-common.js';
@@ -222,32 +222,10 @@ export class DockerSandbox extends Sandbox {
       dockerArgs.push('-v', `${contextDir}:/context:Z,ro`);
     }
 
-    // Mount init scripts (root + per-project)
-    const allInitScripts = projectConfig.allInitScripts;
-    for (let i = 0; i < allInitScripts.length; i++) {
-      const entry = allInitScripts[i];
-      if (entry.path) {
-        continue;
-      }
-      const initScriptAbsPath = resolveInitScriptPath(
-        projectConfig.projectRoot,
-        entry.script,
-        entry.path
-      );
-      if (existsSync(initScriptAbsPath)) {
-        const mountPath =
-          allInitScripts.length === 1 && !entry.path
-            ? '/init-script.sh'
-            : `/init-script-${i}.sh`;
-        dockerArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
-      } else if (!isJsonMode()) {
-        console.log(
-          colors.yellow(
-            `⚠ Warning: initScript '${entry.script}' does not exist`
-          )
-        );
-      }
-    }
+    // Mount init scripts (root-only; project-scoped scripts run from cloned workspace)
+    dockerArgs.push(
+      ...getInitScriptMounts(projectConfig, { warnMissing: !isJsonMode() })
+    );
 
     // Mount workspace description if projects are configured
     const workspaceDescPath = setupBuilder.generateWorkspaceDescription();
@@ -657,26 +635,8 @@ export class DockerSandbox extends Sandbox {
         dockerArgs.push('-v', `${contextDir}:/context:Z,ro`);
       }
 
-      // Mount init scripts (root + per-project)
-      const allInitScripts = projectConfig.allInitScripts;
-      for (let i = 0; i < allInitScripts.length; i++) {
-        const entry = allInitScripts[i];
-        if (entry.path) {
-          continue;
-        }
-        const initScriptAbsPath = resolveInitScriptPath(
-          projectConfig.projectRoot,
-          entry.script,
-          entry.path
-        );
-        if (existsSync(initScriptAbsPath)) {
-          const mountPath =
-            allInitScripts.length === 1 && !entry.path
-              ? '/init-script.sh'
-              : `/init-script-${i}.sh`;
-          dockerArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
-        }
-      }
+      // Mount init scripts (root-only; project-scoped scripts run from cloned workspace)
+      dockerArgs.push(...getInitScriptMounts(projectConfig));
 
       // Mount workspace description if projects are configured
       const workspaceDescPath = setupBuilder.generateWorkspaceDescription();

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -401,7 +401,15 @@ export class DockerSandbox extends Sandbox {
           networkName,
           this.task.id,
           this.task.iterations,
-          dockerEnv
+          dockerEnv,
+          startedContainerNames => {
+            this.serviceContext = {
+              networkName,
+              containerNames: startedContainerNames,
+              taskId: this.task.id,
+              iteration: this.task.iterations,
+            };
+          }
         );
         this.serviceContext = {
           networkName,
@@ -550,7 +558,15 @@ export class DockerSandbox extends Sandbox {
           networkName,
           this.task.id,
           this.task.iterations,
-          dockerEnv
+          dockerEnv,
+          startedContainerNames => {
+            this.serviceContext = {
+              networkName,
+              containerNames: startedContainerNames,
+              taskId: this.task.id,
+              iteration: this.task.iterations,
+            };
+          }
         );
         this.serviceContext = {
           networkName,

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -411,6 +411,12 @@ export class DockerSandbox extends Sandbox {
           this.task.iterations,
           dockerEnv
         );
+        this.serviceContext = {
+          networkName,
+          containerNames: [],
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
         const containerNames = await startServiceContainers(
           ContainerBackend.Docker,
           services,
@@ -463,6 +469,18 @@ export class DockerSandbox extends Sandbox {
       this.processManager?.completeLastItem();
     } catch (err) {
       this.runTmpCleanups();
+      if (this.serviceContext) {
+        try {
+          await teardownServiceContainers(
+            ContainerBackend.Docker,
+            this.serviceContext,
+            this.getDockerEnv()
+          );
+        } catch {
+          // Don't mask the original sandbox startup error with cleanup failures.
+        }
+        this.serviceContext = undefined;
+      }
       this.processManager?.failLastItem();
       this.processManager?.finish();
       throw err;

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -753,9 +753,19 @@ export class DockerSandbox extends Sandbox {
       if (!output) return null;
       const [status, exitCodeStr] = output.split('|');
       const exitCode = exitCodeStr ? parseInt(exitCodeStr, 10) : undefined;
-      return status
-        ? { status, exitCode: Number.isNaN(exitCode) ? undefined : exitCode }
-        : null;
+      if (!status) {
+        return null;
+      }
+
+      const containerState = {
+        status,
+        exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
+      };
+      if (status !== 'running') {
+        await this.teardownServicesIfConfigured();
+      }
+
+      return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {
         return null;

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -673,10 +673,6 @@ export class DockerSandbox extends Sandbox {
     return process.env;
   }
 
-  private shouldTeardownServicesForStatus(status: string): boolean {
-    return status === 'exited' || status === 'dead' || status === 'removing';
-  }
-
   async inspect(
     options?: SandboxInspectOptions
   ): Promise<{ status: string; exitCode?: number } | null> {
@@ -704,13 +700,6 @@ export class DockerSandbox extends Sandbox {
         status,
         exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
       };
-      if (
-        shouldTeardownServices &&
-        this.shouldTeardownServicesForStatus(status)
-      ) {
-        await this.teardownServicesIfConfigured();
-      }
-
       return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -1,33 +1,46 @@
-import { getAIAgentTool } from '../agents/index.js';
-import { join } from 'node:path';
-import { ProjectConfigManager, TaskDescriptionManager } from 'rover-core';
-import { Sandbox, SandboxOptions } from './types.js';
-import { SetupBuilder } from '../setup.js';
-import { generateRandomId, launch, ProcessManager, VERBOSE } from 'rover-core';
 import { existsSync, mkdirSync } from 'node:fs';
 import { userInfo } from 'node:os';
+import { join } from 'node:path';
+import colors from 'ansi-colors';
+import {
+  generateRandomId,
+  launch,
+  ProcessManager,
+  ProjectConfigManager,
+  TaskDescriptionManager,
+  VERBOSE,
+} from 'rover-core';
+import { getAIAgentTool } from '../agents/index.js';
+import { isJsonMode } from '../context.js';
+import { mergeNetworkConfig } from '../network-config.js';
+import { SetupBuilder } from '../setup.js';
 import {
   ContainerBackend,
   getCheckpointArgs,
   getWorktreeGitMounts,
+  normalizeExtraArgs,
   resolveAgentImage,
   resolveInitScriptPath,
-  warnIfCustomImage,
   tmpUserGroupFiles,
-  normalizeExtraArgs,
+  warnIfCustomImage,
 } from './container-common.js';
 import {
   checkImageCache,
   waitForInitAndCommit,
 } from './container-image-cache.js';
 import {
-  getDownloadCacheMounts,
   ensureDownloadCacheVolumes,
+  getDownloadCacheMounts,
 } from './download-cache.js';
 import { isContainerMissingInspectError } from './inspect-errors.js';
-import { mergeNetworkConfig } from '../network-config.js';
-import { isJsonMode } from '../context.js';
-import colors from 'ansi-colors';
+import {
+  createServiceNetwork,
+  getServiceNetworkArgs,
+  startServiceContainers,
+  teardownServiceContainers,
+  waitForServicesReady,
+} from './service-containers.js';
+import { Sandbox, SandboxOptions } from './types.js';
 import { validateSandboxWorktreePath } from './worktree-path.js';
 
 export class DockerSandbox extends Sandbox {
@@ -132,6 +145,13 @@ export class DockerSandbox extends Sandbox {
     }
 
     const dockerArgs = ['create', '--name', this.sandboxName];
+
+    // Attach to the service network if services are running
+    if (this.serviceContext) {
+      dockerArgs.push(
+        ...getServiceNetworkArgs(this.serviceContext.networkName)
+      );
+    }
 
     const rawUserInfo = userInfo();
     const userInfo_ = {
@@ -376,6 +396,58 @@ export class DockerSandbox extends Sandbox {
       this.cacheTag = undefined;
     }
 
+    // Start service containers before the task container (runtime only, not during cache builds)
+    const projectConfig = ProjectConfigManager.load(
+      this.options?.projectPath ?? process.cwd()
+    );
+    const services = projectConfig.services;
+    if (services && services.length > 0) {
+      this.processManager?.addItem('Starting service containers...');
+      const dockerEnv = this.getDockerEnv();
+      try {
+        const networkName = await createServiceNetwork(
+          ContainerBackend.Docker,
+          this.task.id,
+          this.task.iterations,
+          dockerEnv
+        );
+        const containerNames = await startServiceContainers(
+          ContainerBackend.Docker,
+          services,
+          networkName,
+          this.task.id,
+          this.task.iterations,
+          dockerEnv
+        );
+        this.serviceContext = {
+          networkName,
+          containerNames,
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
+        await waitForServicesReady(
+          ContainerBackend.Docker,
+          services,
+          containerNames,
+          dockerEnv
+        );
+        this.processManager?.completeLastItem();
+      } catch (err) {
+        this.processManager?.failLastItem();
+        // Best-effort cleanup of any partially started services
+        if (this.serviceContext) {
+          await teardownServiceContainers(
+            ContainerBackend.Docker,
+            this.serviceContext,
+            dockerEnv
+          );
+          this.serviceContext = undefined;
+        }
+        this.processManager?.finish();
+        throw err;
+      }
+    }
+
     // Cache-hit path (or phase 2 after init)
     let sandboxId = '';
     this.processManager?.addItem(
@@ -456,8 +528,47 @@ export class DockerSandbox extends Sandbox {
       projectConfig
     );
 
+    // Start service containers for interactive mode
+    const services = projectConfig.services;
+    if (services && services.length > 0 && !this.serviceContext) {
+      const dockerEnv = this.getDockerEnv();
+      const networkName = await createServiceNetwork(
+        ContainerBackend.Docker,
+        this.task.id,
+        this.task.iterations,
+        dockerEnv
+      );
+      const containerNames = await startServiceContainers(
+        ContainerBackend.Docker,
+        services,
+        networkName,
+        this.task.id,
+        this.task.iterations,
+        dockerEnv
+      );
+      this.serviceContext = {
+        networkName,
+        containerNames,
+        taskId: this.task.id,
+        iteration: this.task.iterations,
+      };
+      await waitForServicesReady(
+        ContainerBackend.Docker,
+        services,
+        containerNames,
+        dockerEnv
+      );
+    }
+
     const interactiveName = `${this.sandboxName}-i`;
     const dockerArgs = ['run', '--name', interactiveName, '-it', '--rm'];
+
+    // Attach to service network
+    if (this.serviceContext) {
+      dockerArgs.push(
+        ...getServiceNetworkArgs(this.serviceContext.networkName)
+      );
+    }
 
     const rawUserInfoInteractive = userInfo();
     const userInfo_ = {

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -541,7 +541,8 @@ export class DockerSandbox extends Sandbox {
     try {
       // Start service containers for interactive mode
       const services = projectConfig.services;
-      if (services && services.length > 0 && !this.serviceContext) {
+      const existingServiceContext = this.resolveServiceContext();
+      if (services && services.length > 0 && !existingServiceContext) {
         const dockerEnv = this.getDockerEnv();
         const networkName = await createServiceNetwork(
           ContainerBackend.Docker,
@@ -590,10 +591,9 @@ export class DockerSandbox extends Sandbox {
       const dockerArgs = ['run', '--name', interactiveName, '-it', '--rm'];
 
       // Attach to service network
-      if (this.serviceContext) {
-        dockerArgs.push(
-          ...getServiceNetworkArgs(this.serviceContext.networkName)
-        );
+      const serviceContext = this.resolveServiceContext();
+      if (serviceContext) {
+        dockerArgs.push(...getServiceNetworkArgs(serviceContext.networkName));
       }
 
       const rawUserInfoInteractive = userInfo();
@@ -778,6 +778,7 @@ export class DockerSandbox extends Sandbox {
       return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {
+        await this.teardownServicesIfConfigured();
         return null;
       }
       throw error;

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -37,7 +37,7 @@ import {
   getServiceNetworkArgs,
   teardownServiceContainers,
 } from './service-containers.js';
-import { Sandbox, SandboxOptions } from './types.js';
+import { Sandbox, SandboxInspectOptions, SandboxOptions } from './types.js';
 import { validateSandboxWorktreePath } from './worktree-path.js';
 
 export class DockerSandbox extends Sandbox {
@@ -64,7 +64,9 @@ export class DockerSandbox extends Sandbox {
   async isBackendAvailable(): Promise<boolean> {
     try {
       // Check if docker command exists and verify it's actual Docker (not Podman)
-      const result = await launch('docker', ['info', '--format', 'json']);
+      const result = await launch('docker', ['info', '--format', 'json'], {
+        env: this.getDockerEnv(),
+      });
       const info = JSON.parse(result.stdout?.toString() || '{}');
 
       // Docker will have ServerVersion set, Podman (even aliased as docker) will not
@@ -137,7 +139,9 @@ export class DockerSandbox extends Sandbox {
 
     // Clean up any existing container with same name
     try {
-      await launch('docker', ['rm', '-f', this.sandboxName]);
+      await launch('docker', ['rm', '-f', this.sandboxName], {
+        env: this.getDockerEnv(),
+      });
     } catch (error) {
       // Container doesn't exist, which is fine
     }
@@ -300,14 +304,19 @@ export class DockerSandbox extends Sandbox {
     }
 
     return (
-      (await launch('docker', dockerArgs)).stdout?.toString().trim() ||
-      this.sandboxName
+      (await launch('docker', dockerArgs, { env: this.getDockerEnv() })).stdout
+        ?.toString()
+        .trim() || this.sandboxName
     );
   }
 
   protected async start(): Promise<string> {
     return (
-      (await launch('docker', ['start', this.sandboxName])).stdout
+      (
+        await launch('docker', ['start', this.sandboxName], {
+          env: this.getDockerEnv(),
+        })
+      ).stdout
         ?.toString()
         .trim() || this.sandboxName
     );
@@ -631,6 +640,7 @@ export class DockerSandbox extends Sandbox {
 
       // Use detached: false to ensure proper TTY signal handling and job control
       return await launch('docker', dockerArgs, {
+        env: this.getDockerEnv(),
         stdio: 'inherit',
         reject: false,
         detached: false,
@@ -667,7 +677,10 @@ export class DockerSandbox extends Sandbox {
     return status === 'exited' || status === 'dead' || status === 'removing';
   }
 
-  async inspect(): Promise<{ status: string; exitCode?: number } | null> {
+  async inspect(
+    options?: SandboxInspectOptions
+  ): Promise<{ status: string; exitCode?: number } | null> {
+    const shouldTeardownServices = options?.teardownServices !== false;
     try {
       const result = await launch(
         'docker',
@@ -691,14 +704,19 @@ export class DockerSandbox extends Sandbox {
         status,
         exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
       };
-      if (this.shouldTeardownServicesForStatus(status)) {
+      if (
+        shouldTeardownServices &&
+        this.shouldTeardownServicesForStatus(status)
+      ) {
         await this.teardownServicesIfConfigured();
       }
 
       return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {
-        await this.teardownServicesIfConfigured();
+        if (shouldTeardownServices) {
+          await this.teardownServicesIfConfigured();
+        }
         return null;
       }
       throw error;
@@ -816,6 +834,7 @@ export class DockerSandbox extends Sandbox {
       // Start Docker container with direct stdio inheritance for true interactivity
       // Use detached: false to ensure proper TTY signal handling and job control
       return await launch('docker', dockerArgs, {
+        env: this.getDockerEnv(),
         reject: false,
         stdio: 'inherit', // This gives full control to the user
         detached: false,

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -546,184 +546,206 @@ export class DockerSandbox extends Sandbox {
       projectConfig
     );
 
-    // Start service containers for interactive mode
-    const services = projectConfig.services;
-    if (services && services.length > 0 && !this.serviceContext) {
-      const dockerEnv = this.getDockerEnv();
-      const networkName = await createServiceNetwork(
-        ContainerBackend.Docker,
-        this.task.id,
-        this.task.iterations,
-        dockerEnv
-      );
-      const containerNames = await startServiceContainers(
-        ContainerBackend.Docker,
-        services,
-        networkName,
-        this.task.id,
-        this.task.iterations,
-        dockerEnv
-      );
-      this.serviceContext = {
-        networkName,
-        containerNames,
-        taskId: this.task.id,
-        iteration: this.task.iterations,
+    let startedInteractiveServices = false;
+
+    try {
+      // Start service containers for interactive mode
+      const services = projectConfig.services;
+      if (services && services.length > 0 && !this.serviceContext) {
+        const dockerEnv = this.getDockerEnv();
+        const networkName = await createServiceNetwork(
+          ContainerBackend.Docker,
+          this.task.id,
+          this.task.iterations,
+          dockerEnv
+        );
+        this.serviceContext = {
+          networkName,
+          containerNames: [],
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
+        startedInteractiveServices = true;
+        const containerNames = await startServiceContainers(
+          ContainerBackend.Docker,
+          services,
+          networkName,
+          this.task.id,
+          this.task.iterations,
+          dockerEnv
+        );
+        this.serviceContext = {
+          networkName,
+          containerNames,
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
+        await waitForServicesReady(
+          ContainerBackend.Docker,
+          services,
+          containerNames,
+          dockerEnv
+        );
+      }
+
+      const interactiveName = `${this.sandboxName}-i`;
+      const dockerArgs = ['run', '--name', interactiveName, '-it', '--rm'];
+
+      // Attach to service network
+      if (this.serviceContext) {
+        dockerArgs.push(
+          ...getServiceNetworkArgs(this.serviceContext.networkName)
+        );
+      }
+
+      const rawUserInfoInteractive = userInfo();
+      const userInfo_ = {
+        ...rawUserInfoInteractive,
+        uid:
+          rawUserInfoInteractive.uid === -1 ? 1000 : rawUserInfoInteractive.uid,
+        gid:
+          rawUserInfoInteractive.gid === -1 ? 1000 : rawUserInfoInteractive.gid,
       };
-      await waitForServicesReady(
+
+      // Warn if using a custom agent image
+      warnIfCustomImage(projectConfig);
+
+      const {
+        etcPasswd,
+        etcGroup,
+        cleanup: cleanupTmpFiles,
+      } = await tmpUserGroupFiles(
         ContainerBackend.Docker,
-        services,
-        containerNames,
-        dockerEnv
+        effectiveImage,
+        userInfo_
       );
-    }
+      this._tmpCleanups.push(cleanupTmpFiles);
 
-    const interactiveName = `${this.sandboxName}-i`;
-    const dockerArgs = ['run', '--name', interactiveName, '-it', '--rm'];
-
-    // Attach to service network
-    if (this.serviceContext) {
-      dockerArgs.push(
-        ...getServiceNetworkArgs(this.serviceContext.networkName)
+      // Add NET_ADMIN capability if network filtering is configured
+      const effectiveNetworkConfigInteractive = mergeNetworkConfig(
+        projectConfig.network,
+        this.task.networkConfig
       );
-    }
-
-    const rawUserInfoInteractive = userInfo();
-    const userInfo_ = {
-      ...rawUserInfoInteractive,
-      uid:
-        rawUserInfoInteractive.uid === -1 ? 1000 : rawUserInfoInteractive.uid,
-      gid:
-        rawUserInfoInteractive.gid === -1 ? 1000 : rawUserInfoInteractive.gid,
-    };
-
-    // Warn if using a custom agent image
-    warnIfCustomImage(projectConfig);
-
-    const {
-      etcPasswd,
-      etcGroup,
-      cleanup: cleanupTmpFiles,
-    } = await tmpUserGroupFiles(
-      ContainerBackend.Docker,
-      effectiveImage,
-      userInfo_
-    );
-    this._tmpCleanups.push(cleanupTmpFiles);
-
-    // Add NET_ADMIN capability if network filtering is configured
-    const effectiveNetworkConfigInteractive = mergeNetworkConfig(
-      projectConfig.network,
-      this.task.networkConfig
-    );
-    if (
-      effectiveNetworkConfigInteractive &&
-      effectiveNetworkConfigInteractive.mode !== 'allowall'
-    ) {
-      dockerArgs.push('--cap-add=NET_ADMIN');
-    }
-
-    dockerArgs.push(
-      '-v',
-      `${etcPasswd}:/etc/passwd:Z,ro`,
-      '-v',
-      `${etcGroup}:/etc/group:Z,ro`,
-      '--user',
-      `${userInfo_.uid}:${userInfo_.gid}`,
-      '-v',
-      `${worktreePath}:/workspace:Z,rw`,
-      ...getWorktreeGitMounts(worktreePath),
-      '-v',
-      `${iteration.iterationPath}:/output:Z,rw`,
-      ...dockerMounts,
-      '-v',
-      `${entrypointScriptPath}:/entrypoint.sh:Z,ro`
-    );
-
-    // Mount context directory if available (read-only)
-    const contextDir = join(iteration.iterationPath, 'context');
-    const hasContext = existsSync(contextDir);
-    if (hasContext) {
-      dockerArgs.push('-v', `${contextDir}:/context:Z,ro`);
-    }
-
-    // Mount init scripts (root + per-project)
-    const allInitScripts = projectConfig.allInitScripts;
-    for (let i = 0; i < allInitScripts.length; i++) {
-      const entry = allInitScripts[i];
-      if (entry.path) {
-        continue;
+      if (
+        effectiveNetworkConfigInteractive &&
+        effectiveNetworkConfigInteractive.mode !== 'allowall'
+      ) {
+        dockerArgs.push('--cap-add=NET_ADMIN');
       }
-      const initScriptAbsPath = resolveInitScriptPath(
-        projectConfig.projectRoot,
-        entry.script,
-        entry.path
-      );
-      if (existsSync(initScriptAbsPath)) {
-        const mountPath =
-          allInitScripts.length === 1 && !entry.path
-            ? '/init-script.sh'
-            : `/init-script-${i}.sh`;
-        dockerArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
-      }
-    }
 
-    // Mount workspace description if projects are configured
-    const workspaceDescPath = setupBuilder.generateWorkspaceDescription();
-    if (workspaceDescPath) {
       dockerArgs.push(
         '-v',
-        `${workspaceDescPath}:/workspace/.rover-workspace.json:Z,ro`
+        `${etcPasswd}:/etc/passwd:Z,ro`,
+        '-v',
+        `${etcGroup}:/etc/group:Z,ro`,
+        '--user',
+        `${userInfo_.uid}:${userInfo_.gid}`,
+        '-v',
+        `${worktreePath}:/workspace:Z,rw`,
+        ...getWorktreeGitMounts(worktreePath),
+        '-v',
+        `${iteration.iterationPath}:/output:Z,rw`,
+        ...dockerMounts,
+        '-v',
+        `${entrypointScriptPath}:/entrypoint.sh:Z,ro`
       );
+
+      // Mount context directory if available (read-only)
+      const contextDir = join(iteration.iterationPath, 'context');
+      const hasContext = existsSync(contextDir);
+      if (hasContext) {
+        dockerArgs.push('-v', `${contextDir}:/context:Z,ro`);
+      }
+
+      // Mount init scripts (root + per-project)
+      const allInitScripts = projectConfig.allInitScripts;
+      for (let i = 0; i < allInitScripts.length; i++) {
+        const entry = allInitScripts[i];
+        if (entry.path) {
+          continue;
+        }
+        const initScriptAbsPath = resolveInitScriptPath(
+          projectConfig.projectRoot,
+          entry.script,
+          entry.path
+        );
+        if (existsSync(initScriptAbsPath)) {
+          const mountPath =
+            allInitScripts.length === 1 && !entry.path
+              ? '/init-script.sh'
+              : `/init-script-${i}.sh`;
+          dockerArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
+        }
+      }
+
+      // Mount workspace description if projects are configured
+      const workspaceDescPath = setupBuilder.generateWorkspaceDescription();
+      if (workspaceDescPath) {
+        dockerArgs.push(
+          '-v',
+          `${workspaceDescPath}:/workspace/.rover-workspace.json:Z,ro`
+        );
+      }
+
+      // Mount download cache volumes for interactive mode too
+      ensureDownloadCacheVolumes(ContainerBackend.Docker, projectConfig);
+      dockerArgs.push(...getDownloadCacheMounts(projectConfig));
+
+      // Get extra args from CLI options and project config, merge them
+      const configExtraArgs = normalizeExtraArgs(
+        projectConfig.sandboxExtraArgs
+      );
+      const cliExtraArgs = normalizeExtraArgs(this.options?.extraArgs);
+      const extraArgs = [...configExtraArgs, ...cliExtraArgs];
+
+      dockerArgs.push(
+        ...envVariables,
+        '-w',
+        '/workspace',
+        '--entrypoint',
+        '/entrypoint.sh',
+        ...extraArgs,
+        effectiveImage,
+        'rover-agent',
+        'session',
+        this.task.agent!
+      );
+
+      if (initialPrompt) {
+        dockerArgs.push(initialPrompt);
+      }
+
+      // Pass context directory argument if context was mounted
+      if (hasContext) {
+        dockerArgs.push('--context-dir', '/context');
+      }
+
+      // Pass model if specified
+      if (this.task.agentModel) {
+        dockerArgs.push('--agent-model', this.task.agentModel);
+      }
+
+      // Forward verbose flag to rover-agent if enabled
+      if (VERBOSE) {
+        dockerArgs.push('-v');
+      }
+
+      // Use detached: false to ensure proper TTY signal handling and job control
+      return await launch('docker', dockerArgs, {
+        stdio: 'inherit',
+        reject: false,
+        detached: false,
+      });
+    } finally {
+      if (startedInteractiveServices && this.serviceContext) {
+        await teardownServiceContainers(
+          ContainerBackend.Docker,
+          this.serviceContext,
+          this.getDockerEnv()
+        );
+        this.serviceContext = undefined;
+      }
     }
-
-    // Mount download cache volumes for interactive mode too
-    ensureDownloadCacheVolumes(ContainerBackend.Docker, projectConfig);
-    dockerArgs.push(...getDownloadCacheMounts(projectConfig));
-
-    // Get extra args from CLI options and project config, merge them
-    const configExtraArgs = normalizeExtraArgs(projectConfig.sandboxExtraArgs);
-    const cliExtraArgs = normalizeExtraArgs(this.options?.extraArgs);
-    const extraArgs = [...configExtraArgs, ...cliExtraArgs];
-
-    dockerArgs.push(
-      ...envVariables,
-      '-w',
-      '/workspace',
-      '--entrypoint',
-      '/entrypoint.sh',
-      ...extraArgs,
-      effectiveImage,
-      'rover-agent',
-      'session',
-      this.task.agent!
-    );
-
-    if (initialPrompt) {
-      dockerArgs.push(initialPrompt);
-    }
-
-    // Pass context directory argument if context was mounted
-    if (hasContext) {
-      dockerArgs.push('--context-dir', '/context');
-    }
-
-    // Pass model if specified
-    if (this.task.agentModel) {
-      dockerArgs.push('--agent-model', this.task.agentModel);
-    }
-
-    // Forward verbose flag to rover-agent if enabled
-    if (VERBOSE) {
-      dockerArgs.push('-v');
-    }
-
-    // Use detached: false to ensure proper TTY signal handling and job control
-    return launch('docker', dockerArgs, {
-      stdio: 'inherit',
-      reject: false,
-      detached: false,
-    });
   }
 
   /**

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -743,6 +743,10 @@ export class DockerSandbox extends Sandbox {
     return process.env;
   }
 
+  private shouldTeardownServicesForStatus(status: string): boolean {
+    return status === 'exited' || status === 'dead' || status === 'removing';
+  }
+
   async inspect(): Promise<{ status: string; exitCode?: number } | null> {
     try {
       const result = await launch(
@@ -767,7 +771,7 @@ export class DockerSandbox extends Sandbox {
         status,
         exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
       };
-      if (status !== 'running') {
+      if (this.shouldTeardownServicesForStatus(status)) {
         await this.teardownServicesIfConfigured();
       }
 

--- a/packages/cli/src/lib/sandbox/download-cache.ts
+++ b/packages/cli/src/lib/sandbox/download-cache.ts
@@ -1,7 +1,9 @@
 import { launch, launchSync, ProjectConfigManager, VERBOSE } from 'rover-core';
+import type { Language, PackageManager } from 'rover-schemas';
 import { ContainerBackend } from './container-common.js';
 
 const VOLUME_PREFIX = 'rover-dlcache';
+type CacheTrigger = Language | PackageManager;
 
 interface DownloadCacheEntry {
   /** Docker/Podman named volume name */
@@ -21,7 +23,7 @@ interface DownloadCacheEntry {
  * re-downloading the same files from the network.
  */
 const CACHE_DEFINITIONS: Array<{
-  triggers: string[];
+  triggers: CacheTrigger[];
   volume: string;
   containerPath: string;
 }> = [

--- a/packages/cli/src/lib/sandbox/download-cache.ts
+++ b/packages/cli/src/lib/sandbox/download-cache.ts
@@ -84,10 +84,7 @@ export function getDownloadCacheEntries(
   const entries: DownloadCacheEntry[] = [];
 
   for (const def of CACHE_DEFINITIONS) {
-    if (
-      def.triggers.length === 0 ||
-      def.triggers.some(t => allNames.has(t))
-    ) {
+    if (def.triggers.length === 0 || def.triggers.some(t => allNames.has(t))) {
       entries.push({ volume: def.volume, containerPath: def.containerPath });
     }
   }
@@ -191,9 +188,7 @@ export async function removeDownloadCacheVolumes(
       removed.push(vol);
     } catch {
       if (VERBOSE) {
-        console.warn(
-          `Warning: Failed to remove download cache volume: ${vol}`
-        );
+        console.warn(`Warning: Failed to remove download cache volume: ${vol}`);
       }
     }
   }

--- a/packages/cli/src/lib/sandbox/index.ts
+++ b/packages/cli/src/lib/sandbox/index.ts
@@ -76,3 +76,11 @@ export async function createSandbox(
     'Neither Docker nor Podman are available. Please install Docker or Podman to run tasks.'
   );
 }
+
+export function isSandboxBackendUnavailableError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message ===
+      'Neither Docker nor Podman are available. Please install Docker or Podman to run tasks.'
+  );
+}

--- a/packages/cli/src/lib/sandbox/languages/dart.ts
+++ b/packages/cli/src/lib/sandbox/languages/dart.ts
@@ -5,21 +5,10 @@ export class DartSandboxPackage extends SandboxPackage {
   name = 'dart';
 
   installScript(): string {
-    // Install Flutter SDK (includes Dart SDK) and Linux desktop build deps.
+    // Install Flutter SDK (includes Dart SDK).
     // Reads .fvmrc for project-pinned version, falls back to stable.
-    // Uses pre-built SDK archive for speed instead of cloning the git repo.
+    // Uses the git repo for the channel name and the archive for pinned versions.
     return `
-# Linux desktop build toolchain (required for flutter test integration_test/)
-sudo apt-get update -qq && sudo apt-get install -y -qq cmake clang ninja-build pkg-config libgtk-3-dev 2>/dev/null || true
-# systemd postinst creates systemd-network (UID 998) which can conflict
-# with the container runtime user. Remove it to avoid HOME resolution issues.
-if getent passwd systemd-network >/dev/null 2>&1; then
-  sudo userdel systemd-network 2>/dev/null || sudo sed -i '/^systemd-network:/d' /etc/passwd
-fi
-if getent group systemd-network >/dev/null 2>&1; then
-  sudo groupdel systemd-network 2>/dev/null || sudo sed -i '/^systemd-network:/d' /etc/group
-fi
-
 FLUTTER_VERSION="stable"
 if [ -f /workspace/.fvmrc ]; then
   FVM_VER=$(cat /workspace/.fvmrc | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat /workspace/.fvmrc | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
@@ -34,10 +23,29 @@ case "$ARCH" in
   aarch64) FLUTTER_ARCH="arm64" ;;
   *) FLUTTER_ARCH="x64" ;;
 esac
+
+rm -rf $HOME/.flutter
+if [ "$FLUTTER_VERSION" = "stable" ]; then
+  echo "Resolving latest Flutter stable archive..."
+  FLUTTER_VERSION=$(python3 - <<'PY'
+import json
+import sys
+from urllib.request import urlopen
+
+meta = json.load(urlopen("https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"))
+stable_hash = meta["current_release"]["stable"]
+for release in meta["releases"]:
+    if release.get("hash") == stable_hash:
+        print(release["version"])
+        sys.exit(0)
+sys.exit(1)
+PY
+  ) || FLUTTER_VERSION="stable"
+fi
+
 FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_\${FLUTTER_VERSION}-stable.tar.xz"
 echo "Downloading Flutter SDK from $FLUTTER_URL ..."
 if curl -fsSL "$FLUTTER_URL" -o /tmp/flutter.tar.xz 2>/dev/null; then
-  rm -rf $HOME/.flutter
   tar xf /tmp/flutter.tar.xz -C $HOME --strip-components=0
   mv $HOME/flutter $HOME/.flutter
   rm -f /tmp/flutter.tar.xz
@@ -89,7 +97,6 @@ if [ -f /workspace/.fvmrc ]; then
   fi
 fi
 
-flutter precache --no-ios --no-macos --no-windows --no-fuchsia --no-universal-apk --no-web 2>/dev/null || true
 if [ -f /workspace/pubspec.yaml ]; then
   cd /workspace && flutter pub get 2>/dev/null || true
 fi`;

--- a/packages/cli/src/lib/sandbox/languages/dart.ts
+++ b/packages/cli/src/lib/sandbox/languages/dart.ts
@@ -73,8 +73,7 @@ fi
   }
 
   initScript(): string {
-    // Add Flutter and Dart to PATH, run precache for linux desktop only,
-    // and pre-resolve project dependencies.
+    // Add Flutter and Dart to PATH and run precache for linux desktop only.
     // Also reconcile Flutter version: the cache image may have been built
     // without /workspace mounted, so .fvmrc was unavailable during install.
     return `echo 'export PATH="$HOME/.flutter/bin:$HOME/.flutter/bin/cache/dart-sdk/bin:$HOME/.pub-cache/bin:$PATH"' >> $HOME/.profile
@@ -117,9 +116,6 @@ if [ -f /workspace/.fvmrc ]; then
   fi
 fi
 
-flutter precache --no-ios --no-macos --no-windows --no-fuchsia --no-universal-apk --no-web 2>/dev/null || true
-if [ -f /workspace/pubspec.yaml ]; then
-  cd /workspace && flutter pub get 2>/dev/null || true
-fi`;
+flutter precache --no-ios --no-macos --no-windows --no-fuchsia --no-universal-apk --no-web 2>/dev/null || true`;
   }
 }

--- a/packages/cli/src/lib/sandbox/languages/dart.ts
+++ b/packages/cli/src/lib/sandbox/languages/dart.ts
@@ -24,8 +24,13 @@ FLUTTER_VERSION="stable"
 if [ -f /workspace/.fvmrc ]; then
   FVM_VER=$(cat /workspace/.fvmrc | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat /workspace/.fvmrc | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
   if [ -n "$FVM_VER" ]; then
-    FLUTTER_VERSION="$FVM_VER"
-    echo "Using Flutter version from .fvmrc: $FLUTTER_VERSION"
+    # Validate version looks like a semver string or channel name to prevent injection
+    if echo "$FVM_VER" | grep -qP '^[0-9]+\\.[0-9]+\\.[0-9]+([._-].*)?$' || echo "$FVM_VER" | grep -qP '^(stable|beta|master|dev)$'; then
+      FLUTTER_VERSION="$FVM_VER"
+      echo "Using Flutter version from .fvmrc: $FLUTTER_VERSION"
+    else
+      echo "Warning: Invalid Flutter version in .fvmrc ($FVM_VER), using stable"
+    fi
   fi
 fi
 ARCH=$(uname -m)
@@ -80,6 +85,11 @@ source $HOME/.profile
 # Reconcile Flutter version: cache may have been built without .fvmrc
 if [ -f /workspace/.fvmrc ]; then
   WANT_VER=$(cat /workspace/.fvmrc | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat /workspace/.fvmrc | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
+  # Validate version before using it
+  if [ -n "$WANT_VER" ] && ! (echo "$WANT_VER" | grep -qP '^[0-9]+\\.[0-9]+\\.[0-9]+([._-].*)?$' || echo "$WANT_VER" | grep -qP '^(stable|beta|master|dev)$'); then
+    echo "Warning: Invalid Flutter version in .fvmrc ($WANT_VER), skipping reconciliation"
+    WANT_VER=""
+  fi
   if [ -n "$WANT_VER" ]; then
     HAVE_VER=$($HOME/.flutter/bin/flutter --version --machine 2>/dev/null | grep -oP '"frameworkVersion"\\s*:\\s*"\\K[^"]+' 2>/dev/null || echo "")
     if [ "$HAVE_VER" != "$WANT_VER" ]; then

--- a/packages/cli/src/lib/sandbox/languages/dart.ts
+++ b/packages/cli/src/lib/sandbox/languages/dart.ts
@@ -1,10 +1,27 @@
 import { SandboxPackage } from '../types.js';
 
 export class DartSandboxPackage extends SandboxPackage {
+  constructor(private readonly workspaceProjectPaths: string[] = []) {
+    super();
+  }
+
+  private getEscapedFvmrcPaths(): string {
+    const fvmrcPaths = ['/workspace/.fvmrc'];
+    for (const projectPath of this.workspaceProjectPaths) {
+      fvmrcPaths.push(`/workspace/${projectPath}/.fvmrc`);
+    }
+
+    return [...new Set(fvmrcPaths)]
+      .map(path => `'${path.replaceAll("'", "'\"'\"'")}'`)
+      .join(' ');
+  }
+
   // Name of the package
   name = 'dart';
 
   installScript(): string {
+    const escapedPaths = this.getEscapedFvmrcPaths();
+
     // Install Flutter SDK (includes Dart SDK) and Linux desktop build deps.
     // Reads .fvmrc for project-pinned version, falls back to stable.
     // Uses the git repo for the channel name and the archive for pinned versions.
@@ -21,18 +38,21 @@ if getent group systemd-network >/dev/null 2>&1; then
 fi
 
 FLUTTER_VERSION="stable"
-if [ -f /workspace/.fvmrc ]; then
-  FVM_VER=$(cat /workspace/.fvmrc | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat /workspace/.fvmrc | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
-  if [ -n "$FVM_VER" ]; then
-    # Validate version looks like a semver string or channel name to prevent injection
-    if echo "$FVM_VER" | grep -qP '^[0-9]+\\.[0-9]+\\.[0-9]+([._-].*)?$' || echo "$FVM_VER" | grep -qP '^(stable|beta|master|dev)$'; then
-      FLUTTER_VERSION="$FVM_VER"
-      echo "Using Flutter version from .fvmrc: $FLUTTER_VERSION"
-    else
-      echo "Warning: Invalid Flutter version in .fvmrc ($FVM_VER), using stable"
+for fvmrc_path in ${escapedPaths}; do
+  if [ -f "$fvmrc_path" ]; then
+    FVM_VER=$(cat "$fvmrc_path" | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat "$fvmrc_path" | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
+    if [ -n "$FVM_VER" ]; then
+      # Validate version looks like a semver string or channel name to prevent injection
+      if echo "$FVM_VER" | grep -qP '^[0-9]+\\.[0-9]+\\.[0-9]+([._-].*)?$' || echo "$FVM_VER" | grep -qP '^(stable|beta|master|dev)$'; then
+        FLUTTER_VERSION="$FVM_VER"
+        echo "Using Flutter version from $fvmrc_path: $FLUTTER_VERSION"
+        break
+      else
+        echo "Warning: Invalid Flutter version in $fvmrc_path ($FVM_VER), using stable"
+      fi
     fi
   fi
-fi
+done
 ARCH=$(uname -m)
 case "$ARCH" in
   x86_64) FLUTTER_ARCH="x64" ;;
@@ -73,6 +93,8 @@ fi
   }
 
   initScript(): string {
+    const escapedPaths = this.getEscapedFvmrcPaths();
+
     // Add Flutter and Dart to PATH and run precache for linux desktop only.
     // Also reconcile Flutter version: the cache image may have been built
     // without /workspace mounted, so .fvmrc was unavailable during install.
@@ -82,39 +104,42 @@ echo 'export PUB_CACHE="$HOME/.pub-cache"' >> $HOME/.profile
 source $HOME/.profile
 
 # Reconcile Flutter version: cache may have been built without .fvmrc
-if [ -f /workspace/.fvmrc ]; then
-  WANT_VER=$(cat /workspace/.fvmrc | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat /workspace/.fvmrc | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
-  # Validate version before using it
-  if [ -n "$WANT_VER" ] && ! (echo "$WANT_VER" | grep -qP '^[0-9]+\\.[0-9]+\\.[0-9]+([._-].*)?$' || echo "$WANT_VER" | grep -qP '^(stable|beta|master|dev)$'); then
-    echo "Warning: Invalid Flutter version in .fvmrc ($WANT_VER), skipping reconciliation"
-    WANT_VER=""
-  fi
-  if [ -n "$WANT_VER" ]; then
-    HAVE_VER=$($HOME/.flutter/bin/flutter --version --machine 2>/dev/null | grep -oP '"frameworkVersion"\\s*:\\s*"\\K[^"]+' 2>/dev/null || echo "")
-    if [ "$HAVE_VER" != "$WANT_VER" ]; then
-      echo "Flutter version mismatch: have=$HAVE_VER want=$WANT_VER — upgrading..."
-      ARCH=$(uname -m)
-      case "$ARCH" in
-        x86_64) FLUTTER_ARCH="x64" ;;
-        aarch64) FLUTTER_ARCH="arm64" ;;
-        *) FLUTTER_ARCH="x64" ;;
-      esac
-      FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_\${WANT_VER}-stable.tar.xz"
-      if curl -fsSL "$FLUTTER_URL" -o /tmp/flutter.tar.xz 2>/dev/null; then
-        rm -rf $HOME/.flutter
-        tar xf /tmp/flutter.tar.xz -C $HOME --strip-components=0
-        mv $HOME/flutter $HOME/.flutter
-        rm -f /tmp/flutter.tar.xz
-        echo "Flutter upgraded to $WANT_VER"
-      else
-        echo "Archive download failed, trying git..."
-        rm -rf $HOME/.flutter
-        git clone --depth 1 --branch "$WANT_VER" https://github.com/flutter/flutter.git $HOME/.flutter 2>/dev/null || true
+for fvmrc_path in ${escapedPaths}; do
+  if [ -f "$fvmrc_path" ]; then
+    WANT_VER=$(cat "$fvmrc_path" | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat "$fvmrc_path" | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
+    # Validate version before using it
+    if [ -n "$WANT_VER" ] && ! (echo "$WANT_VER" | grep -qP '^[0-9]+\\.[0-9]+\\.[0-9]+([._-].*)?$' || echo "$WANT_VER" | grep -qP '^(stable|beta|master|dev)$'); then
+      echo "Warning: Invalid Flutter version in $fvmrc_path ($WANT_VER), skipping reconciliation"
+      WANT_VER=""
+    fi
+    if [ -n "$WANT_VER" ]; then
+      HAVE_VER=$($HOME/.flutter/bin/flutter --version --machine 2>/dev/null | grep -oP '"frameworkVersion"\\s*:\\s*"\\K[^"]+' 2>/dev/null || echo "")
+      if [ "$HAVE_VER" != "$WANT_VER" ]; then
+        echo "Flutter version mismatch: have=$HAVE_VER want=$WANT_VER from $fvmrc_path — upgrading..."
+        ARCH=$(uname -m)
+        case "$ARCH" in
+          x86_64) FLUTTER_ARCH="x64" ;;
+          aarch64) FLUTTER_ARCH="arm64" ;;
+          *) FLUTTER_ARCH="x64" ;;
+        esac
+        FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_\${WANT_VER}-stable.tar.xz"
+        if curl -fsSL "$FLUTTER_URL" -o /tmp/flutter.tar.xz 2>/dev/null; then
+          rm -rf $HOME/.flutter
+          tar xf /tmp/flutter.tar.xz -C $HOME --strip-components=0
+          mv $HOME/flutter $HOME/.flutter
+          rm -f /tmp/flutter.tar.xz
+          echo "Flutter upgraded to $WANT_VER"
+        else
+          echo "Archive download failed, trying git..."
+          rm -rf $HOME/.flutter
+          git clone --depth 1 --branch "$WANT_VER" https://github.com/flutter/flutter.git $HOME/.flutter 2>/dev/null || true
+        fi
+        source $HOME/.profile
       fi
-      source $HOME/.profile
+      break
     fi
   fi
-fi
+done
 
 flutter precache --no-ios --no-macos --no-windows --no-fuchsia --no-universal-apk --no-web 2>/dev/null || true`;
   }

--- a/packages/cli/src/lib/sandbox/languages/dart.ts
+++ b/packages/cli/src/lib/sandbox/languages/dart.ts
@@ -5,10 +5,21 @@ export class DartSandboxPackage extends SandboxPackage {
   name = 'dart';
 
   installScript(): string {
-    // Install Flutter SDK (includes Dart SDK).
+    // Install Flutter SDK (includes Dart SDK) and Linux desktop build deps.
     // Reads .fvmrc for project-pinned version, falls back to stable.
     // Uses the git repo for the channel name and the archive for pinned versions.
     return `
+# Linux desktop build toolchain (required for flutter test integration_test/)
+sudo apt-get update -qq && sudo apt-get install -y -qq cmake clang ninja-build pkg-config libgtk-3-dev 2>/dev/null || true
+# systemd postinst creates systemd-network (UID 998) which can conflict
+# with the container runtime user. Remove it to avoid HOME resolution issues.
+if getent passwd systemd-network >/dev/null 2>&1; then
+  sudo userdel systemd-network 2>/dev/null || sudo sed -i '/^systemd-network:/d' /etc/passwd
+fi
+if getent group systemd-network >/dev/null 2>&1; then
+  sudo groupdel systemd-network 2>/dev/null || sudo sed -i '/^systemd-network:/d' /etc/group
+fi
+
 FLUTTER_VERSION="stable"
 if [ -f /workspace/.fvmrc ]; then
   FVM_VER=$(cat /workspace/.fvmrc | grep -oP '"flutter"\\s*:\\s*"\\K[^"]+' 2>/dev/null || cat /workspace/.fvmrc | tr -d '{}\" ' | grep -oP 'flutter:\\K[^,]+' 2>/dev/null)
@@ -27,20 +38,19 @@ esac
 rm -rf $HOME/.flutter
 if [ "$FLUTTER_VERSION" = "stable" ]; then
   echo "Resolving latest Flutter stable archive..."
-  FLUTTER_VERSION=$(python3 - <<'PY'
-import json
-import sys
-from urllib.request import urlopen
-
-meta = json.load(urlopen("https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"))
-stable_hash = meta["current_release"]["stable"]
-for release in meta["releases"]:
-    if release.get("hash") == stable_hash:
-        print(release["version"])
-        sys.exit(0)
-sys.exit(1)
-PY
-  ) || FLUTTER_VERSION="stable"
+  RELEASES_JSON=$(curl -fsSL "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json" 2>/dev/null || true)
+  if [ -n "$RELEASES_JSON" ]; then
+    # Try python3 first (most reliable JSON parsing), fall back to grep-based extraction.
+    # python3 may not be available yet if dart is the first language being installed.
+    FLUTTER_VERSION=$(echo "$RELEASES_JSON" | python3 -c "
+import json, sys
+meta = json.load(sys.stdin)
+h = meta['current_release']['stable']
+print(next(r['version'] for r in meta['releases'] if r.get('hash') == h))
+" 2>/dev/null) || \
+    FLUTTER_VERSION=$(echo "$RELEASES_JSON" | grep -oP '"version"\\s*:\\s*"\\K[0-9]+\\.[0-9]+\\.[0-9]+' 2>/dev/null | head -1) || \
+    FLUTTER_VERSION="stable"
+  fi
 fi
 
 FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_\${FLUTTER_VERSION}-stable.tar.xz"
@@ -97,6 +107,7 @@ if [ -f /workspace/.fvmrc ]; then
   fi
 fi
 
+flutter precache --no-ios --no-macos --no-windows --no-fuchsia --no-universal-apk --no-web 2>/dev/null || true
 if [ -f /workspace/pubspec.yaml ]; then
   cd /workspace && flutter pub get 2>/dev/null || true
 fi`;

--- a/packages/cli/src/lib/sandbox/languages/go.ts
+++ b/packages/cli/src/lib/sandbox/languages/go.ts
@@ -27,8 +27,8 @@ export class GoSandboxPackage extends SandboxPackage {
 GO_VERSION=""
 for go_mod_path in ${escapedPaths}; do
   if [ -f "$go_mod_path" ]; then
-    GO_VERSION=$(grep -oP '^go \\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' "$go_mod_path" | head -1)
-    TC_VERSION=$(grep -oP '^toolchain go\\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' "$go_mod_path" | head -1)
+    GO_VERSION=$(grep -oP '^go \\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' "$go_mod_path" | head -1 || true)
+    TC_VERSION=$(grep -oP '^toolchain go\\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' "$go_mod_path" | head -1 || true)
     [ -n "$TC_VERSION" ] && GO_VERSION="$TC_VERSION"
     [ -n "$GO_VERSION" ] && break
   fi

--- a/packages/cli/src/lib/sandbox/languages/go.ts
+++ b/packages/cli/src/lib/sandbox/languages/go.ts
@@ -47,27 +47,31 @@ case "$ARCH" in
   *)       GOARCH="amd64" ;;
 esac
 
+GO_INSTALL_DIR="/opt/go"
+
 echo "Installing Go $GO_VERSION_DL ($GOARCH)..."
 
 # Remove any distro-packaged Go first
 sudo apt-get remove -y golang-go 2>/dev/null || true
-sudo rm -rf /usr/local/go
+sudo rm -rf "$GO_INSTALL_DIR"
 
 # Download and extract official binary
 GO_URL="https://dl.google.com/go/go\${GO_VERSION_DL}.linux-\${GOARCH}.tar.gz"
 if curl -fsSL "$GO_URL" -o /tmp/go.tar.gz 2>/dev/null; then
-  sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+  sudo mkdir -p /opt
+  sudo tar -C /opt -xzf /tmp/go.tar.gz
   rm -f /tmp/go.tar.gz
-  echo "Go $GO_VERSION_DL installed to /usr/local/go"
+  echo "Go $GO_VERSION_DL installed to $GO_INSTALL_DIR"
 else
   echo "Download failed for $GO_URL, trying without patch version..."
   # Strip patch version and try again (e.g., 1.24 instead of 1.24.1)
   GO_MAJOR_MINOR=$(echo "$GO_VERSION" | grep -oP '^[0-9]+\\.[0-9]+')
   GO_URL2="https://dl.google.com/go/go\${GO_MAJOR_MINOR}.0.linux-\${GOARCH}.tar.gz"
   if curl -fsSL "$GO_URL2" -o /tmp/go.tar.gz 2>/dev/null; then
-    sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+    sudo mkdir -p /opt
+    sudo tar -C /opt -xzf /tmp/go.tar.gz
     rm -f /tmp/go.tar.gz
-    echo "Go \${GO_MAJOR_MINOR}.0 installed to /usr/local/go"
+    echo "Go \${GO_MAJOR_MINOR}.0 installed to $GO_INSTALL_DIR"
   else
     echo "Warning: could not download Go — falling back to apt"
     sudo apt-get install -y --no-install-recommends golang-go
@@ -79,7 +83,7 @@ fi
   initScript(): string {
     // Add Go to PATH and verify it works
     return `mkdir -p $HOME/go/bin
-echo 'export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"' >> $HOME/.profile
+echo 'export PATH="/opt/go/bin:$HOME/go/bin:$PATH"' >> $HOME/.profile
 echo 'export GOPATH="$HOME/go"' >> $HOME/.profile
 source $HOME/.profile
 # Verify go is accessible and version

--- a/packages/cli/src/lib/sandbox/languages/go.ts
+++ b/packages/cli/src/lib/sandbox/languages/go.ts
@@ -1,29 +1,38 @@
 import { SandboxPackage } from '../types.js';
 
 export class GoSandboxPackage extends SandboxPackage {
+  constructor(private readonly workspaceProjectPaths: string[] = []) {
+    super();
+  }
+
   // Name of the package
   name = 'go';
 
   installScript(): string {
+    const goModPaths = ['/workspace/go.mod', '/workspace/src/go.mod'];
+    for (const projectPath of this.workspaceProjectPaths) {
+      goModPaths.push(`/workspace/${projectPath}/go.mod`);
+      goModPaths.push(`/workspace/${projectPath}/src/go.mod`);
+    }
+
+    const uniqueGoModPaths = [...new Set(goModPaths)];
+    const escapedPaths = uniqueGoModPaths
+      .map(path => `'${path.replaceAll("'", "'\"'\"'")}'`)
+      .join(' ');
+
     // Install Go from official binaries.
     // Reads go.mod for the required version, falls back to latest stable.
     // Uses the official dl.google.com archive for the exact version needed.
     return `
 GO_VERSION=""
-if [ -f /workspace/go.mod ]; then
-  GO_VERSION=$(grep -oP '^go \\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' /workspace/go.mod | head -1)
-elif [ -f /workspace/src/go.mod ]; then
-  GO_VERSION=$(grep -oP '^go \\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' /workspace/src/go.mod | head -1)
-fi
-
-# If go.mod specifies a toolchain line, prefer that (more precise)
-if [ -f /workspace/go.mod ]; then
-  TC_VERSION=$(grep -oP '^toolchain go\\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' /workspace/go.mod | head -1)
-  [ -n "$TC_VERSION" ] && GO_VERSION="$TC_VERSION"
-elif [ -f /workspace/src/go.mod ]; then
-  TC_VERSION=$(grep -oP '^toolchain go\\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' /workspace/src/go.mod | head -1)
-  [ -n "$TC_VERSION" ] && GO_VERSION="$TC_VERSION"
-fi
+for go_mod_path in ${escapedPaths}; do
+  if [ -f "$go_mod_path" ]; then
+    GO_VERSION=$(grep -oP '^go \\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' "$go_mod_path" | head -1)
+    TC_VERSION=$(grep -oP '^toolchain go\\K[0-9]+\\.[0-9]+(\\.[0-9]+)?' "$go_mod_path" | head -1)
+    [ -n "$TC_VERSION" ] && GO_VERSION="$TC_VERSION"
+    [ -n "$GO_VERSION" ] && break
+  fi
+done
 
 if [ -z "$GO_VERSION" ]; then
   # Fallback: fetch latest stable version

--- a/packages/cli/src/lib/sandbox/languages/go.ts
+++ b/packages/cli/src/lib/sandbox/languages/go.ts
@@ -91,12 +91,6 @@ if go version > /dev/null 2>&1; then
   echo "Go ready: $(go version)"
 else
   echo "⚠ Warning: go binary is not accessible"
-fi
-# Pre-download modules if go.mod exists
-if [ -f /workspace/go.mod ]; then
-  cd /workspace && go mod download 2>/dev/null || true
-elif [ -f /workspace/src/go.mod ]; then
-  cd /workspace/src && go mod download 2>/dev/null || true
 fi`;
   }
 }

--- a/packages/cli/src/lib/sandbox/package-managers/uv.ts
+++ b/packages/cli/src/lib/sandbox/package-managers/uv.ts
@@ -16,19 +16,8 @@ fi
   }
 
   initScript(): string {
-    // Sync project dependencies if pyproject.toml exists (--all-extras for dev deps)
-    // Also add venv to PATH so python/pytest work without "uv run" prefix
-    return `
-source $HOME/.profile
-if [ -f /workspace/uv.lock ] && [ -f /workspace/pyproject.toml ]; then
-  cd /workspace && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || true
-elif [ -f /workspace/pyproject.toml ]; then
-  cd /workspace && uv sync --all-extras 2>/dev/null || true
-fi
-if [ -d /workspace/.venv/bin ]; then
-  echo 'export PATH="/workspace/.venv/bin:$PATH"' >> $HOME/.profile
-  source $HOME/.profile
-fi
-`;
+    // Workspace dependency resolution is handled centrally so it can run
+    // after user init scripts and repository materialization.
+    return ``;
   }
 }

--- a/packages/cli/src/lib/sandbox/packages.ts
+++ b/packages/cli/src/lib/sandbox/packages.ts
@@ -1,0 +1,85 @@
+import type { ProjectConfigManager } from 'rover-core';
+
+// Language packages
+import { JavaScriptSandboxPackage } from './languages/javascript.js';
+import { TypeScriptSandboxPackage } from './languages/typescript.js';
+import { PHPSandboxPackage } from './languages/php.js';
+import { RustSandboxPackage } from './languages/rust.js';
+import { GoSandboxPackage } from './languages/go.js';
+import { PythonSandboxPackage } from './languages/python.js';
+import { RubySandboxPackage } from './languages/ruby.js';
+import { DartSandboxPackage } from './languages/dart.js';
+
+// Package manager packages
+import { NpmSandboxPackage } from './package-managers/npm.js';
+import { PnpmSandboxPackage } from './package-managers/pnpm.js';
+import { YarnSandboxPackage } from './package-managers/yarn.js';
+import { ComposerSandboxPackage } from './package-managers/composer.js';
+import { CargoSandboxPackage } from './package-managers/cargo.js';
+import { GomodSandboxPackage } from './package-managers/gomod.js';
+import { PipSandboxPackage } from './package-managers/pip.js';
+import { PoetrySandboxPackage } from './package-managers/poetry.js';
+import { UvSandboxPackage } from './package-managers/uv.js';
+import { RubygemsSandboxPackage } from './package-managers/rubygems.js';
+import { PubSandboxPackage } from './package-managers/pub.js';
+
+// Task manager packages
+import { JustSandboxPackage } from './task-managers/just.js';
+import { MakeSandboxPackage } from './task-managers/make.js';
+import { TaskSandboxPackage } from './task-managers/task.js';
+
+import type { SandboxPackage } from './types.js';
+
+const langMap: Record<string, () => SandboxPackage> = {
+  javascript: () => new JavaScriptSandboxPackage(),
+  typescript: () => new TypeScriptSandboxPackage(),
+  php: () => new PHPSandboxPackage(),
+  rust: () => new RustSandboxPackage(),
+  go: () => new GoSandboxPackage(),
+  python: () => new PythonSandboxPackage(),
+  ruby: () => new RubySandboxPackage(),
+  dart: () => new DartSandboxPackage(),
+};
+
+const pmMap: Record<string, () => SandboxPackage> = {
+  npm: () => new NpmSandboxPackage(),
+  pnpm: () => new PnpmSandboxPackage(),
+  yarn: () => new YarnSandboxPackage(),
+  composer: () => new ComposerSandboxPackage(),
+  cargo: () => new CargoSandboxPackage(),
+  gomod: () => new GomodSandboxPackage(),
+  pip: () => new PipSandboxPackage(),
+  poetry: () => new PoetrySandboxPackage(),
+  uv: () => new UvSandboxPackage(),
+  rubygems: () => new RubygemsSandboxPackage(),
+  pub: () => new PubSandboxPackage(),
+};
+
+const tmMap: Record<string, () => SandboxPackage> = {
+  just: () => new JustSandboxPackage(),
+  make: () => new MakeSandboxPackage(),
+  task: () => new TaskSandboxPackage(),
+};
+
+/**
+ * Instantiate SandboxPackage objects for all languages, package managers,
+ * and task managers declared in the project configuration (including
+ * sub-project entries).
+ */
+export function getPackagesFromConfig(
+  projectConfig: ProjectConfigManager
+): SandboxPackage[] {
+  const packages: SandboxPackage[] = [];
+
+  for (const lang of projectConfig.allLanguages ?? []) {
+    if (langMap[lang]) packages.push(langMap[lang]());
+  }
+  for (const pm of projectConfig.allPackageManagers ?? []) {
+    if (pmMap[pm]) packages.push(pmMap[pm]());
+  }
+  for (const tm of projectConfig.allTaskManagers ?? []) {
+    if (tmMap[tm]) packages.push(tmMap[tm]());
+  }
+
+  return packages;
+}

--- a/packages/cli/src/lib/sandbox/packages.ts
+++ b/packages/cli/src/lib/sandbox/packages.ts
@@ -1,5 +1,8 @@
 import type { ProjectConfigManager } from 'rover-core';
-import { isSafeRelativePath } from '../../utils/path-safety.js';
+import {
+  isSafeRelativePath,
+  resolvePathWithinRoot,
+} from '../../utils/path-safety.js';
 
 // Language packages
 import { JavaScriptSandboxPackage } from './languages/javascript.js';
@@ -74,9 +77,14 @@ export function getPackagesFromConfig(
   projectConfig: ProjectConfigManager
 ): SandboxPackage[] {
   const packages: SandboxPackage[] = [];
+  const isSafeWorkspaceProjectPath = (projectPath: string): boolean =>
+    typeof projectConfig.projectRoot === 'string'
+      ? resolvePathWithinRoot(projectConfig.projectRoot, projectPath) !== null
+      : isSafeRelativePath(projectPath);
   const workspaceProjectPaths = (projectConfig.projects ?? []).flatMap(
     project =>
-      typeof project?.path === 'string' && isSafeRelativePath(project.path)
+      typeof project?.path === 'string' &&
+      isSafeWorkspaceProjectPath(project.path)
         ? [project.path]
         : []
   );

--- a/packages/cli/src/lib/sandbox/packages.ts
+++ b/packages/cli/src/lib/sandbox/packages.ts
@@ -1,4 +1,5 @@
 import type { ProjectConfigManager } from 'rover-core';
+import { isSafeRelativePath } from '../../utils/path-safety.js';
 
 // Language packages
 import { JavaScriptSandboxPackage } from './languages/javascript.js';
@@ -30,15 +31,18 @@ import { TaskSandboxPackage } from './task-managers/task.js';
 
 import type { SandboxPackage } from './types.js';
 
-const langMap: Record<string, () => SandboxPackage> = {
+const langMap: Record<
+  string,
+  (options: { workspaceProjectPaths: string[] }) => SandboxPackage
+> = {
   javascript: () => new JavaScriptSandboxPackage(),
   typescript: () => new TypeScriptSandboxPackage(),
   php: () => new PHPSandboxPackage(),
   rust: () => new RustSandboxPackage(),
-  go: () => new GoSandboxPackage(),
+  go: options => new GoSandboxPackage(options.workspaceProjectPaths),
   python: () => new PythonSandboxPackage(),
   ruby: () => new RubySandboxPackage(),
-  dart: () => new DartSandboxPackage(),
+  dart: options => new DartSandboxPackage(options.workspaceProjectPaths),
 };
 
 const pmMap: Record<string, () => SandboxPackage> = {
@@ -70,9 +74,15 @@ export function getPackagesFromConfig(
   projectConfig: ProjectConfigManager
 ): SandboxPackage[] {
   const packages: SandboxPackage[] = [];
+  const workspaceProjectPaths = (projectConfig.projects ?? []).flatMap(
+    project =>
+      typeof project?.path === 'string' && isSafeRelativePath(project.path)
+        ? [project.path]
+        : []
+  );
 
   for (const lang of projectConfig.allLanguages ?? []) {
-    if (langMap[lang]) packages.push(langMap[lang]());
+    if (langMap[lang]) packages.push(langMap[lang]({ workspaceProjectPaths }));
   }
   for (const pm of projectConfig.allPackageManagers ?? []) {
     if (pmMap[pm]) packages.push(pmMap[pm]());

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -29,6 +29,13 @@ import { mergeNetworkConfig } from '../network-config.js';
 import { isJsonMode } from '../context.js';
 import colors from 'ansi-colors';
 import { validateSandboxWorktreePath } from './worktree-path.js';
+import {
+  createServiceNetwork,
+  startServiceContainers,
+  waitForServicesReady,
+  getServiceNetworkArgs,
+  teardownServiceContainers,
+} from './service-containers.js';
 
 /**
  * Normalize UID/GID for environments that return -1 (e.g. Windows).
@@ -144,6 +151,13 @@ export class PodmanSandbox extends Sandbox {
     }
 
     const podmanArgs = ['create', '--name', this.sandboxName];
+
+    // Attach to the service network if services are running
+    if (this.serviceContext) {
+      podmanArgs.push(
+        ...getServiceNetworkArgs(this.serviceContext.networkName)
+      );
+    }
 
     const userInfo_ = normalizeUserInfo(userInfo());
 
@@ -385,6 +399,58 @@ export class PodmanSandbox extends Sandbox {
       this.cacheTag = undefined;
     }
 
+    // Start service containers before the task container (runtime only, not during cache builds)
+    const projectConfig = ProjectConfigManager.load(
+      this.options?.projectPath ?? process.cwd()
+    );
+    const services = projectConfig.services;
+    if (services && services.length > 0) {
+      this.processManager?.addItem('Starting service containers...');
+      try {
+        const networkName = await createServiceNetwork(
+          ContainerBackend.Podman,
+          this.task.id,
+          this.task.iterations
+        );
+        this.serviceContext = {
+          networkName,
+          containerNames: [],
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
+        const containerNames = await startServiceContainers(
+          ContainerBackend.Podman,
+          services,
+          networkName,
+          this.task.id,
+          this.task.iterations
+        );
+        this.serviceContext = {
+          networkName,
+          containerNames,
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
+        await waitForServicesReady(
+          ContainerBackend.Podman,
+          services,
+          containerNames
+        );
+        this.processManager?.completeLastItem();
+      } catch (err) {
+        this.processManager?.failLastItem();
+        if (this.serviceContext) {
+          await teardownServiceContainers(
+            ContainerBackend.Podman,
+            this.serviceContext
+          );
+          this.serviceContext = undefined;
+        }
+        this.processManager?.finish();
+        throw err;
+      }
+    }
+
     // Cache-hit path (or phase 2 after init)
     let sandboxId = '';
     this.processManager?.addItem(
@@ -400,6 +466,17 @@ export class PodmanSandbox extends Sandbox {
       this.processManager?.completeLastItem();
     } catch (err) {
       this.runTmpCleanups();
+      if (this.serviceContext) {
+        try {
+          await teardownServiceContainers(
+            ContainerBackend.Podman,
+            this.serviceContext
+          );
+        } catch {
+          // Don't mask the original sandbox startup error with cleanup failures.
+        }
+        this.serviceContext = undefined;
+      }
       this.processManager?.failLastItem();
       this.processManager?.finish();
       throw err;
@@ -465,8 +542,47 @@ export class PodmanSandbox extends Sandbox {
       projectConfig
     );
 
+    // Start service containers for interactive mode
+    const interactiveServices = projectConfig.services;
+    if (
+      interactiveServices &&
+      interactiveServices.length > 0 &&
+      !this.serviceContext
+    ) {
+      const networkName = await createServiceNetwork(
+        ContainerBackend.Podman,
+        this.task.id,
+        this.task.iterations
+      );
+      const containerNames = await startServiceContainers(
+        ContainerBackend.Podman,
+        interactiveServices,
+        networkName,
+        this.task.id,
+        this.task.iterations
+      );
+      this.serviceContext = {
+        networkName,
+        containerNames,
+        taskId: this.task.id,
+        iteration: this.task.iterations,
+      };
+      await waitForServicesReady(
+        ContainerBackend.Podman,
+        interactiveServices,
+        containerNames
+      );
+    }
+
     const interactiveName = `${this.sandboxName}-i`;
     const podmanArgs = ['run', '--name', interactiveName, '-it', '--rm'];
+
+    // Attach to service network
+    if (this.serviceContext) {
+      podmanArgs.push(
+        ...getServiceNetworkArgs(this.serviceContext.networkName)
+      );
+    }
 
     const userInfo_ = normalizeUserInfo(userInfo());
 

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -542,10 +542,11 @@ export class PodmanSandbox extends Sandbox {
     try {
       // Start service containers for interactive mode
       const interactiveServices = projectConfig.services;
+      const existingServiceContext = this.resolveServiceContext();
       if (
         interactiveServices &&
         interactiveServices.length > 0 &&
-        !this.serviceContext
+        !existingServiceContext
       ) {
         const networkName = await createServiceNetwork(
           ContainerBackend.Podman,
@@ -592,10 +593,9 @@ export class PodmanSandbox extends Sandbox {
       const podmanArgs = ['run', '--name', interactiveName, '-it', '--rm'];
 
       // Attach to service network
-      if (this.serviceContext) {
-        podmanArgs.push(
-          ...getServiceNetworkArgs(this.serviceContext.networkName)
-        );
+      const serviceContext = this.resolveServiceContext();
+      if (serviceContext) {
+        podmanArgs.push(...getServiceNetworkArgs(serviceContext.networkName));
       }
 
       const userInfo_ = normalizeUserInfo(userInfo());
@@ -757,6 +757,7 @@ export class PodmanSandbox extends Sandbox {
       return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {
+        await this.teardownServicesIfConfigured();
         return null;
       }
       throw error;

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -11,7 +11,7 @@ import {
   getCheckpointArgs,
   getWorktreeGitMounts,
   resolveAgentImage,
-  resolveInitScriptPath,
+  getInitScriptMounts,
   warnIfCustomImage,
   tmpUserGroupFiles,
   normalizeExtraArgs,
@@ -223,32 +223,10 @@ export class PodmanSandbox extends Sandbox {
       podmanArgs.push('-v', `${contextDir}:/context:Z,ro`);
     }
 
-    // Mount init scripts (root + per-project)
-    const allInitScripts = projectConfig.allInitScripts;
-    for (let i = 0; i < allInitScripts.length; i++) {
-      const entry = allInitScripts[i];
-      if (entry.path) {
-        continue;
-      }
-      const initScriptAbsPath = resolveInitScriptPath(
-        projectConfig.projectRoot,
-        entry.script,
-        entry.path
-      );
-      if (existsSync(initScriptAbsPath)) {
-        const mountPath =
-          allInitScripts.length === 1 && !entry.path
-            ? '/init-script.sh'
-            : `/init-script-${i}.sh`;
-        podmanArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
-      } else if (!isJsonMode()) {
-        console.log(
-          colors.yellow(
-            `⚠ Warning: initScript '${entry.script}' does not exist`
-          )
-        );
-      }
-    }
+    // Mount init scripts (root-only; project-scoped scripts run from cloned workspace)
+    podmanArgs.push(
+      ...getInitScriptMounts(projectConfig, { warnMissing: !isJsonMode() })
+    );
 
     // Mount workspace description if projects are configured
     const workspaceDescPath = setupBuilder.generateWorkspaceDescription();
@@ -646,26 +624,8 @@ export class PodmanSandbox extends Sandbox {
         podmanArgs.push('-v', `${contextDir}:/context:Z,ro`);
       }
 
-      // Mount init scripts (root + per-project)
-      const allInitScripts = projectConfig.allInitScripts;
-      for (let i = 0; i < allInitScripts.length; i++) {
-        const entry = allInitScripts[i];
-        if (entry.path) {
-          continue;
-        }
-        const initScriptAbsPath = resolveInitScriptPath(
-          projectConfig.projectRoot,
-          entry.script,
-          entry.path
-        );
-        if (existsSync(initScriptAbsPath)) {
-          const mountPath =
-            allInitScripts.length === 1 && !entry.path
-              ? '/init-script.sh'
-              : `/init-script-${i}.sh`;
-          podmanArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
-        }
-      }
+      // Mount init scripts (root-only; project-scoped scripts run from cloned workspace)
+      podmanArgs.push(...getInitScriptMounts(projectConfig));
 
       // Mount workspace description if projects are configured
       const workspaceDescPath = setupBuilder.generateWorkspaceDescription();

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -134,6 +134,7 @@ export class PodmanSandbox extends Sandbox {
     );
     const inputsPath = setupBuilder.generateInputs();
     const workflowPath = setupBuilder.saveWorkflow(this.task.workflowName);
+    const repositoryMounts = setupBuilder.getRepositoryMounts();
 
     // Get agent-specific container mounts
     const agent = getAIAgentTool(this.task.agent!);
@@ -215,6 +216,13 @@ export class PodmanSandbox extends Sandbox {
       '-v',
       `${iteration.fileDescriptionPath}:/task/description.json:Z,ro`
     );
+
+    for (const repositoryMount of repositoryMounts) {
+      podmanArgs.push(
+        '-v',
+        `${repositoryMount.hostPath}:${repositoryMount.containerPath}:Z,ro`
+      );
+    }
 
     // Mount context directory if available (read-only)
     const contextDir = join(iteration.iterationPath, 'context');
@@ -371,6 +379,9 @@ export class PodmanSandbox extends Sandbox {
         throw err;
       }
 
+      // Clean up Phase 1 temp files before entering Phase 2
+      this.runTmpCleanups();
+
       // Phase 2: create + start the real container from cached image
       this.initMode = false;
       this.shouldCommitCache = false;
@@ -477,6 +488,7 @@ export class PodmanSandbox extends Sandbox {
       'entrypoint-iterate.sh',
       hasCachedImage
     );
+    const repositoryMounts = setupBuilder.getRepositoryMounts();
     // Get agent-specific container mounts and environment variables
     const agent = getAIAgentTool(this.task.agent!);
     const containerMounts: string[] = agent.getContainerMounts();
@@ -547,6 +559,13 @@ export class PodmanSandbox extends Sandbox {
         `${entrypointScriptPath}:/entrypoint.sh:Z,ro`
       );
 
+      for (const repositoryMount of repositoryMounts) {
+        podmanArgs.push(
+          '-v',
+          `${repositoryMount.hostPath}:${repositoryMount.containerPath}:Z,ro`
+        );
+      }
+
       // Mount context directory if available (read-only)
       const contextDir = join(iteration.iterationPath, 'context');
       const hasContext = existsSync(contextDir);
@@ -616,6 +635,7 @@ export class PodmanSandbox extends Sandbox {
         detached: false,
       });
     } finally {
+      this.runTmpCleanups();
       if (startedInteractiveServices && this.serviceContext) {
         try {
           await teardownServiceContainers(
@@ -756,8 +776,14 @@ export class PodmanSandbox extends Sandbox {
 
     const serviceContext = this.resolveServiceContext();
     if (serviceContext) {
+      // Insert network args before the first '-v' flag so they don't land
+      // between '-v' and its volume argument. Using indexOf is resilient to
+      // extraArgs shifting earlier positions.
+      const volumeFlagIndex = podmanArgs.indexOf('-v');
+      const insertAt =
+        volumeFlagIndex !== -1 ? volumeFlagIndex : podmanArgs.length;
       podmanArgs.splice(
-        6,
+        insertAt,
         0,
         ...getServiceNetworkArgs(serviceContext.networkName)
       );

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -30,11 +30,8 @@ import { isJsonMode } from '../context.js';
 import colors from 'ansi-colors';
 import { validateSandboxWorktreePath } from './worktree-path.js';
 import {
-  createServiceNetwork,
   getServiceNetworkArgs,
-  startServiceContainers,
   teardownServiceContainers,
-  waitForServicesReady,
 } from './service-containers.js';
 
 /**
@@ -385,62 +382,13 @@ export class PodmanSandbox extends Sandbox {
       this.options?.projectPath ?? process.cwd()
     );
     const services = projectConfig.services;
-    const existingServiceContext = this.resolveServiceContext();
-    if (services && services.length > 0 && !existingServiceContext) {
-      this.processManager?.addItem('Starting service containers...');
+    if (services && services.length > 0) {
+      this.processManager?.addItem('Ensuring service containers...');
       try {
-        const networkName = await createServiceNetwork(
-          ContainerBackend.Podman,
-          this.task.id,
-          this.task.iterations
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames: [],
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        const containerNames = await startServiceContainers(
-          ContainerBackend.Podman,
-          services,
-          networkName,
-          this.task.id,
-          this.task.iterations,
-          undefined,
-          startedContainerNames => {
-            this.serviceContext = {
-              networkName,
-              containerNames: startedContainerNames,
-              taskId: this.task.id,
-              iteration: this.task.iterations,
-            };
-          }
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames,
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        await waitForServicesReady(
-          ContainerBackend.Podman,
-          services,
-          containerNames
-        );
+        await this.ensureServiceContext(services);
         this.processManager?.completeLastItem();
       } catch (err) {
         this.processManager?.failLastItem();
-        if (this.serviceContext) {
-          try {
-            await teardownServiceContainers(
-              ContainerBackend.Podman,
-              this.serviceContext
-            );
-          } catch {
-            // Don't mask the original service startup error with cleanup failures.
-          }
-          this.serviceContext = undefined;
-        }
         this.processManager?.finish();
         throw err;
       }

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -31,10 +31,10 @@ import colors from 'ansi-colors';
 import { validateSandboxWorktreePath } from './worktree-path.js';
 import {
   createServiceNetwork,
-  startServiceContainers,
-  waitForServicesReady,
   getServiceNetworkArgs,
+  startServiceContainers,
   teardownServiceContainers,
+  waitForServicesReady,
 } from './service-containers.js';
 
 /**
@@ -540,54 +540,10 @@ export class PodmanSandbox extends Sandbox {
     let startedInteractiveServices = false;
 
     try {
-      // Start service containers for interactive mode
-      const interactiveServices = projectConfig.services;
-      const existingServiceContext = this.resolveServiceContext();
-      if (
-        interactiveServices &&
-        interactiveServices.length > 0 &&
-        !existingServiceContext
-      ) {
-        const networkName = await createServiceNetwork(
-          ContainerBackend.Podman,
-          this.task.id,
-          this.task.iterations
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames: [],
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        startedInteractiveServices = true;
-        const containerNames = await startServiceContainers(
-          ContainerBackend.Podman,
-          interactiveServices,
-          networkName,
-          this.task.id,
-          this.task.iterations,
-          undefined,
-          startedContainerNames => {
-            this.serviceContext = {
-              networkName,
-              containerNames: startedContainerNames,
-              taskId: this.task.id,
-              iteration: this.task.iterations,
-            };
-          }
-        );
-        this.serviceContext = {
-          networkName,
-          containerNames,
-          taskId: this.task.id,
-          iteration: this.task.iterations,
-        };
-        await waitForServicesReady(
-          ContainerBackend.Podman,
-          interactiveServices,
-          containerNames
-        );
-      }
+      const ensuredServiceContext = await this.ensureServiceContext(
+        projectConfig.services
+      );
+      startedInteractiveServices = ensuredServiceContext.started;
 
       const interactiveName = `${this.sandboxName}-i`;
       const podmanArgs = ['run', '--name', interactiveName, '-it', '--rm'];
@@ -845,6 +801,11 @@ export class PodmanSandbox extends Sandbox {
       '/bin/bash',
     ];
 
+    const ensuredServiceContext = await this.ensureServiceContext(
+      projectConfig.services
+    );
+    const startedShellServices = ensuredServiceContext.started;
+
     const serviceContext = this.resolveServiceContext();
     if (serviceContext) {
       podmanArgs.splice(
@@ -854,12 +815,26 @@ export class PodmanSandbox extends Sandbox {
       );
     }
 
-    // Start Podman container with direct stdio inheritance for true interactivity
-    // Use detached: false to ensure proper TTY signal handling and job control
-    return await launch('podman', podmanArgs, {
-      reject: false,
-      stdio: 'inherit', // This gives full control to the user
-      detached: false,
-    });
+    try {
+      // Start Podman container with direct stdio inheritance for true interactivity
+      // Use detached: false to ensure proper TTY signal handling and job control
+      return await launch('podman', podmanArgs, {
+        reject: false,
+        stdio: 'inherit', // This gives full control to the user
+        detached: false,
+      });
+    } finally {
+      if (startedShellServices && this.serviceContext) {
+        try {
+          await teardownServiceContainers(
+            ContainerBackend.Podman,
+            this.serviceContext
+          );
+        } catch {
+          // Shell exit status takes precedence over sidecar cleanup.
+        }
+        this.serviceContext = undefined;
+      }
+    }
   }
 }

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -401,7 +401,16 @@ export class PodmanSandbox extends Sandbox {
           services,
           networkName,
           this.task.id,
-          this.task.iterations
+          this.task.iterations,
+          undefined,
+          startedContainerNames => {
+            this.serviceContext = {
+              networkName,
+              containerNames: startedContainerNames,
+              taskId: this.task.id,
+              iteration: this.task.iterations,
+            };
+          }
         );
         this.serviceContext = {
           networkName,
@@ -547,7 +556,16 @@ export class PodmanSandbox extends Sandbox {
           interactiveServices,
           networkName,
           this.task.id,
-          this.task.iterations
+          this.task.iterations,
+          undefined,
+          startedContainerNames => {
+            this.serviceContext = {
+              networkName,
+              containerNames: startedContainerNames,
+              taskId: this.task.id,
+              iteration: this.task.iterations,
+            };
+          }
         );
         this.serviceContext = {
           networkName,

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -427,10 +427,14 @@ export class PodmanSandbox extends Sandbox {
       } catch (err) {
         this.processManager?.failLastItem();
         if (this.serviceContext) {
-          await teardownServiceContainers(
-            ContainerBackend.Podman,
-            this.serviceContext
-          );
+          try {
+            await teardownServiceContainers(
+              ContainerBackend.Podman,
+              this.serviceContext
+            );
+          } catch {
+            // Don't mask the original service startup error with cleanup failures.
+          }
           this.serviceContext = undefined;
         }
         this.processManager?.finish();
@@ -705,10 +709,14 @@ export class PodmanSandbox extends Sandbox {
       });
     } finally {
       if (startedInteractiveServices && this.serviceContext) {
-        await teardownServiceContainers(
-          ContainerBackend.Podman,
-          this.serviceContext
-        );
+        try {
+          await teardownServiceContainers(
+            ContainerBackend.Podman,
+            this.serviceContext
+          );
+        } catch {
+          // Interactive session result takes precedence over sidecar cleanup.
+        }
         this.serviceContext = undefined;
       }
     }

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -542,177 +542,198 @@ export class PodmanSandbox extends Sandbox {
       projectConfig
     );
 
-    // Start service containers for interactive mode
-    const interactiveServices = projectConfig.services;
-    if (
-      interactiveServices &&
-      interactiveServices.length > 0 &&
-      !this.serviceContext
-    ) {
-      const networkName = await createServiceNetwork(
-        ContainerBackend.Podman,
-        this.task.id,
-        this.task.iterations
-      );
-      const containerNames = await startServiceContainers(
-        ContainerBackend.Podman,
-        interactiveServices,
-        networkName,
-        this.task.id,
-        this.task.iterations
-      );
-      this.serviceContext = {
-        networkName,
-        containerNames,
-        taskId: this.task.id,
-        iteration: this.task.iterations,
-      };
-      await waitForServicesReady(
-        ContainerBackend.Podman,
-        interactiveServices,
-        containerNames
-      );
-    }
+    let startedInteractiveServices = false;
 
-    const interactiveName = `${this.sandboxName}-i`;
-    const podmanArgs = ['run', '--name', interactiveName, '-it', '--rm'];
-
-    // Attach to service network
-    if (this.serviceContext) {
-      podmanArgs.push(
-        ...getServiceNetworkArgs(this.serviceContext.networkName)
-      );
-    }
-
-    const userInfo_ = normalizeUserInfo(userInfo());
-
-    // Warn if using a custom agent image
-    warnIfCustomImage(projectConfig);
-
-    const {
-      etcPasswd,
-      etcGroup,
-      cleanup: cleanupTmpFiles,
-    } = await tmpUserGroupFiles(
-      ContainerBackend.Podman,
-      effectiveImage,
-      userInfo_
-    );
-    this._tmpCleanups.push(cleanupTmpFiles);
-
-    // Add NET_ADMIN capability if network filtering is configured
-    const effectiveNetworkConfigInteractive = mergeNetworkConfig(
-      projectConfig.network,
-      this.task.networkConfig
-    );
-    if (
-      effectiveNetworkConfigInteractive &&
-      effectiveNetworkConfigInteractive.mode !== 'allowall'
-    ) {
-      podmanArgs.push('--cap-add=NET_ADMIN');
-    }
-
-    podmanArgs.push(
-      '-v',
-      `${etcPasswd}:/etc/passwd:Z,ro`,
-      '-v',
-      `${etcGroup}:/etc/group:Z,ro`,
-      '--user',
-      `${userInfo_.uid}:${userInfo_.gid}`,
-      '-v',
-      `${worktreePath}:/workspace:Z,rw`,
-      ...getWorktreeGitMounts(worktreePath),
-      '-v',
-      `${iteration.iterationPath}:/output:Z,rw`,
-      ...containerMounts,
-      '-v',
-      `${entrypointScriptPath}:/entrypoint.sh:Z,ro`
-    );
-
-    // Mount context directory if available (read-only)
-    const contextDir = join(iteration.iterationPath, 'context');
-    const hasContext = existsSync(contextDir);
-    if (hasContext) {
-      podmanArgs.push('-v', `${contextDir}:/context:Z,ro`);
-    }
-
-    // Mount init scripts (root + per-project)
-    const allInitScripts = projectConfig.allInitScripts;
-    for (let i = 0; i < allInitScripts.length; i++) {
-      const entry = allInitScripts[i];
-      if (entry.path) {
-        continue;
+    try {
+      // Start service containers for interactive mode
+      const interactiveServices = projectConfig.services;
+      if (
+        interactiveServices &&
+        interactiveServices.length > 0 &&
+        !this.serviceContext
+      ) {
+        const networkName = await createServiceNetwork(
+          ContainerBackend.Podman,
+          this.task.id,
+          this.task.iterations
+        );
+        this.serviceContext = {
+          networkName,
+          containerNames: [],
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
+        startedInteractiveServices = true;
+        const containerNames = await startServiceContainers(
+          ContainerBackend.Podman,
+          interactiveServices,
+          networkName,
+          this.task.id,
+          this.task.iterations
+        );
+        this.serviceContext = {
+          networkName,
+          containerNames,
+          taskId: this.task.id,
+          iteration: this.task.iterations,
+        };
+        await waitForServicesReady(
+          ContainerBackend.Podman,
+          interactiveServices,
+          containerNames
+        );
       }
-      const initScriptAbsPath = resolveInitScriptPath(
-        projectConfig.projectRoot,
-        entry.script,
-        entry.path
-      );
-      if (existsSync(initScriptAbsPath)) {
-        const mountPath =
-          allInitScripts.length === 1 && !entry.path
-            ? '/init-script.sh'
-            : `/init-script-${i}.sh`;
-        podmanArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
-      }
-    }
 
-    // Mount workspace description if projects are configured
-    const workspaceDescPath = setupBuilder.generateWorkspaceDescription();
-    if (workspaceDescPath) {
+      const interactiveName = `${this.sandboxName}-i`;
+      const podmanArgs = ['run', '--name', interactiveName, '-it', '--rm'];
+
+      // Attach to service network
+      if (this.serviceContext) {
+        podmanArgs.push(
+          ...getServiceNetworkArgs(this.serviceContext.networkName)
+        );
+      }
+
+      const userInfo_ = normalizeUserInfo(userInfo());
+
+      // Warn if using a custom agent image
+      warnIfCustomImage(projectConfig);
+
+      const {
+        etcPasswd,
+        etcGroup,
+        cleanup: cleanupTmpFiles,
+      } = await tmpUserGroupFiles(
+        ContainerBackend.Podman,
+        effectiveImage,
+        userInfo_
+      );
+      this._tmpCleanups.push(cleanupTmpFiles);
+
+      // Add NET_ADMIN capability if network filtering is configured
+      const effectiveNetworkConfigInteractive = mergeNetworkConfig(
+        projectConfig.network,
+        this.task.networkConfig
+      );
+      if (
+        effectiveNetworkConfigInteractive &&
+        effectiveNetworkConfigInteractive.mode !== 'allowall'
+      ) {
+        podmanArgs.push('--cap-add=NET_ADMIN');
+      }
+
       podmanArgs.push(
         '-v',
-        `${workspaceDescPath}:/workspace/.rover-workspace.json:Z,ro`
+        `${etcPasswd}:/etc/passwd:Z,ro`,
+        '-v',
+        `${etcGroup}:/etc/group:Z,ro`,
+        '--user',
+        `${userInfo_.uid}:${userInfo_.gid}`,
+        '-v',
+        `${worktreePath}:/workspace:Z,rw`,
+        ...getWorktreeGitMounts(worktreePath),
+        '-v',
+        `${iteration.iterationPath}:/output:Z,rw`,
+        ...containerMounts,
+        '-v',
+        `${entrypointScriptPath}:/entrypoint.sh:Z,ro`
       );
+
+      // Mount context directory if available (read-only)
+      const contextDir = join(iteration.iterationPath, 'context');
+      const hasContext = existsSync(contextDir);
+      if (hasContext) {
+        podmanArgs.push('-v', `${contextDir}:/context:Z,ro`);
+      }
+
+      // Mount init scripts (root + per-project)
+      const allInitScripts = projectConfig.allInitScripts;
+      for (let i = 0; i < allInitScripts.length; i++) {
+        const entry = allInitScripts[i];
+        if (entry.path) {
+          continue;
+        }
+        const initScriptAbsPath = resolveInitScriptPath(
+          projectConfig.projectRoot,
+          entry.script,
+          entry.path
+        );
+        if (existsSync(initScriptAbsPath)) {
+          const mountPath =
+            allInitScripts.length === 1 && !entry.path
+              ? '/init-script.sh'
+              : `/init-script-${i}.sh`;
+          podmanArgs.push('-v', `${initScriptAbsPath}:${mountPath}:Z,ro`);
+        }
+      }
+
+      // Mount workspace description if projects are configured
+      const workspaceDescPath = setupBuilder.generateWorkspaceDescription();
+      if (workspaceDescPath) {
+        podmanArgs.push(
+          '-v',
+          `${workspaceDescPath}:/workspace/.rover-workspace.json:Z,ro`
+        );
+      }
+
+      // Mount download cache volumes for interactive mode too
+      ensureDownloadCacheVolumes(ContainerBackend.Podman, projectConfig);
+      podmanArgs.push(...getDownloadCacheMounts(projectConfig));
+
+      // Get extra args from CLI options and project config, merge them
+      const configExtraArgs = normalizeExtraArgs(
+        projectConfig.sandboxExtraArgs
+      );
+      const cliExtraArgs = normalizeExtraArgs(this.options?.extraArgs);
+      const extraArgs = [...configExtraArgs, ...cliExtraArgs];
+
+      podmanArgs.push(
+        ...envVariables,
+        '-w',
+        '/workspace',
+        '--entrypoint',
+        '/entrypoint.sh',
+        ...extraArgs,
+        effectiveImage,
+        'rover-agent',
+        'session',
+        this.task.agent!
+      );
+
+      if (initialPrompt) {
+        podmanArgs.push(initialPrompt);
+      }
+
+      // Pass context directory argument if context was mounted
+      if (hasContext) {
+        podmanArgs.push('--context-dir', '/context');
+      }
+
+      // Pass model if specified
+      if (this.task.agentModel) {
+        podmanArgs.push('--agent-model', this.task.agentModel);
+      }
+
+      // Forward verbose flag to rover-agent if enabled
+      if (VERBOSE) {
+        podmanArgs.push('-v');
+      }
+
+      // Use detached: false to ensure proper TTY signal handling and job control
+      return await launch('podman', podmanArgs, {
+        stdio: 'inherit',
+        reject: false,
+        detached: false,
+      });
+    } finally {
+      if (startedInteractiveServices && this.serviceContext) {
+        await teardownServiceContainers(
+          ContainerBackend.Podman,
+          this.serviceContext
+        );
+        this.serviceContext = undefined;
+      }
     }
-
-    // Mount download cache volumes for interactive mode too
-    ensureDownloadCacheVolumes(ContainerBackend.Podman, projectConfig);
-    podmanArgs.push(...getDownloadCacheMounts(projectConfig));
-
-    // Get extra args from CLI options and project config, merge them
-    const configExtraArgs = normalizeExtraArgs(projectConfig.sandboxExtraArgs);
-    const cliExtraArgs = normalizeExtraArgs(this.options?.extraArgs);
-    const extraArgs = [...configExtraArgs, ...cliExtraArgs];
-
-    podmanArgs.push(
-      ...envVariables,
-      '-w',
-      '/workspace',
-      '--entrypoint',
-      '/entrypoint.sh',
-      ...extraArgs,
-      effectiveImage,
-      'rover-agent',
-      'session',
-      this.task.agent!
-    );
-
-    if (initialPrompt) {
-      podmanArgs.push(initialPrompt);
-    }
-
-    // Pass context directory argument if context was mounted
-    if (hasContext) {
-      podmanArgs.push('--context-dir', '/context');
-    }
-
-    // Pass model if specified
-    if (this.task.agentModel) {
-      podmanArgs.push('--agent-model', this.task.agentModel);
-    }
-
-    // Forward verbose flag to rover-agent if enabled
-    if (VERBOSE) {
-      podmanArgs.push('-v');
-    }
-
-    // Use detached: false to ensure proper TTY signal handling and job control
-    return launch('podman', podmanArgs, {
-      stdio: 'inherit',
-      reject: false,
-      detached: false,
-    });
   }
 
   async inspect(): Promise<{ status: string; exitCode?: number } | null> {

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -213,6 +213,9 @@ export class PodmanSandbox extends Sandbox {
     const allInitScripts = projectConfig.allInitScripts;
     for (let i = 0; i < allInitScripts.length; i++) {
       const entry = allInitScripts[i];
+      if (entry.path) {
+        continue;
+      }
       const initScriptAbsPath = resolveInitScriptPath(
         projectConfig.projectRoot,
         entry.script,
@@ -521,6 +524,9 @@ export class PodmanSandbox extends Sandbox {
     const allInitScripts = projectConfig.allInitScripts;
     for (let i = 0; i < allInitScripts.length; i++) {
       const entry = allInitScripts[i];
+      if (entry.path) {
+        continue;
+      }
       const initScriptAbsPath = resolveInitScriptPath(
         projectConfig.projectRoot,
         entry.script,

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -65,6 +65,10 @@ export class PodmanSandbox extends Sandbox {
     this._tmpCleanups = [];
   }
 
+  private shouldTeardownServicesForStatus(status: string): boolean {
+    return status === 'exited' || status === 'dead' || status === 'removing';
+  }
+
   constructor(
     task: TaskDescriptionManager,
     processManager?: ProcessManager,
@@ -746,7 +750,7 @@ export class PodmanSandbox extends Sandbox {
         status,
         exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
       };
-      if (status !== 'running') {
+      if (this.shouldTeardownServicesForStatus(status)) {
         await this.teardownServicesIfConfigured();
       }
 

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -845,6 +845,15 @@ export class PodmanSandbox extends Sandbox {
       '/bin/bash',
     ];
 
+    const serviceContext = this.resolveServiceContext();
+    if (serviceContext) {
+      podmanArgs.splice(
+        6,
+        0,
+        ...getServiceNetworkArgs(serviceContext.networkName)
+      );
+    }
+
     // Start Podman container with direct stdio inheritance for true interactivity
     // Use detached: false to ensure proper TTY signal handling and job control
     await launch('podman', podmanArgs, {

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -731,9 +731,19 @@ export class PodmanSandbox extends Sandbox {
       if (!output) return null;
       const [status, exitCodeStr] = output.split('|');
       const exitCode = exitCodeStr ? parseInt(exitCodeStr, 10) : undefined;
-      return status
-        ? { status, exitCode: Number.isNaN(exitCode) ? undefined : exitCode }
-        : null;
+      if (!status) {
+        return null;
+      }
+
+      const containerState = {
+        status,
+        exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
+      };
+      if (status !== 'running') {
+        await this.teardownServicesIfConfigured();
+      }
+
+      return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {
         return null;

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -156,11 +156,10 @@ export class PodmanSandbox extends Sandbox {
 
     const podmanArgs = ['create', '--name', this.sandboxName];
 
-    // Attach to the service network if services are running
-    if (this.serviceContext) {
-      podmanArgs.push(
-        ...getServiceNetworkArgs(this.serviceContext.networkName)
-      );
+    // Attach to the persisted or newly created service network when sidecars exist.
+    const serviceContext = this.resolveServiceContext();
+    if (serviceContext) {
+      podmanArgs.push(...getServiceNetworkArgs(serviceContext.networkName));
     }
 
     const userInfo_ = normalizeUserInfo(userInfo());
@@ -386,7 +385,8 @@ export class PodmanSandbox extends Sandbox {
       this.options?.projectPath ?? process.cwd()
     );
     const services = projectConfig.services;
-    if (services && services.length > 0) {
+    const existingServiceContext = this.resolveServiceContext();
+    if (services && services.length > 0 && !existingServiceContext) {
       this.processManager?.addItem('Starting service containers...');
       try {
         const networkName = await createServiceNetwork(
@@ -812,7 +812,7 @@ export class PodmanSandbox extends Sandbox {
     }
   }
 
-  async openShellAtWorktree(): Promise<void> {
+  async openShellAtWorktree(): Promise<{ exitCode?: number }> {
     // Check if worktree exists
     if (!this.task.worktreePath || !existsSync(this.task.worktreePath)) {
       throw new Error('No worktree found for this task');
@@ -856,7 +856,7 @@ export class PodmanSandbox extends Sandbox {
 
     // Start Podman container with direct stdio inheritance for true interactivity
     // Use detached: false to ensure proper TTY signal handling and job control
-    await launch('podman', podmanArgs, {
+    return await launch('podman', podmanArgs, {
       reject: false,
       stdio: 'inherit', // This gives full control to the user
       detached: false,

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -1,7 +1,7 @@
 import { getAIAgentTool } from '../agents/index.js';
 import { join } from 'node:path';
 import { ProjectConfigManager, TaskDescriptionManager } from 'rover-core';
-import { Sandbox, SandboxOptions } from './types.js';
+import { Sandbox, SandboxInspectOptions, SandboxOptions } from './types.js';
 import { SetupBuilder } from '../setup.js';
 import { generateRandomId, launch, ProcessManager, VERBOSE } from 'rover-core';
 import { existsSync, mkdirSync } from 'node:fs';
@@ -650,7 +650,10 @@ export class PodmanSandbox extends Sandbox {
     }
   }
 
-  async inspect(): Promise<{ status: string; exitCode?: number } | null> {
+  async inspect(
+    options?: SandboxInspectOptions
+  ): Promise<{ status: string; exitCode?: number } | null> {
+    const shouldTeardownServices = options?.teardownServices !== false;
     try {
       const result = await launch(
         'podman',
@@ -674,14 +677,19 @@ export class PodmanSandbox extends Sandbox {
         status,
         exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
       };
-      if (this.shouldTeardownServicesForStatus(status)) {
+      if (
+        shouldTeardownServices &&
+        this.shouldTeardownServicesForStatus(status)
+      ) {
         await this.teardownServicesIfConfigured();
       }
 
       return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {
-        await this.teardownServicesIfConfigured();
+        if (shouldTeardownServices) {
+          await this.teardownServicesIfConfigured();
+        }
         return null;
       }
       throw error;

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -62,10 +62,6 @@ export class PodmanSandbox extends Sandbox {
     this._tmpCleanups = [];
   }
 
-  private shouldTeardownServicesForStatus(status: string): boolean {
-    return status === 'exited' || status === 'dead' || status === 'removing';
-  }
-
   constructor(
     task: TaskDescriptionManager,
     processManager?: ProcessManager,
@@ -677,13 +673,6 @@ export class PodmanSandbox extends Sandbox {
         status,
         exitCode: Number.isNaN(exitCode) ? undefined : exitCode,
       };
-      if (
-        shouldTeardownServices &&
-        this.shouldTeardownServicesForStatus(status)
-      ) {
-        await this.teardownServicesIfConfigured();
-      }
-
       return containerState;
     } catch (error) {
       if (isContainerMissingInspectError(error)) {

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -16,6 +16,7 @@ export interface ServiceContainerContext {
   containerNames: string[];
   taskId: number;
   iteration: number;
+  serviceConfigHash?: string;
 }
 
 function serviceContainerName(

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -208,6 +208,7 @@ export async function waitForServicesReady(
       );
     }
 
+    let healthy = false;
     while (Date.now() < deadline) {
       try {
         const result = await launch(
@@ -221,6 +222,7 @@ export async function waitForServicesReady(
           if (VERBOSE) {
             console.error(`[rover] service ${service.name} is healthy`);
           }
+          healthy = true;
           break;
         }
 
@@ -240,7 +242,7 @@ export async function waitForServicesReady(
       await sleep(2000);
     }
 
-    if (Date.now() >= deadline) {
+    if (!healthy) {
       throw new Error(
         `Service "${service.name}" did not become healthy within ${service.readyTimeout}s`
       );

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -6,8 +6,8 @@
  * the task finishes.  Backend-agnostic: accepts a ContainerBackend parameter
  * so the same functions work for both Docker and Podman.
  */
-
 import { launch, VERBOSE } from 'rover-core';
+import { parseCommandString } from 'execa';
 import type { ServiceContainer } from 'rover-schemas';
 import { ContainerBackend } from './container-common.js';
 
@@ -130,7 +130,7 @@ export async function startServiceContainers(
       if (Array.isArray(service.command)) {
         args.push(...service.command);
       } else {
-        args.push(service.command);
+        args.push(...parseCommandString(service.command));
       }
     }
 

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -168,8 +168,8 @@ export async function startServiceContainers(
     }
 
     await launch(backend, args, opts);
-    await launch(backend, ['start', name], opts);
     onContainerStarted?.([...containerNames]);
+    await launch(backend, ['start', name], opts);
   }
 
   return containerNames;

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -94,6 +94,38 @@ export async function createServiceNetwork(
   return networkName;
 }
 
+export async function hasAnyServiceContainerResources(
+  backend: ContainerBackend,
+  context: ServiceContainerContext,
+  env?: NodeJS.ProcessEnv
+): Promise<boolean> {
+  const opts = env
+    ? { env, reject: false as const }
+    : { reject: false as const };
+
+  const networkInspect = await launch(
+    backend,
+    ['network', 'inspect', context.networkName],
+    opts
+  );
+  if (networkInspect.exitCode === 0) {
+    return true;
+  }
+
+  for (const name of context.containerNames) {
+    const containerInspect = await launch(
+      backend,
+      ['inspect', '--format', '{{.Id}}', name],
+      opts
+    );
+    if (containerInspect.exitCode === 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Start services
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -1,0 +1,261 @@
+/**
+ * Per-task service container (sidecar) lifecycle management.
+ *
+ * Creates an isolated Docker/Podman network for each task, starts configured
+ * service containers on it, waits for health, and tears everything down when
+ * the task finishes.  Backend-agnostic: accepts a ContainerBackend parameter
+ * so the same functions work for both Docker and Podman.
+ */
+
+import { launch, VERBOSE } from 'rover-core';
+import type { ServiceContainer } from 'rover-schemas';
+import { ContainerBackend } from './container-common.js';
+
+export interface ServiceContainerContext {
+  networkName: string;
+  containerNames: string[];
+  taskId: number;
+  iteration: number;
+}
+
+function serviceContainerName(
+  taskId: number,
+  iteration: number,
+  serviceName: string
+): string {
+  return `rover-svc-${taskId}-${iteration}-${serviceName}`;
+}
+
+function serviceNetworkName(taskId: number, iteration: number): string {
+  return `rover-services-${taskId}-${iteration}`;
+}
+
+export function buildServiceContainerContext(
+  services: Pick<ServiceContainer, 'name'>[],
+  taskId: number,
+  iteration: number
+): ServiceContainerContext {
+  return {
+    networkName: serviceNetworkName(taskId, iteration),
+    containerNames: services.map(service =>
+      serviceContainerName(taskId, iteration, service.name)
+    ),
+    taskId,
+    iteration,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Network
+// ---------------------------------------------------------------------------
+
+export async function createServiceNetwork(
+  backend: ContainerBackend,
+  taskId: number,
+  iteration: number,
+  env?: NodeJS.ProcessEnv
+): Promise<string> {
+  const networkName = serviceNetworkName(taskId, iteration);
+  const opts = env ? { env } : undefined;
+
+  if (VERBOSE) {
+    console.error(`[rover] creating service network ${networkName}`);
+  }
+
+  await launch(backend, ['network', 'create', networkName], opts);
+  return networkName;
+}
+
+// ---------------------------------------------------------------------------
+// Start services
+// ---------------------------------------------------------------------------
+
+export async function startServiceContainers(
+  backend: ContainerBackend,
+  services: ServiceContainer[],
+  networkName: string,
+  taskId: number,
+  iteration: number,
+  env?: NodeJS.ProcessEnv
+): Promise<string[]> {
+  const opts = env ? { env } : undefined;
+  const containerNames: string[] = [];
+
+  for (const service of services) {
+    const name = serviceContainerName(taskId, iteration, service.name);
+    containerNames.push(name);
+
+    const args: string[] = [
+      'create',
+      '--name',
+      name,
+      '--network',
+      networkName,
+      '--network-alias',
+      service.name,
+    ];
+
+    // Environment variables
+    for (const envVar of service.env ?? []) {
+      args.push('-e', envVar);
+    }
+
+    // Volume mounts
+    for (const vol of service.volumes ?? []) {
+      args.push('-v', vol);
+    }
+
+    // Healthcheck
+    if (service.healthcheck) {
+      const hc = service.healthcheck;
+      args.push(
+        '--health-cmd',
+        hc.cmd,
+        '--health-interval',
+        `${hc.interval}s`,
+        '--health-timeout',
+        `${hc.timeout}s`,
+        '--health-retries',
+        `${hc.retries}`,
+        '--health-start-period',
+        `${hc.startPeriod}s`
+      );
+    }
+
+    // Image
+    args.push(service.image);
+
+    // Command override
+    if (service.command) {
+      if (Array.isArray(service.command)) {
+        args.push(...service.command);
+      } else {
+        args.push(service.command);
+      }
+    }
+
+    if (VERBOSE) {
+      console.error(`[rover] creating service container ${name}`);
+    }
+
+    await launch(backend, args, opts);
+    await launch(backend, ['start', name], opts);
+  }
+
+  return containerNames;
+}
+
+// ---------------------------------------------------------------------------
+// Health polling
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function waitForServicesReady(
+  backend: ContainerBackend,
+  services: ServiceContainer[],
+  containerNames: string[],
+  env?: NodeJS.ProcessEnv
+): Promise<void> {
+  const opts = env ? { env } : undefined;
+
+  for (let i = 0; i < services.length; i++) {
+    const service = services[i];
+    const containerName = containerNames[i];
+
+    // Services without a healthcheck are assumed ready immediately
+    if (!service.healthcheck) {
+      continue;
+    }
+
+    const deadline = Date.now() + service.readyTimeout * 1000;
+
+    if (VERBOSE) {
+      console.error(
+        `[rover] waiting for service ${service.name} to become healthy (timeout: ${service.readyTimeout}s)`
+      );
+    }
+
+    while (Date.now() < deadline) {
+      try {
+        const result = await launch(
+          backend,
+          ['inspect', '--format', '{{.State.Health.Status}}', containerName],
+          opts
+        );
+        const status = result.stdout?.toString().trim();
+
+        if (status === 'healthy') {
+          if (VERBOSE) {
+            console.error(`[rover] service ${service.name} is healthy`);
+          }
+          break;
+        }
+
+        if (status === 'unhealthy') {
+          throw new Error(`Service "${service.name}" reported unhealthy`);
+        }
+      } catch (error: unknown) {
+        if (
+          error instanceof Error &&
+          error.message.includes('reported unhealthy')
+        ) {
+          throw error;
+        }
+        // inspect may fail if container is still starting — retry
+      }
+
+      await sleep(2000);
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Service "${service.name}" did not become healthy within ${service.readyTimeout}s`
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Network args for the task container
+// ---------------------------------------------------------------------------
+
+export function getServiceNetworkArgs(networkName: string): string[] {
+  return ['--network', networkName];
+}
+
+// ---------------------------------------------------------------------------
+// Teardown
+// ---------------------------------------------------------------------------
+
+export async function teardownServiceContainers(
+  backend: ContainerBackend,
+  context: ServiceContainerContext,
+  env?: NodeJS.ProcessEnv
+): Promise<void> {
+  const opts = env ? { env } : undefined;
+
+  // Remove service containers (best-effort)
+  for (const name of context.containerNames) {
+    try {
+      await launch(backend, ['rm', '-f', name], opts);
+    } catch {
+      if (VERBOSE) {
+        console.error(`[rover] failed to remove service container ${name}`);
+      }
+    }
+  }
+
+  // Remove the network (best-effort)
+  try {
+    await launch(backend, ['network', 'rm', context.networkName], opts);
+  } catch {
+    if (VERBOSE) {
+      console.error(
+        `[rover] failed to remove service network ${context.networkName}`
+      );
+    }
+  }
+}

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -200,7 +200,10 @@ export async function waitForServicesReady(
       continue;
     }
 
-    const deadline = Date.now() + service.readyTimeout * 1000;
+    const timeout = Number.isFinite(service.readyTimeout)
+      ? service.readyTimeout
+      : 30;
+    const deadline = Date.now() + timeout * 1000;
 
     if (VERBOSE) {
       console.error(

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -76,7 +76,8 @@ export async function startServiceContainers(
   networkName: string,
   taskId: number,
   iteration: number,
-  env?: NodeJS.ProcessEnv
+  env?: NodeJS.ProcessEnv,
+  onContainerStarted?: (containerNames: string[]) => void
 ): Promise<string[]> {
   const opts = env ? { env } : undefined;
   const containerNames: string[] = [];
@@ -140,6 +141,7 @@ export async function startServiceContainers(
 
     await launch(backend, args, opts);
     await launch(backend, ['start', name], opts);
+    onContainerStarted?.([...containerNames]);
   }
 
   return containerNames;

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -256,6 +256,34 @@ export function getServiceNetworkArgs(networkName: string): string[] {
   return ['--network', networkName];
 }
 
+export async function isServiceContainerContextAvailable(
+  backend: ContainerBackend,
+  context: ServiceContainerContext,
+  env?: NodeJS.ProcessEnv
+): Promise<boolean> {
+  const opts = env
+    ? { env, reject: false as const }
+    : { reject: false as const };
+
+  const networkInspect = await launch(
+    backend,
+    ['network', 'inspect', context.networkName],
+    opts
+  );
+  if (networkInspect.exitCode !== 0) {
+    return false;
+  }
+
+  for (const name of context.containerNames) {
+    const containerInspect = await launch(backend, ['inspect', name], opts);
+    if (containerInspect.exitCode !== 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Teardown
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -57,12 +57,40 @@ export async function createServiceNetwork(
 ): Promise<string> {
   const networkName = serviceNetworkName(taskId, iteration);
   const opts = env ? { env } : undefined;
+  const inspectOpts = opts
+    ? { ...opts, reject: false as const }
+    : { reject: false as const };
 
   if (VERBOSE) {
     console.error(`[rover] creating service network ${networkName}`);
   }
 
-  await launch(backend, ['network', 'create', networkName], opts);
+  const inspectResult = await launch(
+    backend,
+    ['network', 'inspect', networkName],
+    inspectOpts
+  );
+  if (inspectResult.exitCode === 0) {
+    if (VERBOSE) {
+      console.error(`[rover] reusing existing service network ${networkName}`);
+    }
+    return networkName;
+  }
+
+  try {
+    await launch(backend, ['network', 'create', networkName], opts);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.toLowerCase().includes('already exists')) {
+      if (VERBOSE) {
+        console.error(
+          `[rover] service network ${networkName} was created concurrently; reusing it`
+        );
+      }
+      return networkName;
+    }
+    throw error;
+  }
   return networkName;
 }
 

--- a/packages/cli/src/lib/sandbox/service-containers.ts
+++ b/packages/cli/src/lib/sandbox/service-containers.ts
@@ -275,8 +275,34 @@ export async function isServiceContainerContextAvailable(
   }
 
   for (const name of context.containerNames) {
-    const containerInspect = await launch(backend, ['inspect', name], opts);
+    const containerInspect = await launch(
+      backend,
+      ['inspect', '--format', '{{json .State}}', name],
+      opts
+    );
     if (containerInspect.exitCode !== 0) {
+      return false;
+    }
+
+    try {
+      const state = JSON.parse(String(containerInspect.stdout ?? '')) as {
+        Running?: boolean;
+        Status?: string;
+        Health?: { Status?: string };
+      };
+
+      if (state.Running !== true) {
+        return false;
+      }
+
+      const healthStatus = state.Health?.Status;
+      if (
+        typeof healthStatus === 'string' &&
+        !['healthy', 'none'].includes(healthStatus)
+      ) {
+        return false;
+      }
+    } catch {
       return false;
     }
   }

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -59,7 +59,7 @@ export abstract class Sandbox {
   }
 
   abstract isBackendAvailable(): Promise<boolean>;
-  abstract openShellAtWorktree(): Promise<void>;
+  abstract openShellAtWorktree(): Promise<{ exitCode?: number }>;
   abstract inspect(): Promise<{ status: string; exitCode?: number } | null>;
 
   protected abstract create(): Promise<string>;

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -114,6 +114,20 @@ export abstract class Sandbox {
     return undefined;
   }
 
+  protected async teardownServicesIfConfigured(): Promise<void> {
+    const serviceContext = this.resolveServiceContext();
+    if (!serviceContext) {
+      return;
+    }
+
+    await teardownServiceContainers(
+      this.getContainerBackend(),
+      serviceContext,
+      this.getServiceEnvironment()
+    );
+    this.serviceContext = undefined;
+  }
+
   async createAndStart(): Promise<string> {
     let sandboxId = '';
     this.processManager?.addItem(
@@ -156,15 +170,7 @@ export abstract class Sandbox {
     }
 
     // Tear down service containers when the task is paused/stopped
-    const serviceContext = this.resolveServiceContext();
-    if (serviceContext) {
-      await teardownServiceContainers(
-        this.getContainerBackend(),
-        serviceContext,
-        this.getServiceEnvironment()
-      );
-      this.serviceContext = undefined;
-    }
+    await this.teardownServicesIfConfigured();
 
     return sandboxId;
   }
@@ -197,15 +203,7 @@ export abstract class Sandbox {
     }
 
     // Tear down service containers and network after the task container is gone
-    const serviceContext = this.resolveServiceContext();
-    if (serviceContext) {
-      await teardownServiceContainers(
-        this.getContainerBackend(),
-        serviceContext,
-        this.getServiceEnvironment()
-      );
-      this.serviceContext = undefined;
-    }
+    await this.teardownServicesIfConfigured();
 
     return sandboxId;
   }

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -11,10 +11,11 @@ import {
 import { AIAgentTool } from '../agents/index.js';
 import { ContainerBackend } from './container-common.js';
 import {
-  buildServiceContainerContext,
   type ServiceContainerContext,
   teardownServiceContainers,
 } from './service-containers.js';
+
+const SERVICE_CONTEXT_METADATA_KEY = 'serviceContext';
 
 export interface SandboxOptions {
   /** Extra arguments to pass to Docker/Podman from CLI */
@@ -75,28 +76,41 @@ export abstract class Sandbox {
     return `rover-task-${this.task.id}-${this.task.iterations}`;
   }
 
+  private getPersistedServiceContext(): ServiceContainerContext | undefined {
+    const persisted =
+      this.options?.sandboxMetadata?.[SERVICE_CONTEXT_METADATA_KEY];
+    const record =
+      persisted && typeof persisted === 'object'
+        ? (persisted as Record<string, unknown>)
+        : undefined;
+
+    if (
+      record &&
+      typeof record.networkName === 'string' &&
+      Array.isArray(record.containerNames) &&
+      record.containerNames.every(
+        (name: unknown) => typeof name === 'string'
+      ) &&
+      typeof record.taskId === 'number' &&
+      typeof record.iteration === 'number'
+    ) {
+      return {
+        networkName: record.networkName,
+        containerNames: [...record.containerNames],
+        taskId: record.taskId,
+        iteration: record.iteration,
+      };
+    }
+
+    return undefined;
+  }
+
   protected resolveServiceContext(): ServiceContainerContext | undefined {
     if (this.serviceContext) {
       return this.serviceContext;
     }
 
-    try {
-      const projectConfig = ProjectConfigManager.load(
-        this.options?.projectPath ?? process.cwd()
-      );
-      const services = projectConfig.services;
-      if (!services || services.length === 0) {
-        return undefined;
-      }
-
-      return buildServiceContainerContext(
-        services,
-        this.task.id,
-        this.task.iterations
-      );
-    } catch {
-      return undefined;
-    }
+    return this.getPersistedServiceContext();
   }
 
   protected getContainerBackend(): ContainerBackend {
@@ -126,6 +140,30 @@ export abstract class Sandbox {
       this.getServiceEnvironment()
     );
     this.serviceContext = undefined;
+  }
+
+  getSandboxMetadata(): Record<string, unknown> | undefined {
+    const metadata = this.options?.sandboxMetadata
+      ? { ...this.options.sandboxMetadata }
+      : {};
+    if (
+      typeof metadata.dockerHost !== 'string' &&
+      typeof process.env.DOCKER_HOST === 'string'
+    ) {
+      metadata.dockerHost = process.env.DOCKER_HOST;
+    }
+
+    const serviceContext = this.resolveServiceContext();
+    if (serviceContext) {
+      metadata[SERVICE_CONTEXT_METADATA_KEY] = {
+        networkName: serviceContext.networkName,
+        containerNames: [...serviceContext.containerNames],
+        taskId: serviceContext.taskId,
+        iteration: serviceContext.iteration,
+      };
+    }
+
+    return Object.keys(metadata).length > 0 ? metadata : undefined;
   }
 
   async createAndStart(): Promise<string> {

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -73,9 +73,9 @@ export interface SandboxOptions {
 
 export interface SandboxInspectOptions {
   /**
-   * Whether inspecting a stopped or missing task container should also tear
-   * down persisted sidecars. Pause/resume flows disable this so service state
-   * survives until an explicit stop/remove path cleans it up.
+   * Whether inspecting a missing task container should also tear down
+   * persisted sidecars. Exited containers keep their service state until an
+   * explicit stop/remove path confirms the task container is gone.
    */
   teardownServices?: boolean;
 }

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -11,9 +11,14 @@ import {
 import { AIAgentTool } from '../agents/index.js';
 import { ContainerBackend } from './container-common.js';
 import {
+  createServiceNetwork,
+  isServiceContainerContextAvailable,
+  startServiceContainers,
   type ServiceContainerContext,
   teardownServiceContainers,
+  waitForServicesReady,
 } from './service-containers.js';
+import type { ServiceContainer } from 'rover-schemas';
 
 const SERVICE_CONTEXT_METADATA_KEY = 'serviceContext';
 
@@ -150,6 +155,98 @@ export abstract class Sandbox {
     );
     this.serviceContext = undefined;
     this.servicesTornDown = true;
+  }
+
+  protected async ensureServiceContext(
+    services: ServiceContainer[] | undefined
+  ): Promise<{ started: boolean; serviceContext?: ServiceContainerContext }> {
+    if (!services || services.length === 0) {
+      return {
+        started: false,
+        serviceContext: this.resolveServiceContext(),
+      };
+    }
+
+    const env = this.getServiceEnvironment();
+    const existingServiceContext = this.resolveServiceContext();
+    if (existingServiceContext) {
+      const isAvailable = await isServiceContainerContextAvailable(
+        this.getContainerBackend(),
+        existingServiceContext,
+        env
+      );
+      if (isAvailable) {
+        return {
+          started: false,
+          serviceContext: existingServiceContext,
+        };
+      }
+
+      await teardownServiceContainers(
+        this.getContainerBackend(),
+        existingServiceContext,
+        env
+      );
+      this.serviceContext = undefined;
+    }
+
+    const networkName = await createServiceNetwork(
+      this.getContainerBackend(),
+      this.task.id,
+      this.task.iterations,
+      env
+    );
+    this.serviceContext = {
+      networkName,
+      containerNames: [],
+      taskId: this.task.id,
+      iteration: this.task.iterations,
+    };
+
+    try {
+      const containerNames = await startServiceContainers(
+        this.getContainerBackend(),
+        services,
+        networkName,
+        this.task.id,
+        this.task.iterations,
+        env,
+        startedContainerNames => {
+          this.serviceContext = {
+            networkName,
+            containerNames: startedContainerNames,
+            taskId: this.task.id,
+            iteration: this.task.iterations,
+          };
+        }
+      );
+      this.serviceContext = {
+        networkName,
+        containerNames,
+        taskId: this.task.id,
+        iteration: this.task.iterations,
+      };
+      await waitForServicesReady(
+        this.getContainerBackend(),
+        services,
+        containerNames,
+        env
+      );
+      return {
+        started: true,
+        serviceContext: this.serviceContext,
+      };
+    } catch (error) {
+      if (this.serviceContext) {
+        await teardownServiceContainers(
+          this.getContainerBackend(),
+          this.serviceContext,
+          env
+        );
+      }
+      this.serviceContext = undefined;
+      throw error;
+    }
   }
 
   async teardownServices(): Promise<void> {

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -105,6 +105,15 @@ export abstract class Sandbox {
       : ContainerBackend.Podman;
   }
 
+  protected getServiceEnvironment(): NodeJS.ProcessEnv | undefined {
+    const dockerHost = this.options?.sandboxMetadata?.dockerHost;
+    if (typeof dockerHost === 'string') {
+      return { ...process.env, DOCKER_HOST: dockerHost };
+    }
+
+    return undefined;
+  }
+
   async createAndStart(): Promise<string> {
     let sandboxId = '';
     this.processManager?.addItem(
@@ -151,7 +160,8 @@ export abstract class Sandbox {
     if (serviceContext) {
       await teardownServiceContainers(
         this.getContainerBackend(),
-        serviceContext
+        serviceContext,
+        this.getServiceEnvironment()
       );
       this.serviceContext = undefined;
     }
@@ -191,7 +201,8 @@ export abstract class Sandbox {
     if (serviceContext) {
       await teardownServiceContainers(
         this.getContainerBackend(),
-        serviceContext
+        serviceContext,
+        this.getServiceEnvironment()
       );
       this.serviceContext = undefined;
     }

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -211,11 +211,13 @@ export abstract class Sandbox {
    */
   async stopGracefully(): Promise<string> {
     let sandboxId = '';
+    let stopped = false;
     this.processManager?.addItem(
       `Stopping sandbox (${this.backend}) | Name: ${this.sandboxName}`
     );
     try {
       sandboxId = await this.stop();
+      stopped = true;
       this.processManager?.completeLastItem();
     } catch (_err: any) {
       this.processManager?.failLastItem();
@@ -223,8 +225,10 @@ export abstract class Sandbox {
       this.processManager?.finish();
     }
 
-    // Tear down service containers when the task is paused/stopped
-    await this.teardownServicesIfConfigured();
+    // Only tear down sidecars after the task container has definitely stopped.
+    if (stopped) {
+      await this.teardownServicesIfConfigured();
+    }
 
     return sandboxId;
   }

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -235,6 +235,7 @@ export abstract class Sandbox {
 
   async stopAndRemove(): Promise<string> {
     let sandboxId = '';
+    let removed = false;
     this.processManager?.addItem(
       `Stopping sandbox (${this.backend}) | Name: ${this.sandboxName}`
     );
@@ -253,6 +254,7 @@ export abstract class Sandbox {
 
     try {
       sandboxId = await this.remove();
+      removed = true;
       this.processManager?.completeLastItem();
     } catch (_err: any) {
       this.processManager?.failLastItem();
@@ -260,8 +262,11 @@ export abstract class Sandbox {
       this.processManager?.finish();
     }
 
-    // Tear down service containers and network after the task container is gone
-    await this.teardownServicesIfConfigured();
+    // Tear down service containers and network only after the task container
+    // is definitely gone.
+    if (removed) {
+      await this.teardownServicesIfConfigured();
+    }
 
     return sandboxId;
   }

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -4,6 +4,7 @@ import {
   ProjectConfigManager,
   TaskDescriptionManager,
 } from 'rover-core';
+import { createHash } from 'node:crypto';
 import {
   loadEnvsFile,
   parseCustomEnvironmentVariables,
@@ -24,6 +25,36 @@ import {
 import type { ServiceContainer } from 'rover-schemas';
 
 const SERVICE_CONTEXT_METADATA_KEY = 'serviceContext';
+
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(item => stableSerialize(item)).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(
+      ([left], [right]) => left.localeCompare(right)
+    );
+    return `{${entries
+      .map(
+        ([key, nestedValue]) =>
+          `${JSON.stringify(key)}:${stableSerialize(nestedValue)}`
+      )
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function getServiceConfigHash(
+  services: ServiceContainer[] | undefined
+): string | undefined {
+  if (!services || services.length === 0) {
+    return undefined;
+  }
+
+  return createHash('sha256').update(stableSerialize(services)).digest('hex');
+}
 
 export interface SandboxOptions {
   /** Extra arguments to pass to Docker/Podman from CLI */
@@ -123,6 +154,10 @@ export abstract class Sandbox {
         containerNames: [...record.containerNames],
         taskId: record.taskId,
         iteration: record.iteration,
+        serviceConfigHash:
+          typeof record.serviceConfigHash === 'string'
+            ? record.serviceConfigHash
+            : undefined,
       };
     }
 
@@ -203,6 +238,7 @@ export abstract class Sandbox {
       this.task.id,
       this.task.iterations
     );
+    expectedServiceContext.serviceConfigHash = getServiceConfigHash(services);
 
     if (existingServiceContext) {
       const matchesConfiguredServices =
@@ -210,6 +246,8 @@ export abstract class Sandbox {
           expectedServiceContext.networkName &&
         existingServiceContext.taskId === expectedServiceContext.taskId &&
         existingServiceContext.iteration === expectedServiceContext.iteration &&
+        existingServiceContext.serviceConfigHash ===
+          expectedServiceContext.serviceConfigHash &&
         existingServiceContext.containerNames.length ===
           expectedServiceContext.containerNames.length &&
         existingServiceContext.containerNames.every(
@@ -264,6 +302,7 @@ export abstract class Sandbox {
       containerNames: [],
       taskId: this.task.id,
       iteration: this.task.iterations,
+      serviceConfigHash: expectedServiceContext.serviceConfigHash,
     };
 
     try {
@@ -280,6 +319,7 @@ export abstract class Sandbox {
             containerNames: startedContainerNames,
             taskId: this.task.id,
             iteration: this.task.iterations,
+            serviceConfigHash: expectedServiceContext.serviceConfigHash,
           };
         }
       );
@@ -288,6 +328,7 @@ export abstract class Sandbox {
         containerNames,
         taskId: this.task.id,
         iteration: this.task.iterations,
+        serviceConfigHash: expectedServiceContext.serviceConfigHash,
       };
       await waitForServicesReady(
         this.getContainerBackend(),
@@ -335,12 +376,17 @@ export abstract class Sandbox {
 
     const serviceContext = this.resolveServiceContext();
     if (serviceContext) {
-      metadata[SERVICE_CONTEXT_METADATA_KEY] = {
+      const persistedServiceContext: Record<string, unknown> = {
         networkName: serviceContext.networkName,
         containerNames: [...serviceContext.containerNames],
         taskId: serviceContext.taskId,
         iteration: serviceContext.iteration,
       };
+      if (typeof serviceContext.serviceConfigHash === 'string') {
+        persistedServiceContext.serviceConfigHash =
+          serviceContext.serviceConfigHash;
+      }
+      metadata[SERVICE_CONTEXT_METADATA_KEY] = persistedServiceContext;
     }
 
     return Object.keys(metadata).length > 0 ? metadata : undefined;

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -46,6 +46,7 @@ export abstract class Sandbox {
   task: TaskDescriptionManager;
   options?: SandboxOptions;
   protected serviceContext?: ServiceContainerContext;
+  private servicesTornDown = false;
 
   constructor(
     task: TaskDescriptionManager,
@@ -77,6 +78,10 @@ export abstract class Sandbox {
   }
 
   private getPersistedServiceContext(): ServiceContainerContext | undefined {
+    if (this.servicesTornDown) {
+      return undefined;
+    }
+
     const persisted =
       this.options?.sandboxMetadata?.[SERVICE_CONTEXT_METADATA_KEY];
     const record =
@@ -106,6 +111,10 @@ export abstract class Sandbox {
   }
 
   protected resolveServiceContext(): ServiceContainerContext | undefined {
+    if (this.servicesTornDown) {
+      return undefined;
+    }
+
     if (this.serviceContext) {
       return this.serviceContext;
     }
@@ -140,12 +149,19 @@ export abstract class Sandbox {
       this.getServiceEnvironment()
     );
     this.serviceContext = undefined;
+    this.servicesTornDown = true;
+  }
+
+  async teardownServices(): Promise<void> {
+    await this.teardownServicesIfConfigured();
   }
 
   getSandboxMetadata(): Record<string, unknown> | undefined {
     const metadata = this.options?.sandboxMetadata
       ? { ...this.options.sandboxMetadata }
       : {};
+    delete metadata[SERVICE_CONTEXT_METADATA_KEY];
+
     if (
       typeof metadata.dockerHost !== 'string' &&
       typeof process.env.DOCKER_HOST === 'string'

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -10,7 +10,9 @@ import {
 } from '../../utils/env-variables.js';
 import { AIAgentTool } from '../agents/index.js';
 import { ContainerBackend } from './container-common.js';
+import { isContainerMissingInspectError } from './inspect-errors.js';
 import {
+  buildServiceContainerContext,
   createServiceNetwork,
   isServiceContainerContextAvailable,
   startServiceContainers,
@@ -116,12 +118,12 @@ export abstract class Sandbox {
   }
 
   protected resolveServiceContext(): ServiceContainerContext | undefined {
-    if (this.servicesTornDown) {
-      return undefined;
-    }
-
     if (this.serviceContext) {
       return this.serviceContext;
+    }
+
+    if (this.servicesTornDown) {
+      return undefined;
     }
 
     return this.getPersistedServiceContext();
@@ -160,26 +162,60 @@ export abstract class Sandbox {
   protected async ensureServiceContext(
     services: ServiceContainer[] | undefined
   ): Promise<{ started: boolean; serviceContext?: ServiceContainerContext }> {
+    const env = this.getServiceEnvironment();
+    const existingServiceContext = this.resolveServiceContext();
+
     if (!services || services.length === 0) {
+      if (existingServiceContext) {
+        try {
+          await teardownServiceContainers(
+            this.getContainerBackend(),
+            existingServiceContext,
+            env
+          );
+        } catch {
+          // The current config no longer uses services, so stale cleanup
+          // failures should not block startup or shell flows.
+        }
+        this.serviceContext = undefined;
+        this.servicesTornDown = true;
+      }
       return {
         started: false,
-        serviceContext: this.resolveServiceContext(),
+        serviceContext: undefined,
       };
     }
 
-    const env = this.getServiceEnvironment();
-    const existingServiceContext = this.resolveServiceContext();
+    const expectedServiceContext = buildServiceContainerContext(
+      services,
+      this.task.id,
+      this.task.iterations
+    );
+
     if (existingServiceContext) {
-      const isAvailable = await isServiceContainerContextAvailable(
-        this.getContainerBackend(),
-        existingServiceContext,
-        env
-      );
-      if (isAvailable) {
-        return {
-          started: false,
-          serviceContext: existingServiceContext,
-        };
+      const matchesConfiguredServices =
+        existingServiceContext.networkName ===
+          expectedServiceContext.networkName &&
+        existingServiceContext.taskId === expectedServiceContext.taskId &&
+        existingServiceContext.iteration === expectedServiceContext.iteration &&
+        existingServiceContext.containerNames.length ===
+          expectedServiceContext.containerNames.length &&
+        existingServiceContext.containerNames.every(
+          (name, index) => name === expectedServiceContext.containerNames[index]
+        );
+
+      if (matchesConfiguredServices) {
+        const isAvailable = await isServiceContainerContextAvailable(
+          this.getContainerBackend(),
+          existingServiceContext,
+          env
+        );
+        if (isAvailable) {
+          return {
+            started: false,
+            serviceContext: existingServiceContext,
+          };
+        }
       }
 
       await teardownServiceContainers(
@@ -196,6 +232,7 @@ export abstract class Sandbox {
       this.task.iterations,
       env
     );
+    this.servicesTornDown = false;
     this.serviceContext = {
       networkName,
       containerNames: [],
@@ -312,23 +349,33 @@ export abstract class Sandbox {
    */
   async stopGracefully(): Promise<string> {
     let sandboxId = '';
-    let stopped = false;
+    let stoppedOrMissing = false;
+    let stopError: unknown;
     this.processManager?.addItem(
       `Stopping sandbox (${this.backend}) | Name: ${this.sandboxName}`
     );
     try {
       sandboxId = await this.stop();
-      stopped = true;
+      stoppedOrMissing = true;
       this.processManager?.completeLastItem();
     } catch (_err: any) {
+      if (isContainerMissingInspectError(_err)) {
+        stoppedOrMissing = true;
+      } else {
+        stopError = _err;
+      }
       this.processManager?.failLastItem();
     } finally {
       this.processManager?.finish();
     }
 
     // Only tear down sidecars after the task container has definitely stopped.
-    if (stopped) {
+    if (stoppedOrMissing) {
       await this.teardownServicesIfConfigured();
+    }
+
+    if (stopError) {
+      throw stopError;
     }
 
     return sandboxId;
@@ -336,7 +383,9 @@ export abstract class Sandbox {
 
   async stopAndRemove(): Promise<string> {
     let sandboxId = '';
-    let removed = false;
+    let removedOrMissing = false;
+    let stopError: unknown;
+    let removeError: unknown;
     this.processManager?.addItem(
       `Stopping sandbox (${this.backend}) | Name: ${this.sandboxName}`
     );
@@ -344,6 +393,11 @@ export abstract class Sandbox {
       sandboxId = await this.stop();
       this.processManager?.completeLastItem();
     } catch (_err: any) {
+      if (isContainerMissingInspectError(_err)) {
+        removedOrMissing = true;
+      } else {
+        stopError = _err;
+      }
       this.processManager?.failLastItem();
     } finally {
       this.processManager?.finish();
@@ -355,9 +409,14 @@ export abstract class Sandbox {
 
     try {
       sandboxId = await this.remove();
-      removed = true;
+      removedOrMissing = true;
       this.processManager?.completeLastItem();
     } catch (_err: any) {
+      if (isContainerMissingInspectError(_err)) {
+        removedOrMissing = true;
+      } else {
+        removeError = _err;
+      }
       this.processManager?.failLastItem();
     } finally {
       this.processManager?.finish();
@@ -365,8 +424,12 @@ export abstract class Sandbox {
 
     // Tear down service containers and network only after the task container
     // is definitely gone.
-    if (removed) {
+    if (removedOrMissing) {
       await this.teardownServicesIfConfigured();
+    }
+
+    if (!removedOrMissing) {
+      throw removeError ?? stopError ?? new Error('Failed to stop sandbox');
     }
 
     return sandboxId;

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -462,7 +462,9 @@ export abstract class Sandbox {
         customEnvVariables = [...customEnvVariables, ...fileEnvVariables];
       }
     } catch (error) {
-      // Silently skip if there's an error loading project config
+      console.error(
+        `[rover] warning: failed to load custom environment variables: ${error instanceof Error ? error.message : error}`
+      );
     }
 
     // Merge agent environment variables with custom environment variables

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -4,11 +4,17 @@ import {
   ProjectConfigManager,
   TaskDescriptionManager,
 } from 'rover-core';
-import { AIAgentTool } from '../agents/index.js';
 import {
   loadEnvsFile,
   parseCustomEnvironmentVariables,
 } from '../../utils/env-variables.js';
+import { AIAgentTool } from '../agents/index.js';
+import { ContainerBackend } from './container-common.js';
+import {
+  buildServiceContainerContext,
+  type ServiceContainerContext,
+  teardownServiceContainers,
+} from './service-containers.js';
 
 export interface SandboxOptions {
   /** Extra arguments to pass to Docker/Podman from CLI */
@@ -38,6 +44,7 @@ export abstract class Sandbox {
   processManager?: ProcessManager;
   task: TaskDescriptionManager;
   options?: SandboxOptions;
+  protected serviceContext?: ServiceContainerContext;
 
   constructor(
     task: TaskDescriptionManager,
@@ -66,6 +73,36 @@ export abstract class Sandbox {
 
   protected get sandboxName(): string {
     return `rover-task-${this.task.id}-${this.task.iterations}`;
+  }
+
+  protected resolveServiceContext(): ServiceContainerContext | undefined {
+    if (this.serviceContext) {
+      return this.serviceContext;
+    }
+
+    try {
+      const projectConfig = ProjectConfigManager.load(
+        this.options?.projectPath ?? process.cwd()
+      );
+      const services = projectConfig.services;
+      if (!services || services.length === 0) {
+        return undefined;
+      }
+
+      return buildServiceContainerContext(
+        services,
+        this.task.id,
+        this.task.iterations
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  protected getContainerBackend(): ContainerBackend {
+    return this.backend === 'docker'
+      ? ContainerBackend.Docker
+      : ContainerBackend.Podman;
   }
 
   async createAndStart(): Promise<string> {
@@ -108,6 +145,17 @@ export abstract class Sandbox {
     } finally {
       this.processManager?.finish();
     }
+
+    // Tear down service containers when the task is paused/stopped
+    const serviceContext = this.resolveServiceContext();
+    if (serviceContext) {
+      await teardownServiceContainers(
+        this.getContainerBackend(),
+        serviceContext
+      );
+      this.serviceContext = undefined;
+    }
+
     return sandboxId;
   }
 
@@ -136,6 +184,16 @@ export abstract class Sandbox {
       this.processManager?.failLastItem();
     } finally {
       this.processManager?.finish();
+    }
+
+    // Tear down service containers and network after the task container is gone
+    const serviceContext = this.resolveServiceContext();
+    if (serviceContext) {
+      await teardownServiceContainers(
+        this.getContainerBackend(),
+        serviceContext
+      );
+      this.serviceContext = undefined;
     }
 
     return sandboxId;

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -238,11 +238,15 @@ export abstract class Sandbox {
       };
     } catch (error) {
       if (this.serviceContext) {
-        await teardownServiceContainers(
-          this.getContainerBackend(),
-          this.serviceContext,
-          env
-        );
+        try {
+          await teardownServiceContainers(
+            this.getContainerBackend(),
+            this.serviceContext,
+            env
+          );
+        } catch {
+          // Preserve the original service startup error.
+        }
       }
       this.serviceContext = undefined;
       throw error;

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -14,6 +14,7 @@ import { isContainerMissingInspectError } from './inspect-errors.js';
 import {
   buildServiceContainerContext,
   createServiceNetwork,
+  hasAnyServiceContainerResources,
   isServiceContainerContextAvailable,
   startServiceContainers,
   type ServiceContainerContext,
@@ -37,6 +38,15 @@ export interface SandboxOptions {
   checkpointPath?: string;
   /** Resume from an existing checkpoint without resetting workspace state */
   resumeFromCheckpoint?: boolean;
+}
+
+export interface SandboxInspectOptions {
+  /**
+   * Whether inspecting a stopped or missing task container should also tear
+   * down persisted sidecars. Pause/resume flows disable this so service state
+   * survives until an explicit stop/remove path cleans it up.
+   */
+  teardownServices?: boolean;
 }
 
 export abstract class SandboxPackage {
@@ -67,7 +77,9 @@ export abstract class Sandbox {
 
   abstract isBackendAvailable(): Promise<boolean>;
   abstract openShellAtWorktree(): Promise<{ exitCode?: number }>;
-  abstract inspect(): Promise<{ status: string; exitCode?: number } | null>;
+  abstract inspect(
+    options?: SandboxInspectOptions
+  ): Promise<{ status: string; exitCode?: number } | null>;
 
   protected abstract create(): Promise<string>;
   protected abstract start(): Promise<string>;
@@ -226,6 +238,20 @@ export abstract class Sandbox {
       this.serviceContext = undefined;
     }
 
+    if (
+      await hasAnyServiceContainerResources(
+        this.getContainerBackend(),
+        expectedServiceContext,
+        env
+      )
+    ) {
+      await teardownServiceContainers(
+        this.getContainerBackend(),
+        expectedServiceContext,
+        env
+      );
+    }
+
     const networkName = await createServiceNetwork(
       this.getContainerBackend(),
       this.task.id,
@@ -367,11 +393,6 @@ export abstract class Sandbox {
       this.processManager?.failLastItem();
     } finally {
       this.processManager?.finish();
-    }
-
-    // Only tear down sidecars after the task container has definitely stopped.
-    if (stoppedOrMissing) {
-      await this.teardownServicesIfConfigured();
     }
 
     if (stopError) {

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -24,20 +24,9 @@ import { mergeNetworkConfig, generateNetworkScript } from './network-config.js';
 import { initWorkflowStore } from './workflow.js';
 import { getDependencyResolutionCommands } from './dependency-resolution.js';
 import { shellEscape } from '../utils/shell.js';
+import { isSafeRelativePath } from '../utils/path-safety.js';
 
 import { getPackagesFromConfig } from './sandbox/packages.js';
-
-function isSafeWorkspaceProjectPath(projectPath: string): boolean {
-  if (projectPath.startsWith('/') || projectPath.length === 0) {
-    return false;
-  }
-
-  const normalized = projectPath
-    .split('/')
-    .filter(segment => segment.length > 0);
-
-  return normalized.length > 0 && normalized.every(segment => segment !== '..');
-}
 
 /**
  * SetupBuilder class - Consolidates Docker setup script generation
@@ -124,7 +113,7 @@ export class SetupBuilder {
             ]
           : []
       )
-      .filter(project => isSafeWorkspaceProjectPath(project.path));
+      .filter(project => isSafeRelativePath(project.path));
   }
 
   private getPersistedWorkspaceProjects():
@@ -199,7 +188,7 @@ export class SetupBuilder {
                 ]
               : []
           )
-          .filter(project => isSafeWorkspaceProjectPath(project.path));
+          .filter(project => isSafeRelativePath(project.path));
       } catch {
         continue;
       }
@@ -452,7 +441,11 @@ echo -e "\\n📦 Done installing MCP servers"`;
     let initScriptExecution = '';
     const allInitScripts = this.projectConfig.allInitScripts;
     const executableInitScripts = allInitScripts.flatMap((entry, index) =>
-      useCachedImage && !entry.path ? [] : [{ entry, index }]
+      useCachedImage && !entry.path
+        ? []
+        : !entry.path || isSafeRelativePath(entry.path)
+          ? [{ entry, index }]
+          : []
     );
     if (executableInitScripts.length > 0) {
       const scriptBlocks: string[] = [];

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -455,12 +455,12 @@ echo -e "\\n📦 Done installing MCP servers"`;
           scriptBlocks.push(`echo "🔧 Running initialization script${label}"
 workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
 workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
-if [ -f "$workspace_root_script_${index}" ]; then
-  workspace_script_${index}="$workspace_root_script_${index}"
-  workspace_dir_${index}='/workspace'
-elif [ -f "$workspace_project_script_${index}" ]; then
+if [ -f "$workspace_project_script_${index}" ]; then
   workspace_script_${index}="$workspace_project_script_${index}"
   workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
+elif [ -f "$workspace_root_script_${index}" ]; then
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
 else
   workspace_script_${index}="$workspace_root_script_${index}"
   workspace_dir_${index}='/workspace'

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -212,6 +212,102 @@ export class SetupBuilder {
     return `'${value.replace(/'/g, `'\"'\"'`)}'`;
   }
 
+  private getDependencyResolutionCommands(): string[] {
+    const commands: string[] = [];
+    const locations = [
+      {
+        path: '/workspace',
+        packageManagers: this.projectConfig.packageManagers ?? [],
+        label: 'workspace root',
+      },
+      ...(this.projectConfig.projects ?? []).map(project => ({
+        path: `/workspace/${project.path}`,
+        packageManagers: project.packageManagers ?? [],
+        label: project.path,
+      })),
+    ];
+
+    for (const location of locations) {
+      const quotedPath = this.shellEscape(location.path);
+      const pms = location.packageManagers;
+
+      if (pms.includes('uv')) {
+        commands.push(
+          `if [ -f ${quotedPath}/pyproject.toml ]; then`,
+          `  echo "📦 Resolving Python dependencies (uv) in ${location.label}..."`,
+          `  cd ${quotedPath} && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true`,
+          `  if [ -d ${quotedPath}/.venv/bin ]; then`,
+          `    export PATH="${location.path}/.venv/bin:$PATH"`,
+          `    echo 'export PATH="${location.path}/.venv/bin:$PATH"' >> $HOME/.profile`,
+          '  fi',
+          'fi'
+        );
+      }
+
+      if (pms.includes('poetry')) {
+        commands.push(
+          `if [ -f ${quotedPath}/pyproject.toml ]; then`,
+          `  echo "📦 Resolving Python dependencies (poetry) in ${location.label}..."`,
+          `  cd ${quotedPath} && poetry install --no-interaction 2>/dev/null || true`,
+          'fi'
+        );
+      }
+
+      if (pms.includes('pub')) {
+        commands.push(
+          `if [ -f ${quotedPath}/pubspec.yaml ]; then`,
+          `  echo "📦 Resolving Dart dependencies in ${location.label}..."`,
+          `  cd ${quotedPath} && flutter pub get 2>/dev/null || dart pub get 2>/dev/null || true`,
+          'fi'
+        );
+      }
+
+      if (pms.includes('pnpm')) {
+        commands.push(
+          `if [ -f ${quotedPath}/pnpm-lock.yaml ]; then`,
+          `  echo "📦 Resolving Node dependencies (pnpm) in ${location.label}..."`,
+          `  cd ${quotedPath} && pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true`,
+          'fi'
+        );
+      }
+
+      if (pms.includes('npm')) {
+        commands.push(
+          `if [ -f ${quotedPath}/package-lock.json ]; then`,
+          `  echo "📦 Resolving Node dependencies (npm) in ${location.label}..."`,
+          `  cd ${quotedPath} && npm ci 2>/dev/null || npm install 2>/dev/null || true`,
+          'fi'
+        );
+      }
+
+      if (pms.includes('yarn')) {
+        commands.push(
+          `if [ -f ${quotedPath}/yarn.lock ]; then`,
+          `  echo "📦 Resolving Node dependencies (yarn) in ${location.label}..."`,
+          `  cd ${quotedPath} && yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true`,
+          'fi'
+        );
+      }
+
+      if (pms.includes('gomod')) {
+        commands.push(
+          `if [ -f ${quotedPath}/go.mod ]; then`,
+          `  echo "📦 Resolving Go dependencies in ${location.label}..."`,
+          `  cd ${quotedPath} && go mod download 2>/dev/null || true`,
+          `elif [ -f ${quotedPath}/src/go.mod ]; then`,
+          `  cd ${quotedPath}/src && go mod download 2>/dev/null || true`,
+          'fi'
+        );
+      }
+    }
+
+    if (commands.length > 0) {
+      commands.push('cd /workspace');
+    }
+
+    return commands;
+  }
+
   /**
    * Generate and save the setup script to the appropriate task directory
    */
@@ -264,77 +360,17 @@ sudo chown -R $(id -u):$(id -g) /workspace
 source $HOME/.profile`;
     }
 
+    const gitSafeDirectorySetup = `# Allow git operations across mounted workspaces and embedded repositories
+git config --global --add safe.directory '*' 2>/dev/null || true
+git config --system --add safe.directory '*' 2>/dev/null || true`;
+
     // --- workspace dependency resolution (runs even with cached images) ---
     // Some package managers (uv, poetry, pip -e) create virtualenvs in /workspace
     // which can't be done during image build (/workspace is read-only).
     // Resolve deps here since /workspace is now read-write.
     let workspaceDeps = '';
     if (useCachedImage) {
-      const depCmds: string[] = [];
-      const pms = this.projectConfig.allPackageManagers ?? [];
-      if (pms.includes('uv')) {
-        depCmds.push(
-          'if [ -f /workspace/pyproject.toml ]; then',
-          '  echo "📦 Resolving Python dependencies (uv)..."',
-          '  cd /workspace && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true',
-          '  # Add venv to PATH so python/pytest are available without "uv run"',
-          '  if [ -d /workspace/.venv/bin ]; then',
-          '    export PATH="/workspace/.venv/bin:$PATH"',
-          '    echo \'export PATH="/workspace/.venv/bin:$PATH"\' >> $HOME/.profile',
-          '  fi',
-          'fi'
-        );
-      }
-      if (pms.includes('poetry')) {
-        depCmds.push(
-          'if [ -f /workspace/pyproject.toml ]; then',
-          '  echo "📦 Resolving Python dependencies (poetry)..."',
-          '  cd /workspace && poetry install --no-interaction 2>/dev/null || true',
-          'fi'
-        );
-      }
-      if (pms.includes('pub')) {
-        depCmds.push(
-          'if [ -f /workspace/pubspec.yaml ]; then',
-          '  echo "📦 Resolving Dart dependencies..."',
-          '  cd /workspace && flutter pub get 2>/dev/null || dart pub get 2>/dev/null || true',
-          'fi'
-        );
-      }
-      if (pms.includes('pnpm')) {
-        depCmds.push(
-          'if [ -f /workspace/pnpm-lock.yaml ]; then',
-          '  echo "📦 Resolving Node dependencies (pnpm)..."',
-          '  cd /workspace && pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true',
-          'fi'
-        );
-      }
-      if (pms.includes('npm')) {
-        depCmds.push(
-          'if [ -f /workspace/package-lock.json ]; then',
-          '  echo "📦 Resolving Node dependencies (npm)..."',
-          '  cd /workspace && npm ci 2>/dev/null || npm install 2>/dev/null || true',
-          'fi'
-        );
-      }
-      if (pms.includes('yarn')) {
-        depCmds.push(
-          'if [ -f /workspace/yarn.lock ]; then',
-          '  echo "📦 Resolving Node dependencies (yarn)..."',
-          '  cd /workspace && yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true',
-          'fi'
-        );
-      }
-      if (pms.includes('gomod')) {
-        depCmds.push(
-          'if [ -f /workspace/go.mod ]; then',
-          '  echo "📦 Resolving Go dependencies..."',
-          '  cd /workspace && go mod download 2>/dev/null || true',
-          'elif [ -f /workspace/src/go.mod ]; then',
-          '  cd /workspace/src && go mod download 2>/dev/null || true',
-          'fi'
-        );
-      }
+      const depCmds = this.getDependencyResolutionCommands();
       if (depCmds.length > 0) {
         workspaceDeps = depCmds.join('\n');
       }
@@ -518,30 +554,40 @@ echo -e "\\n📦 Done installing MCP servers"`;
     if (executableInitScripts.length > 0) {
       const scriptBlocks: string[] = [];
       for (const { entry, index } of executableInitScripts) {
-        const mountPath =
-          allInitScripts.length === 1 && !entry.path
-            ? '/init-script.sh'
-            : `/init-script-${index}.sh`;
-        const escapedWorkspacePath = entry.path
-          ? this.shellEscape(`/workspace/${entry.path}`)
-          : '';
         const label = entry.path ? ` (${entry.path})` : '';
-        let block = `echo "🔧 Running initialization script${label}"
-chmod +x ${mountPath}`;
         if (entry.path) {
-          block += `\ncd ${escapedWorkspacePath}`;
-        }
-        block += `\n/bin/sh ${mountPath}
+          const escapedWorkspacePath = this.shellEscape(
+            `/workspace/${entry.path}`
+          );
+          const escapedWorkspaceScript = this.shellEscape(
+            `/workspace/${entry.path}/${entry.script}`
+          );
+          scriptBlocks.push(`echo "🔧 Running initialization script${label}"
+chmod +x ${escapedWorkspaceScript}
+cd ${escapedWorkspacePath}
+${escapedWorkspaceScript}
 if [ $? -eq 0 ]; then
   echo "✅ Initialization script${label} completed successfully"
 else
   echo "❌ Initialization script${label} failed"
   safe_exit 1
-fi`;
-        if (entry.path) {
-          block += '\ncd /workspace';
+fi
+cd /workspace`);
+          continue;
         }
-        scriptBlocks.push(block);
+
+        const escapedWorkspaceScript = this.shellEscape(
+          `/workspace/${entry.script}`
+        );
+        scriptBlocks.push(`echo "🔧 Running initialization script${label}"
+chmod +x ${escapedWorkspaceScript}
+${escapedWorkspaceScript}
+if [ $? -eq 0 ]; then
+  echo "✅ Initialization script${label} completed successfully"
+else
+  echo "❌ Initialization script${label} failed"
+  safe_exit 1
+fi`);
       }
       initScriptExecution = `
 echo -e "\\n======================================="
@@ -558,6 +604,8 @@ ${scriptBlocks.join('\n')}
     );
 
     if (projectsWithRepositories.length > 0) {
+      const taskBranch = this.task.branchName || `task/${this.task.id}`;
+      const escapedTaskBranch = this.shellEscape(taskBranch);
       const repositoryStateFunctions = `
 compute_repo_untracked_hash() {
   local repo_path="$1"
@@ -714,6 +762,16 @@ if ! git -C ${escapedPath} fetch --all --tags --prune; then
   safe_exit 1
 fi
 ${checkoutRef}
+if git -C ${escapedPath} rev-parse --verify refs/remotes/origin/${escapedTaskBranch} >/dev/null 2>&1; then
+  echo "🌿 Checking out task branch ${escapedTaskBranch} for ${escapedName} from origin"
+  git -C ${escapedPath} checkout -B ${escapedTaskBranch} refs/remotes/origin/${escapedTaskBranch}
+elif git -C ${escapedPath} rev-parse --verify refs/heads/${escapedTaskBranch} >/dev/null 2>&1; then
+  echo "🌿 Reusing local task branch ${escapedTaskBranch} for ${escapedName}"
+  git -C ${escapedPath} checkout ${escapedTaskBranch}
+else
+  echo "🌿 Creating task branch ${escapedTaskBranch} for ${escapedName}"
+  git -C ${escapedPath} checkout -B ${escapedTaskBranch} HEAD
+fi
 git -C ${escapedPath} reset --hard HEAD
 git -C ${escapedPath} clean -fd
 echo "✅ Repository ${escapedName} is ready"`;
@@ -736,7 +794,7 @@ ${syncBlocks.join('\n')}
       ? ''
       : `# Remove ourselves from sudoers
 echo -e "\\n👤 Removing privileges after completing the setup!"
-sudo rm /etc/sudoers.d/1-agent-setup`;
+sudo rm -f /etc/sudoers.d/1-agent-setup`;
 
     // Generate network filtering configuration (always runs — iptables are runtime state)
     const effectiveNetworkConfig = mergeNetworkConfig(
@@ -804,6 +862,7 @@ echo "======================================="
       recoverPermissions,
       aptGetUpdate,
       homeSetup,
+      gitSafeDirectorySetup,
       installAllPackages,
       workspaceDeps,
       agentInstallSection,

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -7,7 +7,8 @@ import {
   readFileSync,
   readdirSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { join, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   TaskDescriptionManager,
   IterationManager,
@@ -33,6 +34,10 @@ import { getPackagesFromConfig } from './sandbox/packages.js';
  * Replaces the existing docker-setup.sh and docker-setup-gemini.sh files
  */
 export class SetupBuilder {
+  private repositoryMounts: Array<{
+    hostPath: string;
+    containerPath: string;
+  }> = [];
   private agent: string;
   private task: TaskDescriptionManager;
   private taskBasePath: string;
@@ -44,6 +49,7 @@ export class SetupBuilder {
     name: string;
     path: string;
     repository?: string;
+    runtimeRepository?: string;
     ref?: string;
     languages?: string[];
     packageManagers?: string[];
@@ -89,6 +95,7 @@ export class SetupBuilder {
     name: string;
     path: string;
     repository?: string;
+    runtimeRepository?: string;
     ref?: string;
     languages?: string[];
     packageManagers?: string[];
@@ -99,20 +106,32 @@ export class SetupBuilder {
     }
 
     return (this.projectConfig.projects ?? [])
-      .flatMap(project =>
-        typeof project?.name === 'string' && typeof project?.path === 'string'
-          ? [
-              {
-                name: project.name,
-                path: project.path,
-                repository: project.repository,
-                ref: project.ref,
-                languages: project.languages ?? [],
-                packageManagers: project.packageManagers ?? [],
-              },
-            ]
-          : []
-      )
+      .flatMap((project, index) => {
+        if (
+          typeof project?.name !== 'string' ||
+          typeof project?.path !== 'string'
+        ) {
+          return [];
+        }
+
+        const repositoryMount = this.resolveRepositoryMount(
+          project.repository,
+          index
+        );
+
+        return [
+          {
+            name: project.name,
+            path: project.path,
+            repository: project.repository,
+            runtimeRepository:
+              repositoryMount?.containerPath ?? project.repository,
+            ref: project.ref,
+            languages: project.languages ?? [],
+            packageManagers: project.packageManagers ?? [],
+          },
+        ];
+      })
       .filter(project => isSafeRelativePath(project.path));
   }
 
@@ -121,6 +140,7 @@ export class SetupBuilder {
         name: string;
         path: string;
         repository?: string;
+        runtimeRepository?: string;
         ref?: string;
         languages?: string[];
         packageManagers?: string[];
@@ -160,34 +180,44 @@ export class SetupBuilder {
         };
 
         return (Array.isArray(parsed.projects) ? parsed.projects : [])
-          .flatMap(project =>
-            typeof project?.name === 'string' &&
-            typeof project?.path === 'string'
-              ? [
-                  {
-                    name: project.name,
-                    path: project.path,
-                    repository:
-                      typeof project.repository === 'string'
-                        ? project.repository
-                        : undefined,
-                    ref:
-                      typeof project.ref === 'string' ? project.ref : undefined,
-                    languages: Array.isArray(project.languages)
-                      ? project.languages.filter(
-                          (language): language is string =>
-                            typeof language === 'string'
-                        )
-                      : [],
-                    packageManagers: Array.isArray(project.packageManagers)
-                      ? project.packageManagers.filter(
-                          (pm): pm is string => typeof pm === 'string'
-                        )
-                      : [],
-                  },
-                ]
-              : []
-          )
+          .flatMap((project, index) => {
+            if (
+              typeof project?.name !== 'string' ||
+              typeof project?.path !== 'string'
+            ) {
+              return [];
+            }
+
+            const repository =
+              typeof project.repository === 'string'
+                ? project.repository
+                : undefined;
+            const repositoryMount = this.resolveRepositoryMount(
+              repository,
+              index
+            );
+
+            return [
+              {
+                name: project.name,
+                path: project.path,
+                repository,
+                runtimeRepository: repositoryMount?.containerPath ?? repository,
+                ref: typeof project.ref === 'string' ? project.ref : undefined,
+                languages: Array.isArray(project.languages)
+                  ? project.languages.filter(
+                      (language): language is string =>
+                        typeof language === 'string'
+                    )
+                  : [],
+                packageManagers: Array.isArray(project.packageManagers)
+                  ? project.packageManagers.filter(
+                      (pm): pm is string => typeof pm === 'string'
+                    )
+                  : [],
+              },
+            ];
+          })
           .filter(project => isSafeRelativePath(project.path));
       } catch {
         continue;
@@ -195,6 +225,41 @@ export class SetupBuilder {
     }
 
     return undefined;
+  }
+
+  private isLocalRepositoryReference(repository: string): boolean {
+    return (
+      repository.startsWith('file://') ||
+      isAbsolute(repository) ||
+      repository === '.' ||
+      repository === '..' ||
+      repository.startsWith('./') ||
+      repository.startsWith('../')
+    );
+  }
+
+  private resolveRepositoryMount(
+    repository: unknown,
+    index: number
+  ): { hostPath: string; containerPath: string } | undefined {
+    if (
+      typeof repository !== 'string' ||
+      !this.isLocalRepositoryReference(repository)
+    ) {
+      return undefined;
+    }
+
+    const hostPath = repository.startsWith('file://')
+      ? fileURLToPath(repository)
+      : resolve(this.projectConfig.projectRoot, repository);
+
+    if (!existsSync(hostPath)) {
+      throw new Error(`Local workspace repository not found: ${hostPath}`);
+    }
+
+    const containerPath = `/workspace-repos/${index}`;
+    this.repositoryMounts.push({ hostPath, containerPath });
+    return { hostPath, containerPath };
   }
 
   private getDependencyResolutionCommands(): string[] {
@@ -590,7 +655,9 @@ NODE
         const targetPath = `/workspace/${project.path}`;
         const escapedName = shellEscape(project.name);
         const escapedPath = shellEscape(targetPath);
-        const escapedRepository = shellEscape(project.repository!);
+        const escapedRepository = shellEscape(
+          project.runtimeRepository ?? project.repository!
+        );
         const escapedRef = project.ref ? shellEscape(project.ref) : '';
         const checkpointLookupScript = shellEscape(
           `const fs=require('fs'); const checkpoint=JSON.parse(fs.readFileSync('/output/checkpoint.json','utf8')); const entry=(checkpoint.externalRepositories||[]).find(repo => repo.path === ${JSON.stringify(project.path)}); if (!entry) process.exit(2); process.stdout.write([entry.head, entry.trackedDiffHash, entry.untrackedHash].join('\\t'));`
@@ -706,7 +773,11 @@ sudo rm -f /etc/sudoers.d/1-agent-setup`;
       this.projectConfig.network,
       this.task.networkConfig
     );
-    const networkConfigSection = generateNetworkScript(effectiveNetworkConfig);
+    const networkConfigSection = generateNetworkScript(effectiveNetworkConfig, {
+      serviceHostnames: (this.projectConfig.services ?? []).map(
+        service => service.name
+      ),
+    });
 
     // Generate template variables for task-related sections
     const validateTaskFileFunction = includeTaskSetup
@@ -840,6 +911,10 @@ echo "======================================="
     writeFileSync(filePath, JSON.stringify(description, null, 2), 'utf-8');
 
     return filePath;
+  }
+
+  getRepositoryMounts(): Array<{ hostPath: string; containerPath: string }> {
+    return [...this.repositoryMounts];
   }
 
   /**

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -7,7 +7,7 @@ import {
   readFileSync,
   readdirSync,
 } from 'node:fs';
-import { join, isAbsolute, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   TaskDescriptionManager,
@@ -29,6 +29,7 @@ import {
   isSafeRelativePath,
   resolvePathWithinRoot,
 } from '../utils/path-safety.js';
+import { isLocalRepositoryReference } from '../utils/repository-reference.js';
 
 import { getRootInitScriptMountPath } from './sandbox/container-common.js';
 import { getPackagesFromConfig } from './sandbox/packages.js';
@@ -275,31 +276,22 @@ export class SetupBuilder {
       : isSafeRelativePath(relativePath);
   }
 
-  private isLocalRepositoryReference(repository: string): boolean {
-    return (
-      repository.startsWith('file://') ||
-      (isAbsolute(repository) && !repository.startsWith('/workspace/')) ||
-      repository === '.' ||
-      repository === '..' ||
-      repository.startsWith('./') ||
-      repository.startsWith('../')
-    );
-  }
-
   private resolveRepositoryMount(
     repository: unknown,
     index: number
   ): { hostPath: string; containerPath: string } | undefined {
     if (
       typeof repository !== 'string' ||
-      !this.isLocalRepositoryReference(repository)
+      !isLocalRepositoryReference(repository)
     ) {
       return undefined;
     }
 
+    const repositoryResolutionRoot =
+      this.projectConfig.projectRoot ?? this.taskBasePath;
     const hostPath = repository.startsWith('file://')
       ? fileURLToPath(repository)
-      : resolve(this.projectConfig.projectRoot, repository);
+      : resolve(repositoryResolutionRoot, repository);
 
     if (!existsSync(hostPath)) {
       throw new Error(`Local workspace repository not found: ${hostPath}`);
@@ -721,6 +713,9 @@ NODE
           project.runtimeRepository ?? project.repository!
         );
         const escapedRef = project.ref ? shellEscape(project.ref) : '';
+        const requiresCheckpointRepoState =
+          typeof project.repository === 'string' &&
+          !isLocalRepositoryReference(project.repository);
         const checkpointLookupScript = shellEscape(
           `const fs=require('fs'); const checkpoint=JSON.parse(fs.readFileSync('/output/checkpoint.json','utf8')); const entry=(checkpoint.externalRepositories||[]).find(repo => repo.path === ${JSON.stringify(project.path)}); if (!entry) process.exit(2); process.stdout.write([entry.head, entry.trackedDiffHash, entry.untrackedHash].join('\\t'));`
         );
@@ -753,6 +748,20 @@ else
 fi`;
 
         if (this.resumeFromCheckpoint) {
+          const checkpointStateValidation = requiresCheckpointRepoState
+            ? `if ! expected_state=$(node -e ${checkpointLookupScript}); then
+  echo "❌ Checkpoint is missing repository state for ${escapedName}; cannot resume safely"
+  safe_exit 1
+fi
+IFS=$'\\t' read -r expected_head expected_tracked_diff_hash expected_untracked_hash <<< "$expected_state"
+current_head=$(git -C ${escapedPath} rev-parse HEAD)
+current_tracked_diff_hash=$(compute_repo_tracked_diff_hash ${escapedPath})
+current_untracked_hash=$(compute_repo_untracked_hash ${escapedPath})
+if [ "$current_head" != "$expected_head" ] || [ "$current_tracked_diff_hash" != "$expected_tracked_diff_hash" ] || [ "$current_untracked_hash" != "$expected_untracked_hash" ]; then
+  echo "❌ Repository ${escapedName} no longer matches the checkpointed revision"
+  safe_exit 1
+fi`
+            : '';
           return `echo "📥 Verifying repository ${escapedName} for checkpoint resume"
 if [ ! -d ${escapedPath}/.git ]; then
   echo "❌ Repository ${escapedName} is missing at ${escapedPath}; cannot resume from checkpoint safely"
@@ -767,18 +776,7 @@ if [ ! -f /output/checkpoint.json ]; then
   echo "❌ Checkpoint file is missing; cannot resume ${escapedName} safely"
   safe_exit 1
 fi
-if ! expected_state=$(node -e ${checkpointLookupScript}); then
-  echo "❌ Checkpoint is missing repository state for ${escapedName}; cannot resume safely"
-  safe_exit 1
-fi
-IFS=$'\\t' read -r expected_head expected_tracked_diff_hash expected_untracked_hash <<< "$expected_state"
-current_head=$(git -C ${escapedPath} rev-parse HEAD)
-current_tracked_diff_hash=$(compute_repo_tracked_diff_hash ${escapedPath})
-current_untracked_hash=$(compute_repo_untracked_hash ${escapedPath})
-if [ "$current_head" != "$expected_head" ] || [ "$current_tracked_diff_hash" != "$expected_tracked_diff_hash" ] || [ "$current_untracked_hash" != "$expected_untracked_hash" ]; then
-  echo "❌ Repository ${escapedName} no longer matches the checkpointed revision"
-  safe_exit 1
-fi
+${checkpointStateValidation}
 echo "✅ Repository ${escapedName} is ready for checkpoint resume"`;
         }
 

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -25,8 +25,12 @@ import { mergeNetworkConfig, generateNetworkScript } from './network-config.js';
 import { initWorkflowStore } from './workflow.js';
 import { getDependencyResolutionCommands } from './dependency-resolution.js';
 import { shellEscape } from '../utils/shell.js';
-import { isSafeRelativePath } from '../utils/path-safety.js';
+import {
+  isSafeRelativePath,
+  resolvePathWithinRoot,
+} from '../utils/path-safety.js';
 
+import { getRootInitScriptMountPath } from './sandbox/container-common.js';
 import { getPackagesFromConfig } from './sandbox/packages.js';
 
 /**
@@ -109,7 +113,7 @@ export class SetupBuilder {
       if (
         typeof project?.name !== 'string' ||
         typeof project?.path !== 'string' ||
-        !isSafeRelativePath(project.path)
+        !this.isSafeWorkspacePath(project.path)
       ) {
         return [];
       }
@@ -145,31 +149,19 @@ export class SetupBuilder {
         packageManagers?: string[];
       }>
     | undefined {
-    const iterationsPath = join(this.taskBasePath, 'iterations');
-    if (!existsSync(iterationsPath)) {
-      return undefined;
-    }
-
-    const iterationIds = readdirSync(iterationsPath, { withFileTypes: true })
-      .filter(dirent => dirent.isDirectory())
-      .map(dirent => Number.parseInt(dirent.name, 10))
-      .filter(iteration => !Number.isNaN(iteration))
-      .sort((a, b) => b - a);
-
-    if (iterationIds.length === 0) {
-      return undefined;
-    }
-
-    for (const iterationId of iterationIds) {
-      const descriptionPath = join(
-        iterationsPath,
-        iterationId.toString(),
-        'workspace-description.json'
-      );
-      if (!existsSync(descriptionPath)) {
-        continue;
-      }
-
+    const parsePersistedWorkspaceProjects = (
+      descriptionPath: string
+    ):
+      | Array<{
+          name: string;
+          path: string;
+          repository?: string;
+          runtimeRepository?: string;
+          ref?: string;
+          languages?: string[];
+          packageManagers?: string[];
+        }>
+      | undefined => {
       try {
         const parsed = JSON.parse(readFileSync(descriptionPath, 'utf8')) as {
           projects?: Array<{
@@ -187,7 +179,7 @@ export class SetupBuilder {
             if (
               typeof project?.name !== 'string' ||
               typeof project?.path !== 'string' ||
-              !isSafeRelativePath(project.path)
+              !this.isSafeWorkspacePath(project.path)
             ) {
               return [];
             }
@@ -224,17 +216,69 @@ export class SetupBuilder {
           }
         );
       } catch {
+        return undefined;
+      }
+    };
+    const legacyDescriptionPath = this.task.worktreePath
+      ? join(this.task.worktreePath, '.rover-workspace.json')
+      : join(this.taskBasePath, '.rover-workspace.json');
+
+    const iterationsPath = join(this.taskBasePath, 'iterations');
+    if (!existsSync(iterationsPath)) {
+      return existsSync(legacyDescriptionPath)
+        ? (parsePersistedWorkspaceProjects(legacyDescriptionPath) ?? [])
+        : undefined;
+    }
+
+    const iterationIds = readdirSync(iterationsPath, { withFileTypes: true })
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => Number.parseInt(dirent.name, 10))
+      .filter(iteration => !Number.isNaN(iteration))
+      .sort((a, b) => b - a);
+
+    if (iterationIds.length === 0) {
+      return existsSync(legacyDescriptionPath)
+        ? (parsePersistedWorkspaceProjects(legacyDescriptionPath) ?? [])
+        : undefined;
+    }
+
+    let foundPersistedWorkspaceDescription = false;
+
+    for (const iterationId of iterationIds) {
+      const descriptionPath = join(
+        iterationsPath,
+        iterationId.toString(),
+        'workspace-description.json'
+      );
+      if (!existsSync(descriptionPath)) {
         continue;
+      }
+      foundPersistedWorkspaceDescription = true;
+      const persistedProjects =
+        parsePersistedWorkspaceProjects(descriptionPath);
+      if (persistedProjects !== undefined) {
+        return persistedProjects;
       }
     }
 
-    return [];
+    if (existsSync(legacyDescriptionPath)) {
+      return parsePersistedWorkspaceProjects(legacyDescriptionPath) ?? [];
+    }
+
+    return foundPersistedWorkspaceDescription ? [] : undefined;
+  }
+
+  private isSafeWorkspacePath(relativePath: string): boolean {
+    return typeof this.projectConfig.projectRoot === 'string'
+      ? resolvePathWithinRoot(this.projectConfig.projectRoot, relativePath) !==
+          null
+      : isSafeRelativePath(relativePath);
   }
 
   private isLocalRepositoryReference(repository: string): boolean {
     return (
       repository.startsWith('file://') ||
-      isAbsolute(repository) ||
+      (isAbsolute(repository) && !repository.startsWith('/workspace/')) ||
       repository === '.' ||
       repository === '..' ||
       repository.startsWith('./') ||
@@ -270,6 +314,7 @@ export class SetupBuilder {
     return getDependencyResolutionCommands({
       rootPackageManagers: this.projectConfig.packageManagers ?? [],
       projects: this.workspaceProjects,
+      workspaceRoot: this.projectConfig.projectRoot,
       addVenvPathExports: true,
     });
   }
@@ -450,7 +495,7 @@ fi`;
       if (mcps && mcps.length > 0) {
         configureAllMCPCommands.push('echo "✅ Configuring custom MCPs"');
         for (const mcp of mcps) {
-          let cmd = `rover-agent config mcp ${this.agent} ${shellEscape(mcp.name)} --transport ${shellEscape(mcp.transport)}`;
+          let cmd = `rover-agent config mcp ${shellEscape(this.agent)} ${shellEscape(mcp.name)} --transport ${shellEscape(mcp.transport)}`;
 
           if (mcp.envs && mcp.envs.length > 0) {
             for (const env of mcp.envs) {
@@ -512,7 +557,7 @@ echo -e "\\n📦 Done installing MCP servers"`;
     const executableInitScripts = allInitScripts.flatMap((entry, index) =>
       useCachedImage && !entry.path
         ? []
-        : !entry.path || isSafeRelativePath(entry.path)
+        : !entry.path || this.isSafeWorkspacePath(entry.path)
           ? [{ entry, index }]
           : []
     );
@@ -523,11 +568,15 @@ echo -e "\\n📦 Done installing MCP servers"`;
         if (entry.path) {
           scriptBlocks.push(`echo "🔧 Running initialization script${label}"
 workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
+workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
 if [ -f "$workspace_project_script_${index}" ]; then
   workspace_script_${index}="$workspace_project_script_${index}"
   workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
+elif [ -f "$workspace_root_script_${index}" ]; then
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
 else
-  echo "❌ Initialization script${label} not found at $workspace_project_script_${index}"
+  echo "❌ Initialization script${label} not found at $workspace_project_script_${index} or $workspace_root_script_${index}"
   safe_exit 1
 fi
 chmod +x "$workspace_script_${index}"
@@ -543,12 +592,25 @@ cd /workspace`);
           continue;
         }
 
+        const escapedMountedScript = shellEscape(
+          getRootInitScriptMountPath(allInitScripts, index)
+        );
         const escapedWorkspaceScript = shellEscape(
           `/workspace/${entry.script}`
         );
         scriptBlocks.push(`echo "🔧 Running initialization script${label}"
-chmod +x ${escapedWorkspaceScript}
-bash ${escapedWorkspaceScript}
+mounted_script_${index}=${escapedMountedScript}
+workspace_script_${index}=${escapedWorkspaceScript}
+if [ -f "$mounted_script_${index}" ]; then
+  root_script_${index}="$mounted_script_${index}"
+elif [ -f "$workspace_script_${index}" ]; then
+  root_script_${index}="$workspace_script_${index}"
+else
+  echo "❌ Initialization script${label} not found at $mounted_script_${index} or $workspace_script_${index}"
+  safe_exit 1
+fi
+chmod +x "$root_script_${index}"
+bash "$root_script_${index}"
 if [ $? -eq 0 ]; then
   echo "✅ Initialization script${label} completed successfully"
 else

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -4,6 +4,8 @@ import {
   mkdirSync,
   cpSync,
   existsSync,
+  readFileSync,
+  readdirSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import {
@@ -63,6 +65,14 @@ export class SetupBuilder {
   private isDockerRootless: boolean;
   private projectConfig: ProjectConfigManager;
   private resumeFromCheckpoint: boolean;
+  private workspaceProjects: Array<{
+    name: string;
+    path: string;
+    repository?: string;
+    ref?: string;
+    languages?: string[];
+    packageManagers?: string[];
+  }>;
 
   constructor(
     taskDescription: TaskDescriptionManager,
@@ -94,9 +104,152 @@ export class SetupBuilder {
     // Set up paths using TaskDescriptionManager methods
     this.taskBasePath = this.task.getBasePath();
     this.iterationPath = this.task.getIterationPath();
+    this.workspaceProjects = this.resolveWorkspaceProjects();
 
     // Ensures the directories exist
     mkdirSync(this.iterationPath, { recursive: true });
+  }
+
+  private resolveWorkspaceProjects(): Array<{
+    name: string;
+    path: string;
+    repository?: string;
+    ref?: string;
+    languages?: string[];
+    packageManagers?: string[];
+  }> {
+    const persistedProjects = this.getPersistedWorkspaceProjects();
+    if (persistedProjects) {
+      return persistedProjects;
+    }
+
+    return (this.projectConfig.projects ?? [])
+      .filter(
+        (
+          project
+        ): project is {
+          name: string;
+          path: string;
+          repository?: string;
+          ref?: string;
+          languages?: string[];
+          packageManagers?: string[];
+        } =>
+          typeof project?.name === 'string' && typeof project?.path === 'string'
+      )
+      .map(project => ({
+        name: project.name,
+        path: project.path,
+        repository: project.repository,
+        ref: project.ref,
+        languages: project.languages ?? [],
+        packageManagers: project.packageManagers ?? [],
+      }));
+  }
+
+  private getPersistedWorkspaceProjects():
+    | Array<{
+        name: string;
+        path: string;
+        repository?: string;
+        ref?: string;
+        languages?: string[];
+        packageManagers?: string[];
+      }>
+    | undefined {
+    const iterationsPath = join(this.taskBasePath, 'iterations');
+    if (!existsSync(iterationsPath)) {
+      return undefined;
+    }
+
+    const iterationIds = readdirSync(iterationsPath, { withFileTypes: true })
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => Number.parseInt(dirent.name, 10))
+      .filter(iteration => !Number.isNaN(iteration))
+      .sort((a, b) => b - a);
+
+    for (const iterationId of iterationIds) {
+      const descriptionPath = join(
+        iterationsPath,
+        iterationId.toString(),
+        'workspace-description.json'
+      );
+      if (!existsSync(descriptionPath)) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(readFileSync(descriptionPath, 'utf8')) as {
+          projects?: Array<{
+            name?: unknown;
+            path?: unknown;
+            repository?: unknown;
+            ref?: unknown;
+            languages?: unknown;
+            packageManagers?: unknown;
+          }>;
+        };
+
+        return (Array.isArray(parsed.projects) ? parsed.projects : [])
+          .filter(
+            (
+              project
+            ): project is {
+              name: string;
+              path: string;
+              repository?: string;
+              ref?: string;
+              languages?: string[];
+              packageManagers?: string[];
+            } =>
+              typeof project?.name === 'string' &&
+              typeof project?.path === 'string'
+          )
+          .map(project => ({
+            name: project.name,
+            path: project.path,
+            repository:
+              typeof project.repository === 'string'
+                ? project.repository
+                : undefined,
+            ref: typeof project.ref === 'string' ? project.ref : undefined,
+            languages: Array.isArray(project.languages)
+              ? project.languages.filter(
+                  (language): language is string => typeof language === 'string'
+                )
+              : [],
+            packageManagers: Array.isArray(project.packageManagers)
+              ? project.packageManagers.filter(
+                  (pm): pm is string => typeof pm === 'string'
+                )
+              : [],
+          }));
+      } catch {
+        continue;
+      }
+    }
+
+    return undefined;
+  }
+
+  private getEffectiveAllLanguages(): string[] {
+    return [
+      ...new Set([
+        ...(this.projectConfig.languages ?? []),
+        ...this.workspaceProjects.flatMap(project => project.languages ?? []),
+      ]),
+    ];
+  }
+
+  private getEffectiveAllPackageManagers(): string[] {
+    return [
+      ...new Set([
+        ...(this.projectConfig.packageManagers ?? []),
+        ...this.workspaceProjects.flatMap(
+          project => project.packageManagers ?? []
+        ),
+      ]),
+    ];
   }
 
   /**
@@ -105,7 +258,7 @@ export class SetupBuilder {
   private getLanguagePackages(): SandboxPackage[] {
     const packages: SandboxPackage[] = [];
 
-    for (const language of this.projectConfig.allLanguages ?? []) {
+    for (const language of this.getEffectiveAllLanguages()) {
       switch (language) {
         case 'javascript':
           packages.push(new JavaScriptSandboxPackage());
@@ -143,7 +296,7 @@ export class SetupBuilder {
   private getPackageManagerPackages(): SandboxPackage[] {
     const packages: SandboxPackage[] = [];
 
-    for (const packageManager of this.projectConfig.allPackageManagers ?? []) {
+    for (const packageManager of this.getEffectiveAllPackageManagers()) {
       switch (packageManager) {
         case 'npm':
           packages.push(new NpmSandboxPackage());
@@ -210,7 +363,7 @@ export class SetupBuilder {
   private getDependencyResolutionCommands(): string[] {
     return getDependencyResolutionCommands({
       rootPackageManagers: this.projectConfig.packageManagers ?? [],
-      projects: this.projectConfig.projects,
+      projects: this.workspaceProjects,
       addVenvPathExports: true,
     });
   }
@@ -507,7 +660,7 @@ ${scriptBlocks.join('\n')}
 
     // --- external project repositories ---
     let projectRepositoriesSection = '';
-    const projectsWithRepositories = (this.projectConfig.projects || []).filter(
+    const projectsWithRepositories = this.workspaceProjects.filter(
       project => project.repository
     );
 
@@ -823,7 +976,7 @@ echo "======================================="
    * Returns the file path, or undefined if no projects are configured.
    */
   generateWorkspaceDescription(): string | undefined {
-    const projects = this.projectConfig.projects;
+    const projects = this.workspaceProjects;
     if (!projects || projects.length === 0) {
       return undefined;
     }

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -21,6 +21,7 @@ import type { SandboxPackage } from './sandbox/types.js';
 import { mergeNetworkConfig, generateNetworkScript } from './network-config.js';
 import { initWorkflowStore } from './workflow.js';
 import { getDependencyResolutionCommands } from './dependency-resolution.js';
+import { shellEscape } from '../utils/shell.js';
 
 // Language packages
 import { JavaScriptSandboxPackage } from './sandbox/languages/javascript.js';
@@ -204,13 +205,6 @@ export class SetupBuilder {
     }
 
     return packages;
-  }
-
-  /**
-   * Safely single-quote a value for shell interpolation.
-   */
-  private shellEscape(value: string): string {
-    return `'${value.replace(/'/g, `'\"'\"'`)}'`;
   }
 
   private getDependencyResolutionCommands(): string[] {
@@ -407,21 +401,21 @@ fi`;
       if (mcps && mcps.length > 0) {
         configureAllMCPCommands.push('echo "✅ Configuring custom MCPs"');
         for (const mcp of mcps) {
-          let cmd = `rover-agent config mcp ${this.agent} ${this.shellEscape(mcp.name)} --transport ${this.shellEscape(mcp.transport)}`;
+          let cmd = `rover-agent config mcp ${this.agent} ${shellEscape(mcp.name)} --transport ${shellEscape(mcp.transport)}`;
 
           if (mcp.envs && mcp.envs.length > 0) {
             for (const env of mcp.envs) {
-              cmd += ` --env ${this.shellEscape(env)}`;
+              cmd += ` --env ${shellEscape(env)}`;
             }
           }
 
           if (mcp.headers && mcp.headers.length > 0) {
             for (const header of mcp.headers) {
-              cmd += ` --header ${this.shellEscape(header)}`;
+              cmd += ` --header ${shellEscape(header)}`;
             }
           }
 
-          cmd += ` ${this.shellEscape(mcp.commandOrUrl)}`;
+          cmd += ` ${shellEscape(mcp.commandOrUrl)}`;
 
           configureAllMCPCommands.push(cmd);
         }
@@ -474,10 +468,8 @@ echo -e "\\n📦 Done installing MCP servers"`;
       for (const { entry, index } of executableInitScripts) {
         const label = entry.path ? ` (${entry.path})` : '';
         if (entry.path) {
-          const escapedWorkspacePath = this.shellEscape(
-            `/workspace/${entry.path}`
-          );
-          const escapedWorkspaceScript = this.shellEscape(
+          const escapedWorkspacePath = shellEscape(`/workspace/${entry.path}`);
+          const escapedWorkspaceScript = shellEscape(
             `/workspace/${entry.path}/${entry.script}`
           );
           scriptBlocks.push(`echo "🔧 Running initialization script${label}"
@@ -494,7 +486,7 @@ cd /workspace`);
           continue;
         }
 
-        const escapedWorkspaceScript = this.shellEscape(
+        const escapedWorkspaceScript = shellEscape(
           `/workspace/${entry.script}`
         );
         scriptBlocks.push(`echo "🔧 Running initialization script${label}"
@@ -523,7 +515,7 @@ ${scriptBlocks.join('\n')}
 
     if (projectsWithRepositories.length > 0) {
       const taskBranch = this.task.branchName || `task/${this.task.id}`;
-      const escapedTaskBranch = this.shellEscape(taskBranch);
+      const escapedTaskBranch = shellEscape(taskBranch);
       const repositoryStateFunctions = `
 compute_repo_untracked_hash() {
   local repo_path="$1"
@@ -604,11 +596,11 @@ NODE
 
       const syncBlocks = projectsWithRepositories.map(project => {
         const targetPath = `/workspace/${project.path}`;
-        const escapedName = this.shellEscape(project.name);
-        const escapedPath = this.shellEscape(targetPath);
-        const escapedRepository = this.shellEscape(project.repository!);
-        const escapedRef = project.ref ? this.shellEscape(project.ref) : '';
-        const checkpointLookupScript = this.shellEscape(
+        const escapedName = shellEscape(project.name);
+        const escapedPath = shellEscape(targetPath);
+        const escapedRepository = shellEscape(project.repository!);
+        const escapedRef = project.ref ? shellEscape(project.ref) : '';
+        const checkpointLookupScript = shellEscape(
           `const fs=require('fs'); const checkpoint=JSON.parse(fs.readFileSync('/output/checkpoint.json','utf8')); const entry=(checkpoint.externalRepositories||[]).find(repo => repo.path === ${JSON.stringify(project.path)}); if (!entry) process.exit(2); process.stdout.write([entry.head, entry.trackedDiffHash, entry.untrackedHash].join('\\t'));`
         );
 

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -20,6 +20,7 @@ import pupa from 'pupa';
 import type { SandboxPackage } from './sandbox/types.js';
 import { mergeNetworkConfig, generateNetworkScript } from './network-config.js';
 import { initWorkflowStore } from './workflow.js';
+import { getDependencyResolutionCommands } from './dependency-resolution.js';
 
 // Language packages
 import { JavaScriptSandboxPackage } from './sandbox/languages/javascript.js';
@@ -213,99 +214,11 @@ export class SetupBuilder {
   }
 
   private getDependencyResolutionCommands(): string[] {
-    const commands: string[] = [];
-    const locations = [
-      {
-        path: '/workspace',
-        packageManagers: this.projectConfig.packageManagers ?? [],
-        label: 'workspace root',
-      },
-      ...(this.projectConfig.projects ?? []).map(project => ({
-        path: `/workspace/${project.path}`,
-        packageManagers: project.packageManagers ?? [],
-        label: project.path,
-      })),
-    ];
-
-    for (const location of locations) {
-      const quotedPath = this.shellEscape(location.path);
-      const pms = location.packageManagers;
-
-      if (pms.includes('uv')) {
-        commands.push(
-          `if [ -f ${quotedPath}/pyproject.toml ]; then`,
-          `  echo "📦 Resolving Python dependencies (uv) in ${location.label}..."`,
-          `  cd ${quotedPath} && uv sync --frozen --all-extras 2>/dev/null || uv sync --all-extras 2>/dev/null || uv sync 2>/dev/null || true`,
-          `  if [ -d ${quotedPath}/.venv/bin ]; then`,
-          `    export PATH="${location.path}/.venv/bin:$PATH"`,
-          `    echo 'export PATH="${location.path}/.venv/bin:$PATH"' >> $HOME/.profile`,
-          '  fi',
-          'fi'
-        );
-      }
-
-      if (pms.includes('poetry')) {
-        commands.push(
-          `if [ -f ${quotedPath}/pyproject.toml ]; then`,
-          `  echo "📦 Resolving Python dependencies (poetry) in ${location.label}..."`,
-          `  cd ${quotedPath} && poetry install --no-interaction 2>/dev/null || true`,
-          'fi'
-        );
-      }
-
-      if (pms.includes('pub')) {
-        commands.push(
-          `if [ -f ${quotedPath}/pubspec.yaml ]; then`,
-          `  echo "📦 Resolving Dart dependencies in ${location.label}..."`,
-          `  cd ${quotedPath} && flutter pub get 2>/dev/null || dart pub get 2>/dev/null || true`,
-          'fi'
-        );
-      }
-
-      if (pms.includes('pnpm')) {
-        commands.push(
-          `if [ -f ${quotedPath}/pnpm-lock.yaml ]; then`,
-          `  echo "📦 Resolving Node dependencies (pnpm) in ${location.label}..."`,
-          `  cd ${quotedPath} && pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true`,
-          'fi'
-        );
-      }
-
-      if (pms.includes('npm')) {
-        commands.push(
-          `if [ -f ${quotedPath}/package-lock.json ]; then`,
-          `  echo "📦 Resolving Node dependencies (npm) in ${location.label}..."`,
-          `  cd ${quotedPath} && npm ci 2>/dev/null || npm install 2>/dev/null || true`,
-          'fi'
-        );
-      }
-
-      if (pms.includes('yarn')) {
-        commands.push(
-          `if [ -f ${quotedPath}/yarn.lock ]; then`,
-          `  echo "📦 Resolving Node dependencies (yarn) in ${location.label}..."`,
-          `  cd ${quotedPath} && yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true`,
-          'fi'
-        );
-      }
-
-      if (pms.includes('gomod')) {
-        commands.push(
-          `if [ -f ${quotedPath}/go.mod ]; then`,
-          `  echo "📦 Resolving Go dependencies in ${location.label}..."`,
-          `  cd ${quotedPath} && go mod download 2>/dev/null || true`,
-          `elif [ -f ${quotedPath}/src/go.mod ]; then`,
-          `  cd ${quotedPath}/src && go mod download 2>/dev/null || true`,
-          'fi'
-        );
-      }
-    }
-
-    if (commands.length > 0) {
-      commands.push('cd /workspace');
-    }
-
-    return commands;
+    return getDependencyResolutionCommands({
+      rootPackageManagers: this.projectConfig.packageManagers ?? [],
+      projects: this.projectConfig.projects,
+      addVenvPathExports: true,
+    });
   }
 
   /**
@@ -360,7 +273,12 @@ sudo chown -R $(id -u):$(id -g) /workspace
 source $HOME/.profile`;
     }
 
-    const gitSafeDirectorySetup = `# Allow git operations across mounted workspaces and embedded repositories
+    // SECURITY NOTE: Disabling git's directory ownership check with '*' is safe here
+    // because this only runs inside ephemeral, single-user task containers where the
+    // workspace is bind-mounted with a different UID than the container user.
+    const gitSafeDirectorySetup = `# Allow git operations across mounted workspaces and embedded repositories.
+# This is safe inside ephemeral task containers — the wildcard disables ownership
+# checks that would otherwise block operations on bind-mounted directories.
 git config --global --add safe.directory '*' 2>/dev/null || true
 git config --system --add safe.directory '*' 2>/dev/null || true`;
 
@@ -565,7 +483,7 @@ echo -e "\\n📦 Done installing MCP servers"`;
           scriptBlocks.push(`echo "🔧 Running initialization script${label}"
 chmod +x ${escapedWorkspaceScript}
 cd ${escapedWorkspacePath}
-${escapedWorkspaceScript}
+bash ${escapedWorkspaceScript}
 if [ $? -eq 0 ]; then
   echo "✅ Initialization script${label} completed successfully"
 else
@@ -581,7 +499,7 @@ cd /workspace`);
         );
         scriptBlocks.push(`echo "🔧 Running initialization script${label}"
 chmod +x ${escapedWorkspaceScript}
-${escapedWorkspaceScript}
+bash ${escapedWorkspaceScript}
 if [ $? -eq 0 ]; then
   echo "✅ Initialization script${label} completed successfully"
 else

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -29,7 +29,10 @@ import {
   isSafeRelativePath,
   resolvePathWithinRoot,
 } from '../utils/path-safety.js';
-import { isLocalRepositoryReference } from '../utils/repository-reference.js';
+import {
+  isLocalRepositoryReference,
+  resolveRepositoryHostPath,
+} from '../utils/repository-reference.js';
 
 import { getRootInitScriptMountPath } from './sandbox/container-common.js';
 import { getPackagesFromConfig } from './sandbox/packages.js';
@@ -291,7 +294,7 @@ export class SetupBuilder {
       this.projectConfig.projectRoot ?? this.taskBasePath;
     const hostPath = repository.startsWith('file://')
       ? fileURLToPath(repository)
-      : resolve(repositoryResolutionRoot, repository);
+      : resolveRepositoryHostPath(repository, repositoryResolutionRoot);
 
     if (!existsSync(hostPath)) {
       throw new Error(`Local workspace repository not found: ${hostPath}`);
@@ -713,9 +716,6 @@ NODE
           project.runtimeRepository ?? project.repository!
         );
         const escapedRef = project.ref ? shellEscape(project.ref) : '';
-        const requiresCheckpointRepoState =
-          typeof project.repository === 'string' &&
-          !isLocalRepositoryReference(project.repository);
         const checkpointLookupScript = shellEscape(
           `const fs=require('fs'); const checkpoint=JSON.parse(fs.readFileSync('/output/checkpoint.json','utf8')); const entry=(checkpoint.externalRepositories||[]).find(repo => repo.path === ${JSON.stringify(project.path)}); if (!entry) process.exit(2); process.stdout.write([entry.head, entry.trackedDiffHash, entry.untrackedHash].join('\\t'));`
         );
@@ -748,8 +748,7 @@ else
 fi`;
 
         if (this.resumeFromCheckpoint) {
-          const checkpointStateValidation = requiresCheckpointRepoState
-            ? `if ! expected_state=$(node -e ${checkpointLookupScript}); then
+          const checkpointStateValidation = `if ! expected_state=$(node -e ${checkpointLookupScript}); then
   echo "❌ Checkpoint is missing repository state for ${escapedName}; cannot resume safely"
   safe_exit 1
 fi
@@ -760,8 +759,7 @@ current_untracked_hash=$(compute_repo_untracked_hash ${escapedPath})
 if [ "$current_head" != "$expected_head" ] || [ "$current_tracked_diff_hash" != "$expected_tracked_diff_hash" ] || [ "$current_untracked_hash" != "$expected_untracked_hash" ]; then
   echo "❌ Repository ${escapedName} no longer matches the checkpointed revision"
   safe_exit 1
-fi`
-            : '';
+fi`;
           return `echo "📥 Verifying repository ${escapedName} for checkpoint resume"
 if [ ! -d ${escapedPath}/.git ]; then
   echo "❌ Repository ${escapedName} is missing at ${escapedPath}; cannot resume from checkpoint safely"

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -738,13 +738,19 @@ else
 fi`
           : `
 default_remote_ref=$(git -C ${escapedPath} symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
-if [ -z "$default_remote_ref" ]; then
-  echo "❌ Could not determine default remote branch for ${escapedName}"
-  safe_exit 1
-fi
-default_branch="\${default_remote_ref#origin/}"
-echo "🔀 Checking out default branch $default_branch for ${escapedName}"
-git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"`;
+if [ -n "$default_remote_ref" ]; then
+  default_branch="\${default_remote_ref#origin/}"
+  echo "🔀 Checking out default branch $default_branch for ${escapedName}"
+  git -C ${escapedPath} checkout -B "$default_branch" "$default_remote_ref"
+else
+  current_branch=$(git -C ${escapedPath} branch --show-current 2>/dev/null || true)
+  if [ -n "$current_branch" ] && git -C ${escapedPath} rev-parse --verify refs/remotes/origin/$current_branch >/dev/null 2>&1; then
+    echo "🔀 Remote HEAD not advertised for ${escapedName}; reusing checked out branch $current_branch"
+    git -C ${escapedPath} checkout -B "$current_branch" "refs/remotes/origin/$current_branch"
+  else
+    echo "🔀 Remote HEAD not advertised for ${escapedName}; keeping current checkout"
+  fi
+fi`;
 
         if (this.resumeFromCheckpoint) {
           return `echo "📥 Verifying repository ${escapedName} for checkpoint resume"

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -25,33 +25,7 @@ import { initWorkflowStore } from './workflow.js';
 import { getDependencyResolutionCommands } from './dependency-resolution.js';
 import { shellEscape } from '../utils/shell.js';
 
-// Language packages
-import { JavaScriptSandboxPackage } from './sandbox/languages/javascript.js';
-import { TypeScriptSandboxPackage } from './sandbox/languages/typescript.js';
-import { PHPSandboxPackage } from './sandbox/languages/php.js';
-import { RustSandboxPackage } from './sandbox/languages/rust.js';
-import { GoSandboxPackage } from './sandbox/languages/go.js';
-import { PythonSandboxPackage } from './sandbox/languages/python.js';
-import { RubySandboxPackage } from './sandbox/languages/ruby.js';
-import { DartSandboxPackage } from './sandbox/languages/dart.js';
-
-// Package manager packages
-import { NpmSandboxPackage } from './sandbox/package-managers/npm.js';
-import { PnpmSandboxPackage } from './sandbox/package-managers/pnpm.js';
-import { YarnSandboxPackage } from './sandbox/package-managers/yarn.js';
-import { ComposerSandboxPackage } from './sandbox/package-managers/composer.js';
-import { CargoSandboxPackage } from './sandbox/package-managers/cargo.js';
-import { GomodSandboxPackage } from './sandbox/package-managers/gomod.js';
-import { PipSandboxPackage } from './sandbox/package-managers/pip.js';
-import { PoetrySandboxPackage } from './sandbox/package-managers/poetry.js';
-import { UvSandboxPackage } from './sandbox/package-managers/uv.js';
-import { RubygemsSandboxPackage } from './sandbox/package-managers/rubygems.js';
-import { PubSandboxPackage } from './sandbox/package-managers/pub.js';
-
-// Task manager packages
-import { JustSandboxPackage } from './sandbox/task-managers/just.js';
-import { MakeSandboxPackage } from './sandbox/task-managers/make.js';
-import { TaskSandboxPackage } from './sandbox/task-managers/task.js';
+import { getPackagesFromConfig } from './sandbox/packages.js';
 
 /**
  * SetupBuilder class - Consolidates Docker setup script generation
@@ -232,134 +206,6 @@ export class SetupBuilder {
     return undefined;
   }
 
-  private getEffectiveAllLanguages(): string[] {
-    return [
-      ...new Set([
-        ...(this.projectConfig.languages ?? []),
-        ...this.workspaceProjects.flatMap(project => project.languages ?? []),
-      ]),
-    ];
-  }
-
-  private getEffectiveAllPackageManagers(): string[] {
-    return [
-      ...new Set([
-        ...(this.projectConfig.packageManagers ?? []),
-        ...this.workspaceProjects.flatMap(
-          project => project.packageManagers ?? []
-        ),
-      ]),
-    ];
-  }
-
-  /**
-   * Get language sandbox packages based on project configuration
-   */
-  private getLanguagePackages(): SandboxPackage[] {
-    const packages: SandboxPackage[] = [];
-
-    for (const language of this.getEffectiveAllLanguages()) {
-      switch (language) {
-        case 'javascript':
-          packages.push(new JavaScriptSandboxPackage());
-          break;
-        case 'typescript':
-          packages.push(new TypeScriptSandboxPackage());
-          break;
-        case 'php':
-          packages.push(new PHPSandboxPackage());
-          break;
-        case 'rust':
-          packages.push(new RustSandboxPackage());
-          break;
-        case 'go':
-          packages.push(new GoSandboxPackage());
-          break;
-        case 'python':
-          packages.push(new PythonSandboxPackage());
-          break;
-        case 'ruby':
-          packages.push(new RubySandboxPackage());
-          break;
-        case 'dart':
-          packages.push(new DartSandboxPackage());
-          break;
-      }
-    }
-
-    return packages;
-  }
-
-  /**
-   * Get package manager sandbox packages based on project configuration
-   */
-  private getPackageManagerPackages(): SandboxPackage[] {
-    const packages: SandboxPackage[] = [];
-
-    for (const packageManager of this.getEffectiveAllPackageManagers()) {
-      switch (packageManager) {
-        case 'npm':
-          packages.push(new NpmSandboxPackage());
-          break;
-        case 'pnpm':
-          packages.push(new PnpmSandboxPackage());
-          break;
-        case 'yarn':
-          packages.push(new YarnSandboxPackage());
-          break;
-        case 'composer':
-          packages.push(new ComposerSandboxPackage());
-          break;
-        case 'cargo':
-          packages.push(new CargoSandboxPackage());
-          break;
-        case 'gomod':
-          packages.push(new GomodSandboxPackage());
-          break;
-        case 'pip':
-          packages.push(new PipSandboxPackage());
-          break;
-        case 'poetry':
-          packages.push(new PoetrySandboxPackage());
-          break;
-        case 'uv':
-          packages.push(new UvSandboxPackage());
-          break;
-        case 'rubygems':
-          packages.push(new RubygemsSandboxPackage());
-          break;
-        case 'pub':
-          packages.push(new PubSandboxPackage());
-          break;
-      }
-    }
-
-    return packages;
-  }
-
-  /**
-   * Get task manager sandbox packages based on project configuration
-   */
-  private getTaskManagerPackages(): SandboxPackage[] {
-    const packages: SandboxPackage[] = [];
-
-    for (const taskManager of this.projectConfig.allTaskManagers ?? []) {
-      switch (taskManager) {
-        case 'just':
-          packages.push(new JustSandboxPackage());
-          break;
-        case 'make':
-          packages.push(new MakeSandboxPackage());
-          break;
-        case 'task':
-          packages.push(new TaskSandboxPackage());
-          break;
-      }
-    }
-
-    return packages;
-  }
-
   private getDependencyResolutionCommands(): string[] {
     return getDependencyResolutionCommands({
       rootPackageManagers: this.projectConfig.packageManagers ?? [],
@@ -442,15 +288,7 @@ git config --system --add safe.directory '*' 2>/dev/null || true`;
     // --- package installation ---
     let installAllPackages = '';
     if (!useCachedImage) {
-      const languagePackages = this.getLanguagePackages();
-      const packageManagerPackages = this.getPackageManagerPackages();
-      const taskManagerPackages = this.getTaskManagerPackages();
-
-      const allPackages = [
-        ...languagePackages,
-        ...packageManagerPackages,
-        ...taskManagerPackages,
-      ];
+      const allPackages = getPackagesFromConfig(this.projectConfig);
 
       if (allPackages.length > 0) {
         const installScripts: string[] = [];

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -8,7 +8,6 @@ import {
   readdirSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import {
   TaskDescriptionManager,
   IterationManager,
@@ -31,7 +30,7 @@ import {
 } from '../utils/path-safety.js';
 import {
   isLocalRepositoryReference,
-  resolveRepositoryHostPath,
+  resolveLocalRepositoryReference,
 } from '../utils/repository-reference.js';
 
 import { getRootInitScriptMountPath } from './sandbox/container-common.js';
@@ -292,9 +291,10 @@ export class SetupBuilder {
 
     const repositoryResolutionRoot =
       this.projectConfig.projectRoot ?? this.taskBasePath;
-    const hostPath = repository.startsWith('file://')
-      ? fileURLToPath(repository)
-      : resolveRepositoryHostPath(repository, repositoryResolutionRoot);
+    const hostPath = resolveLocalRepositoryReference(
+      repository,
+      repositoryResolutionRoot
+    );
 
     if (!existsSync(hostPath)) {
       throw new Error(`Local workspace repository not found: ${hostPath}`);

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -281,11 +281,9 @@ git config --system --add safe.directory '*' 2>/dev/null || true`;
     // which can't be done during image build (/workspace is read-only).
     // Resolve deps here since /workspace is now read-write.
     let workspaceDeps = '';
-    if (useCachedImage) {
-      const depCmds = this.getDependencyResolutionCommands();
-      if (depCmds.length > 0) {
-        workspaceDeps = depCmds.join('\n');
-      }
+    const depCmds = this.getDependencyResolutionCommands();
+    if (depCmds.length > 0) {
+      workspaceDeps = depCmds.join('\n');
     }
 
     // --- package installation ---

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -27,6 +27,18 @@ import { shellEscape } from '../utils/shell.js';
 
 import { getPackagesFromConfig } from './sandbox/packages.js';
 
+function isSafeWorkspaceProjectPath(projectPath: string): boolean {
+  if (projectPath.startsWith('/') || projectPath.length === 0) {
+    return false;
+  }
+
+  const normalized = projectPath
+    .split('/')
+    .filter(segment => segment.length > 0);
+
+  return normalized.length > 0 && normalized.every(segment => segment !== '..');
+}
+
 /**
  * SetupBuilder class - Consolidates Docker setup script generation
  * Replaces the existing docker-setup.sh and docker-setup-gemini.sh files
@@ -98,27 +110,21 @@ export class SetupBuilder {
     }
 
     return (this.projectConfig.projects ?? [])
-      .filter(
-        (
-          project
-        ): project is {
-          name: string;
-          path: string;
-          repository?: string;
-          ref?: string;
-          languages?: string[];
-          packageManagers?: string[];
-        } =>
-          typeof project?.name === 'string' && typeof project?.path === 'string'
+      .flatMap(project =>
+        typeof project?.name === 'string' && typeof project?.path === 'string'
+          ? [
+              {
+                name: project.name,
+                path: project.path,
+                repository: project.repository,
+                ref: project.ref,
+                languages: project.languages ?? [],
+                packageManagers: project.packageManagers ?? [],
+              },
+            ]
+          : []
       )
-      .map(project => ({
-        name: project.name,
-        path: project.path,
-        repository: project.repository,
-        ref: project.ref,
-        languages: project.languages ?? [],
-        packageManagers: project.packageManagers ?? [],
-      }));
+      .filter(project => isSafeWorkspaceProjectPath(project.path));
   }
 
   private getPersistedWorkspaceProjects():
@@ -165,39 +171,35 @@ export class SetupBuilder {
         };
 
         return (Array.isArray(parsed.projects) ? parsed.projects : [])
-          .filter(
-            (
-              project
-            ): project is {
-              name: string;
-              path: string;
-              repository?: string;
-              ref?: string;
-              languages?: string[];
-              packageManagers?: string[];
-            } =>
-              typeof project?.name === 'string' &&
-              typeof project?.path === 'string'
+          .flatMap(project =>
+            typeof project?.name === 'string' &&
+            typeof project?.path === 'string'
+              ? [
+                  {
+                    name: project.name,
+                    path: project.path,
+                    repository:
+                      typeof project.repository === 'string'
+                        ? project.repository
+                        : undefined,
+                    ref:
+                      typeof project.ref === 'string' ? project.ref : undefined,
+                    languages: Array.isArray(project.languages)
+                      ? project.languages.filter(
+                          (language): language is string =>
+                            typeof language === 'string'
+                        )
+                      : [],
+                    packageManagers: Array.isArray(project.packageManagers)
+                      ? project.packageManagers.filter(
+                          (pm): pm is string => typeof pm === 'string'
+                        )
+                      : [],
+                  },
+                ]
+              : []
           )
-          .map(project => ({
-            name: project.name,
-            path: project.path,
-            repository:
-              typeof project.repository === 'string'
-                ? project.repository
-                : undefined,
-            ref: typeof project.ref === 'string' ? project.ref : undefined,
-            languages: Array.isArray(project.languages)
-              ? project.languages.filter(
-                  (language): language is string => typeof language === 'string'
-                )
-              : [],
-            packageManagers: Array.isArray(project.packageManagers)
-              ? project.packageManagers.filter(
-                  (pm): pm is string => typeof pm === 'string'
-                )
-              : [],
-          }));
+          .filter(project => isSafeWorkspaceProjectPath(project.path));
       } catch {
         continue;
       }
@@ -648,7 +650,10 @@ echo "✅ Repository ${escapedName} is ready for checkpoint resume"`;
 mkdir -p "$(dirname ${escapedPath})"
 if [ ! -d ${escapedPath}/.git ]; then
   rm -rf ${escapedPath}
-  git clone ${escapedRepository} ${escapedPath}
+  if ! git clone ${escapedRepository} ${escapedPath}; then
+    echo "❌ Failed to clone repository ${escapedName}"
+    safe_exit 1
+  fi
 else
   current_origin=$(git -C ${escapedPath} remote get-url origin 2>/dev/null || true)
   if [ "$current_origin" != ${escapedRepository} ]; then

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -452,14 +452,22 @@ echo -e "\\n📦 Done installing MCP servers"`;
       for (const { entry, index } of executableInitScripts) {
         const label = entry.path ? ` (${entry.path})` : '';
         if (entry.path) {
-          const escapedWorkspacePath = shellEscape(`/workspace/${entry.path}`);
-          const escapedWorkspaceScript = shellEscape(
-            `/workspace/${entry.path}/${entry.script}`
-          );
           scriptBlocks.push(`echo "🔧 Running initialization script${label}"
-chmod +x ${escapedWorkspaceScript}
-cd ${escapedWorkspacePath}
-bash ${escapedWorkspaceScript}
+workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
+workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
+if [ -f "$workspace_root_script_${index}" ]; then
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
+elif [ -f "$workspace_project_script_${index}" ]; then
+  workspace_script_${index}="$workspace_project_script_${index}"
+  workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
+else
+  workspace_script_${index}="$workspace_root_script_${index}"
+  workspace_dir_${index}='/workspace'
+fi
+chmod +x "$workspace_script_${index}"
+cd "$workspace_dir_${index}"
+bash "$workspace_script_${index}"
 if [ $? -eq 0 ]; then
   echo "✅ Initialization script${label} completed successfully"
 else

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -101,38 +101,37 @@ export class SetupBuilder {
     packageManagers?: string[];
   }> {
     const persistedProjects = this.getPersistedWorkspaceProjects();
-    if (persistedProjects) {
+    if (persistedProjects !== undefined) {
       return persistedProjects;
     }
 
-    return (this.projectConfig.projects ?? [])
-      .flatMap((project, index) => {
-        if (
-          typeof project?.name !== 'string' ||
-          typeof project?.path !== 'string'
-        ) {
-          return [];
-        }
+    return (this.projectConfig.projects ?? []).flatMap((project, index) => {
+      if (
+        typeof project?.name !== 'string' ||
+        typeof project?.path !== 'string' ||
+        !isSafeRelativePath(project.path)
+      ) {
+        return [];
+      }
 
-        const repositoryMount = this.resolveRepositoryMount(
-          project.repository,
-          index
-        );
+      const repositoryMount = this.resolveRepositoryMount(
+        project.repository,
+        index
+      );
 
-        return [
-          {
-            name: project.name,
-            path: project.path,
-            repository: project.repository,
-            runtimeRepository:
-              repositoryMount?.containerPath ?? project.repository,
-            ref: project.ref,
-            languages: project.languages ?? [],
-            packageManagers: project.packageManagers ?? [],
-          },
-        ];
-      })
-      .filter(project => isSafeRelativePath(project.path));
+      return [
+        {
+          name: project.name,
+          path: project.path,
+          repository: project.repository,
+          runtimeRepository:
+            repositoryMount?.containerPath ?? project.repository,
+          ref: project.ref,
+          languages: project.languages ?? [],
+          packageManagers: project.packageManagers ?? [],
+        },
+      ];
+    });
   }
 
   private getPersistedWorkspaceProjects():
@@ -157,6 +156,10 @@ export class SetupBuilder {
       .filter(iteration => !Number.isNaN(iteration))
       .sort((a, b) => b - a);
 
+    if (iterationIds.length === 0) {
+      return undefined;
+    }
+
     for (const iterationId of iterationIds) {
       const descriptionPath = join(
         iterationsPath,
@@ -179,11 +182,12 @@ export class SetupBuilder {
           }>;
         };
 
-        return (Array.isArray(parsed.projects) ? parsed.projects : [])
-          .flatMap((project, index) => {
+        return (Array.isArray(parsed.projects) ? parsed.projects : []).flatMap(
+          (project, index) => {
             if (
               typeof project?.name !== 'string' ||
-              typeof project?.path !== 'string'
+              typeof project?.path !== 'string' ||
+              !isSafeRelativePath(project.path)
             ) {
               return [];
             }
@@ -217,14 +221,14 @@ export class SetupBuilder {
                   : [],
               },
             ];
-          })
-          .filter(project => isSafeRelativePath(project.path));
+          }
+        );
       } catch {
         continue;
       }
     }
 
-    return undefined;
+    return [];
   }
 
   private isLocalRepositoryReference(repository: string): boolean {
@@ -518,17 +522,13 @@ echo -e "\\n📦 Done installing MCP servers"`;
         const label = entry.path ? ` (${entry.path})` : '';
         if (entry.path) {
           scriptBlocks.push(`echo "🔧 Running initialization script${label}"
-workspace_root_script_${index}=${shellEscape(`/workspace/${entry.script}`)}
 workspace_project_script_${index}=${shellEscape(`/workspace/${entry.path}/${entry.script}`)}
 if [ -f "$workspace_project_script_${index}" ]; then
   workspace_script_${index}="$workspace_project_script_${index}"
   workspace_dir_${index}=${shellEscape(`/workspace/${entry.path}`)}
-elif [ -f "$workspace_root_script_${index}" ]; then
-  workspace_script_${index}="$workspace_root_script_${index}"
-  workspace_dir_${index}='/workspace'
 else
-  workspace_script_${index}="$workspace_root_script_${index}"
-  workspace_dir_${index}='/workspace'
+  echo "❌ Initialization script${label} not found at $workspace_project_script_${index}"
+  safe_exit 1
 fi
 chmod +x "$workspace_script_${index}"
 cd "$workspace_dir_${index}"
@@ -745,7 +745,9 @@ else
   git -C ${escapedPath} checkout -B ${escapedTaskBranch} HEAD
 fi
 git -C ${escapedPath} reset --hard HEAD
-git -C ${escapedPath} clean -fd
+# Remove ignored files too so restarted tasks do not inherit stale child-repo
+# build outputs, caches, or generated artifacts from prior runs.
+git -C ${escapedPath} clean -fdx
 echo "✅ Repository ${escapedName} is ready"`;
       });
 

--- a/packages/cli/src/lib/workflows/swe-tdd.yml
+++ b/packages/cli/src/lib/workflows/swe-tdd.yml
@@ -139,9 +139,9 @@ steps:
     type: command
     name: 'Persist Context'
     command: |
-      cat > /output/context.md <<'EOF'
+      cat > /output/context.md <<'ROVER_PERSIST_BLOCK'
       {{steps.context.outputs.context_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: plan
     type: agent
@@ -230,9 +230,9 @@ steps:
     type: command
     name: 'Persist Plan'
     command: |
-      cat > /output/plan.md <<'EOF'
+      cat > /output/plan.md <<'ROVER_PERSIST_BLOCK'
       {{steps.plan.outputs.plan_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: write_tests
     type: agent
@@ -304,9 +304,9 @@ steps:
     type: command
     name: 'Persist Test Changes'
     command: |
-      cat > /output/test_changes.md <<'EOF'
+      cat > /output/test_changes.md <<'ROVER_PERSIST_BLOCK'
       {{steps.write_tests.outputs.test_changes_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: implement
     type: agent
@@ -390,9 +390,9 @@ steps:
     type: command
     name: 'Persist Changes'
     command: |
-      cat > /output/changes.md <<'EOF'
+      cat > /output/changes.md <<'ROVER_PERSIST_BLOCK'
       {{steps.implement.outputs.changes_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: test_fix_loop
     type: loop
@@ -623,18 +623,18 @@ steps:
         name: 'Persist Review'
         if: steps.code_review.outputs.issues_found != false
         command: |
-          cat > /output/review.md <<'EOF'
+          cat > /output/review.md <<'ROVER_PERSIST_BLOCK'
           {{steps.code_review.outputs.review_markdown}}
-          EOF
+          ROVER_PERSIST_BLOCK
 
       - id: persist_review_fixes
         type: command
         name: 'Persist Review Fixes'
         if: steps.apply_fixes.outputs.fixes_applied == true
         command: |
-          cat > /output/review_fixes.md <<'EOF'
+          cat > /output/review_fixes.md <<'ROVER_PERSIST_BLOCK'
           {{steps.apply_fixes.outputs.review_fixes_markdown}}
-          EOF
+          ROVER_PERSIST_BLOCK
 
       - id: build_after_review
         type: command
@@ -787,6 +787,6 @@ steps:
     type: command
     name: 'Persist Summary'
     command: |
-      cat > /output/summary.md <<'EOF'
+      cat > /output/summary.md <<'ROVER_PERSIST_BLOCK'
       {{steps.summary.outputs.summary_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK

--- a/packages/cli/src/lib/workflows/swe-tdd.yml
+++ b/packages/cli/src/lib/workflows/swe-tdd.yml
@@ -73,11 +73,14 @@ steps:
       - Find the main file or files affected by these changes. Then, identify other secondary files. Focus mostly on main files and avoid a deep research in the secondary ones
       - Identify existing test files, test frameworks, and test configuration
       - Determine the correct test command for this project by examining package.json, Makefile, pyproject.toml, go.mod, or other build/test configuration files. If a user-provided test command is shown above, use that instead.
+      - If the workspace root has a `Makefile` and the project is configured around `make`, prefer the root command such as `make test` over ad hoc per-project commands.
+      - For multi-project workspaces, prefer a single root orchestration command when available, and treat per-project commands as supporting detail.
+      - If the task description explicitly requires validating multiple root commands in sequence, the test command may be a shell sequence such as `make setup && make test && make test-e2e` or a dedicated root validation target if the repository provides one.
       - Follow the template strictly
       - Just output the template. Skip any text before and after
       - Use globs when a change affects multiple files
 
-      Then, write your structured analysis to `context.md` following this template. This is mandatory.
+      Return your structured analysis in the `context_markdown` output following this template.
 
       <template>
       # Context
@@ -100,7 +103,7 @@ steps:
 
       ## Extra OS packages
 
-      Identify missing OS packages to accomplish this task and install them using the tools provided by the `package-manager` MCP. Return a list of new installed packages or "No additional packages required".
+      Identify whether any OS packages are missing for this task. Do NOT install OS packages during the task. Rover task containers intentionally have limited sudo after setup, so OS package installation belongs in `rover build`, `sandbox.initScript`, or image configuration. Return either "No additional packages required" or a short list of packages that must be added to build/setup-time configuration.
 
       ## Relevant knowledge
 
@@ -116,7 +119,7 @@ steps:
 
       </template>
 
-      IMPORTANT: After writing context.md, you MUST extract the task complexity value, build command, and test command and return them. For the test command: if the user provided a valid override above, return that exactly. Otherwise, return the command you discovered from the project's configuration files. For the build command: return the compile/build command if the project needs one, or "none" if the test command handles it or the language is interpreted.
+      IMPORTANT: You MUST return three scalar outputs as well: `complexity`, `build_command`, and `test_command`. For the test command: if the user provided a valid override above, return that exactly. Otherwise, return the command you discovered from the project's configuration files. For the build command: return the compile/build command if the project needs one, or "none" if the test command handles it or the language is interpreted.
     outputs:
       - name: complexity
         description: 'Task complexity: either "simple" or "complex"'
@@ -128,10 +131,17 @@ steps:
         description: 'The command to run tests for this project'
         type: string
         required: true
-      - name: context_file
-        description: 'Technical context analysis file'
-        type: file
-        filename: context.md
+      - name: context_markdown
+        description: 'Technical context analysis markdown'
+        type: string
+
+  - id: persist_context
+    type: command
+    name: 'Persist Context'
+    command: |
+      cat > /output/context.md <<'EOF'
+      {{steps.context.outputs.context_markdown}}
+      EOF
 
   - id: plan
     type: agent
@@ -144,7 +154,10 @@ steps:
       └─────────────────────────────────────────────┘
 
       Description: {{inputs.description}}
-      Context: {{steps.context.outputs.context_file}}
+      Context:
+      ```
+      {{steps.context.outputs.context_markdown}}
+      ```
 
       ---
 
@@ -179,7 +192,7 @@ steps:
       - Follow the template strictly
       - Just output the template. Skip any text before and after
 
-      Write your plan to `plan.md` following this template. This is mandatory.
+      Return your plan in the `plan_markdown` output following this template.
 
       <template>
       # TDD Implementation Plan
@@ -209,10 +222,17 @@ steps:
       - Prerequisite libraries, configs, or tasks (skip if none)
       </template>
     outputs:
-      - name: plan_file
-        description: 'TDD Implementation plan file'
-        type: file
-        filename: plan.md
+      - name: plan_markdown
+        description: 'TDD implementation plan markdown'
+        type: string
+
+  - id: persist_plan
+    type: command
+    name: 'Persist Plan'
+    command: |
+      cat > /output/plan.md <<'EOF'
+      {{steps.plan.outputs.plan_markdown}}
+      EOF
 
   - id: write_tests
     type: agent
@@ -233,12 +253,12 @@ steps:
 
       Context:
       ```
-      {{steps.context.outputs.context_file}}
+      {{steps.context.outputs.context_markdown}}
       ```
 
       Plan:
       ```
-      {{steps.plan.outputs.plan_file}}
+      {{steps.plan.outputs.plan_markdown}}
       ```
       ---
 
@@ -258,7 +278,7 @@ steps:
 
       ### Phase 3: Output
 
-      Write `test_changes.md` describing what tests you wrote and why. This is mandatory.
+      Return the markdown in the `test_changes_markdown` output describing what tests you wrote and why.
 
       <template>
       # Tests Written
@@ -276,10 +296,17 @@ steps:
       - List of tests that will fail until implementation is complete
       </template>
     outputs:
-      - name: test_changes_file
+      - name: test_changes_markdown
         description: 'Description of tests written'
-        type: file
-        filename: test_changes.md
+        type: string
+
+  - id: persist_test_changes
+    type: command
+    name: 'Persist Test Changes'
+    command: |
+      cat > /output/test_changes.md <<'EOF'
+      {{steps.write_tests.outputs.test_changes_markdown}}
+      EOF
 
   - id: implement
     type: agent
@@ -296,17 +323,17 @@ steps:
 
       Context:
       ```
-      {{steps.context.outputs.context_file}}
+      {{steps.context.outputs.context_markdown}}
       ```
 
       Plan:
       ```
-      {{steps.plan.outputs.plan_file}}
+      {{steps.plan.outputs.plan_markdown}}
       ```
 
       Tests Written:
       ```
-      {{steps.write_tests.outputs.test_changes_file}}
+      {{steps.write_tests.outputs.test_changes_markdown}}
       ```
       ---
 
@@ -327,7 +354,7 @@ steps:
 
       ### Phase 3: Output
 
-      Write `changes.md` following this template. This is mandatory.
+      Return the markdown in the `changes_markdown` output following this template.
 
       <template>
       # Implementation Changes
@@ -355,10 +382,17 @@ steps:
       - Explanation of structure, functions, and integrations
       </template>
     outputs:
-      - name: changes_file
-        description: 'Implementation changes file'
-        type: file
-        filename: changes.md
+      - name: changes_markdown
+        description: 'Implementation changes markdown'
+        type: string
+
+  - id: persist_changes
+    type: command
+    name: 'Persist Changes'
+    command: |
+      cat > /output/changes.md <<'EOF'
+      {{steps.implement.outputs.changes_markdown}}
+      EOF
 
   - id: test_fix_loop
     type: loop
@@ -503,11 +537,11 @@ steps:
 
           Classify your findings into one of three outcomes:
 
-          - **No issues at all**: output {"issues_found": "false"} and do NOT create any file.
-          - **Only nits** (style, naming, minor comments — nothing that affects correctness or security): output {"issues_found": "nits"}. Create `review.md` with the nits noted, but these will NOT block shipping.
-          - **Blocking issues** (bugs, logic errors, security flaws, missing error handling, compile errors, broken tests, out-of-scope files): output {"issues_found": "blocking"} and create `review.md`. These MUST be fixed before shipping.
+          - **No issues at all**: output {"issues_found": "false", "review_markdown": ""}.
+          - **Only nits** (style, naming, minor comments — nothing that affects correctness or security): output {"issues_found": "nits"} and return the review body in `review_markdown`. These will NOT block shipping.
+          - **Blocking issues** (bugs, logic errors, security flaws, missing error handling, compile errors, broken tests, out-of-scope files): output {"issues_found": "blocking"} and return the review body in `review_markdown`. These MUST be fixed before shipping.
 
-          Do not fabricate content; only report issues you can confirm from the diff or by reading the actual source files. Use `review.md` with the following template:
+          Do not fabricate content; only report issues you can confirm from the diff or by reading the actual source files. Use the following template for `review_markdown`:
 
           <template>
           # Code Review
@@ -530,10 +564,9 @@ steps:
           - name: issues_found
             description: 'Whether issues were found (true/false)'
             type: string
-          - name: review_file
-            description: 'Code review file with issues (only created if issues found)'
-            type: file
-            filename: review.md
+          - name: review_markdown
+            description: 'Code review markdown with issues (empty when no issues are found)'
+            type: string
 
       - id: apply_fixes
         type: agent
@@ -556,7 +589,7 @@ steps:
 
           Review:
           ```
-          {{steps.code_review.outputs.review_file}}
+          {{steps.code_review.outputs.review_markdown}}
           ```
 
           Test command: {{steps.context.outputs.test_command}}
@@ -581,10 +614,27 @@ steps:
           - name: fixes_applied
             description: 'Whether fixes were applied (true/false)'
             type: string
-          - name: review_fixes_file
+          - name: review_fixes_markdown
             description: 'Updated changes file with review fixes appended'
-            type: file
-            filename: review_fixes.md
+            type: string
+
+      - id: persist_review
+        type: command
+        name: 'Persist Review'
+        if: steps.code_review.outputs.issues_found != false
+        command: |
+          cat > /output/review.md <<'EOF'
+          {{steps.code_review.outputs.review_markdown}}
+          EOF
+
+      - id: persist_review_fixes
+        type: command
+        name: 'Persist Review Fixes'
+        if: steps.apply_fixes.outputs.fixes_applied == true
+        command: |
+          cat > /output/review_fixes.md <<'EOF'
+          {{steps.apply_fixes.outputs.review_fixes_markdown}}
+          EOF
 
       - id: build_after_review
         type: command
@@ -680,7 +730,7 @@ steps:
 
       Changes:
       ```
-      {{steps.implement.outputs.changes_file}}
+      {{steps.implement.outputs.changes_markdown}}
       ```
 
       Test-Fix Loop Iterations: {{steps.test_fix_loop.outputs.iterations}}
@@ -702,7 +752,7 @@ steps:
 
       ### Phase 3: Output
 
-      Write to `summary.md` following this template. This is mandatory.
+      Return the markdown in the `summary_markdown` output following this template.
 
       <template>
       # Implementation Summary
@@ -729,7 +779,14 @@ steps:
       - Remaining tasks, considerations, or `None`
       </template>
     outputs:
-      - name: summary_file
-        description: 'Implementation summary file'
-        type: file
-        filename: summary.md
+      - name: summary_markdown
+        description: 'Implementation summary markdown'
+        type: string
+
+  - id: persist_summary
+    type: command
+    name: 'Persist Summary'
+    command: |
+      cat > /output/summary.md <<'EOF'
+      {{steps.summary.outputs.summary_markdown}}
+      EOF

--- a/packages/cli/src/lib/workflows/swe-tdd.yml
+++ b/packages/cli/src/lib/workflows/swe-tdd.yml
@@ -139,9 +139,9 @@ steps:
     type: command
     name: 'Persist Context'
     command: |
-      cat > /output/context.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/context.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.context.outputs.context_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: plan
     type: agent
@@ -230,9 +230,9 @@ steps:
     type: command
     name: 'Persist Plan'
     command: |
-      cat > /output/plan.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/plan.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.plan.outputs.plan_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: write_tests
     type: agent
@@ -304,9 +304,9 @@ steps:
     type: command
     name: 'Persist Test Changes'
     command: |
-      cat > /output/test_changes.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/test_changes.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.write_tests.outputs.test_changes_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: implement
     type: agent
@@ -390,9 +390,9 @@ steps:
     type: command
     name: 'Persist Changes'
     command: |
-      cat > /output/changes.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/changes.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.implement.outputs.changes_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: test_fix_loop
     type: loop
@@ -623,18 +623,18 @@ steps:
         name: 'Persist Review'
         if: steps.code_review.outputs.issues_found != false
         command: |
-          cat > /output/review.md <<'ROVER_PERSIST_BLOCK'
+          cat > /output/review.md <<'__ROVER_EOF_9f3a7c__'
           {{steps.code_review.outputs.review_markdown}}
-          ROVER_PERSIST_BLOCK
+          __ROVER_EOF_9f3a7c__
 
       - id: persist_review_fixes
         type: command
         name: 'Persist Review Fixes'
         if: steps.apply_fixes.outputs.fixes_applied == true
         command: |
-          cat > /output/review_fixes.md <<'ROVER_PERSIST_BLOCK'
+          cat > /output/review_fixes.md <<'__ROVER_EOF_9f3a7c__'
           {{steps.apply_fixes.outputs.review_fixes_markdown}}
-          ROVER_PERSIST_BLOCK
+          __ROVER_EOF_9f3a7c__
 
       - id: build_after_review
         type: command
@@ -787,6 +787,6 @@ steps:
     type: command
     name: 'Persist Summary'
     command: |
-      cat > /output/summary.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/summary.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.summary.outputs.summary_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__

--- a/packages/cli/src/lib/workflows/swe.yml
+++ b/packages/cli/src/lib/workflows/swe.yml
@@ -65,7 +65,7 @@ steps:
       - Just output the template. Skip any text before and after
       - Use globs when a change affects multiple files
 
-      Then, write your structured analysis to `context.md` following this template. This is mandatory.
+      Return your structured analysis in the `context_markdown` output following this template.
 
       <template>
       # Context
@@ -80,7 +80,7 @@ steps:
 
       ## Extra OS packages
 
-      Identify missing OS packages to accomplish this task and install them using the tools provided by the `package-manager` MCP. Return a list of new installed packages or "No additional packages required".
+      Identify whether any OS packages are missing for this task. Do NOT install OS packages during the task. Rover task containers intentionally have limited sudo after setup, so OS package installation belongs in `rover build`, `sandbox.initScript`, or image configuration. Return either "No additional packages required" or a short list of packages that must be added to build/setup-time configuration.
 
       ## Relevant knowledge
 
@@ -96,15 +96,22 @@ steps:
 
       </template>
 
-      IMPORTANT: After writing context.md, you MUST extract the task complexity value and return it.
+      IMPORTANT: You MUST also return the `complexity` scalar output.
     outputs:
       - name: complexity
         description: 'Task complexity: either "simple" or "complex"'
         type: string
-      - name: context_file
-        description: 'Technical context analysis file'
-        type: file
-        filename: context.md
+      - name: context_markdown
+        description: 'Technical context analysis markdown'
+        type: string
+
+  - id: persist_context
+    type: command
+    name: 'Persist Context'
+    command: |
+      cat > /output/context.md <<'EOF'
+      {{steps.context.outputs.context_markdown}}
+      EOF
 
   - id: plan
     type: agent
@@ -117,7 +124,10 @@ steps:
       Title: {{inputs.title}}
       Description:
       {{inputs.description}}
-      Context: {{steps.context.outputs.context_file}}
+      Context:
+      ```
+      {{steps.context.outputs.context_markdown}}
+      ```
 
       ---
 
@@ -150,7 +160,7 @@ steps:
       - Follow the template strictly
       - Just output the template. Skip any text before and after
 
-      Write your plan to `plan.md` following this template. This is mandatory.
+      Return your plan in the `plan_markdown` output following this template.
 
       <template>
       # Implementation Plan
@@ -176,10 +186,17 @@ steps:
       - Prerequisite libraries, configs, or tasks (skip if none)
       </template>
     outputs:
-      - name: plan_file
-        description: 'Implementation plan file'
-        type: file
-        filename: plan.md
+      - name: plan_markdown
+        description: 'Implementation plan markdown'
+        type: string
+
+  - id: persist_plan
+    type: command
+    name: 'Persist Plan'
+    command: |
+      cat > /output/plan.md <<'EOF'
+      {{steps.plan.outputs.plan_markdown}}
+      EOF
 
   - id: implement
     type: agent
@@ -197,12 +214,12 @@ steps:
 
       Context: 
       ```
-      {{steps.context.outputs.context_file}}
+      {{steps.context.outputs.context_markdown}}
       ```
 
       Plan: 
       ```
-      {{steps.plan.outputs.plan_file}}
+      {{steps.plan.outputs.plan_markdown}}
       ```
       ---
 
@@ -228,7 +245,7 @@ steps:
       - Follow the template strictly
       - Just output the template. Skip any text before and after
 
-      Write `changes.md` following this template. This is mandatory.
+      Return the markdown in the `changes_markdown` output following this template.
 
       <template>
       # Implementation Changes
@@ -261,10 +278,17 @@ steps:
       - Dependencies added/changed
       </template>
     outputs:
-      - name: changes_file
-        description: 'Implementation changes file'
-        type: file
-        filename: changes.md
+      - name: changes_markdown
+        description: 'Implementation changes markdown'
+        type: string
+
+  - id: persist_changes
+    type: command
+    name: 'Persist Changes'
+    command: |
+      cat > /output/changes.md <<'EOF'
+      {{steps.implement.outputs.changes_markdown}}
+      EOF
 
   - id: review
     type: agent
@@ -282,12 +306,12 @@ steps:
 
       Plan: 
       ```
-      {{steps.plan.outputs.plan_file}}
+      {{steps.plan.outputs.plan_markdown}}
       ```
 
       Changes: 
       ```
-      {{steps.implement.outputs.changes_file}}
+      {{steps.implement.outputs.changes_markdown}}
       ```
       ---
 
@@ -307,9 +331,9 @@ steps:
 
       ### Phase 3: Output
 
-      - If the implementation is satisfactory: output {"skipped": "false", "issues_found": "false"} and do NOT create any file.
+      - If the implementation is satisfactory: output {"skipped": "false", "issues_found": "false", "review_markdown": ""}.
       - Do not fabricate content; if information is unavailable or irrelevant, skip it
-      - If issues are found: output {"skipped": "false", "issues_found": "true"} and create `review.md` with the following template:
+      - If issues are found: output {"skipped": "false", "issues_found": "true"} and return the review body in `review_markdown` using the following template:
 
       <template>
       # Code Review
@@ -348,10 +372,9 @@ steps:
       - name: issues_found
         description: 'Whether issues were found (true/false)'
         type: string
-      - name: review_file
-        description: 'Code review file with issues (only created if issues found)'
-        type: file
-        filename: review.md
+      - name: review_markdown
+        description: 'Code review markdown with issues (empty when no issues are found)'
+        type: string
 
   - id: apply_review
     type: agent
@@ -368,12 +391,12 @@ steps:
 
       Context: 
       ```
-      {{steps.context.outputs.context_file}}
+      {{steps.context.outputs.context_markdown}}
       ```
 
       Review:
       ```
-      {{steps.review.outputs.review_file}}
+      {{steps.review.outputs.review_markdown}}
       ```
 
       ---
@@ -395,7 +418,7 @@ steps:
 
       ### Phase 3: Output
 
-      Write `review_fixes.md` following this template only if you fixed any issue. This is mandatory.
+      Return the markdown in the `review_fixes_markdown` output only if you fixed any issue.
 
       <template>
       ## Review Fixes Applied
@@ -410,10 +433,27 @@ steps:
       - name: fixes_applied
         description: 'Whether fixes were applied (true/false)'
         type: string
-      - name: review_fixes_file
+      - name: review_fixes_markdown
         description: 'Updated changes file with review fixes appended'
-        type: file
-        filename: review_fixes.md
+        type: string
+
+  - id: persist_review
+    type: command
+    name: 'Persist Review'
+    if: steps.review.outputs.issues_found == true
+    command: |
+      cat > /output/review.md <<'EOF'
+      {{steps.review.outputs.review_markdown}}
+      EOF
+
+  - id: persist_review_fixes
+    type: command
+    name: 'Persist Review Fixes'
+    if: steps.apply_review.outputs.fixes_applied == true
+    command: |
+      cat > /output/review_fixes.md <<'EOF'
+      {{steps.apply_review.outputs.review_fixes_markdown}}
+      EOF
 
   - id: summary
     type: agent
@@ -430,12 +470,12 @@ steps:
 
       Context: 
       ```
-      {{steps.context.outputs.context_file}}
+      {{steps.context.outputs.context_markdown}}
       ```
 
       Changes: 
       ```
-      {{steps.implement.outputs.changes_file}}
+      {{steps.implement.outputs.changes_markdown}}
       ```
       ---
 
@@ -454,7 +494,7 @@ steps:
 
       ### Phase 3: Output
 
-      Write to `summary.md` following this template. This is mandatory.
+      Return the markdown in the `summary_markdown` output following this template.
 
       <template>
       # Implementation Summary
@@ -476,7 +516,14 @@ steps:
       - Remaining tasks, considerations, or `None`
       </template>
     outputs:
-      - name: summary_file
-        description: 'Implementation summary file'
-        type: file
-        filename: summary.md
+      - name: summary_markdown
+        description: 'Implementation summary markdown'
+        type: string
+
+  - id: persist_summary
+    type: command
+    name: 'Persist Summary'
+    command: |
+      cat > /output/summary.md <<'EOF'
+      {{steps.summary.outputs.summary_markdown}}
+      EOF

--- a/packages/cli/src/lib/workflows/swe.yml
+++ b/packages/cli/src/lib/workflows/swe.yml
@@ -109,9 +109,9 @@ steps:
     type: command
     name: 'Persist Context'
     command: |
-      cat > /output/context.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/context.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.context.outputs.context_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: plan
     type: agent
@@ -194,9 +194,9 @@ steps:
     type: command
     name: 'Persist Plan'
     command: |
-      cat > /output/plan.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/plan.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.plan.outputs.plan_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: implement
     type: agent
@@ -286,9 +286,9 @@ steps:
     type: command
     name: 'Persist Changes'
     command: |
-      cat > /output/changes.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/changes.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.implement.outputs.changes_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: review
     type: agent
@@ -442,18 +442,18 @@ steps:
     name: 'Persist Review'
     if: steps.review.outputs.issues_found == true
     command: |
-      cat > /output/review.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/review.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.review.outputs.review_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: persist_review_fixes
     type: command
     name: 'Persist Review Fixes'
     if: steps.apply_review.outputs.fixes_applied == true
     command: |
-      cat > /output/review_fixes.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/review_fixes.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.apply_review.outputs.review_fixes_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__
 
   - id: summary
     type: agent
@@ -524,6 +524,6 @@ steps:
     type: command
     name: 'Persist Summary'
     command: |
-      cat > /output/summary.md <<'ROVER_PERSIST_BLOCK'
+      cat > /output/summary.md <<'__ROVER_EOF_9f3a7c__'
       {{steps.summary.outputs.summary_markdown}}
-      ROVER_PERSIST_BLOCK
+      __ROVER_EOF_9f3a7c__

--- a/packages/cli/src/lib/workflows/swe.yml
+++ b/packages/cli/src/lib/workflows/swe.yml
@@ -109,9 +109,9 @@ steps:
     type: command
     name: 'Persist Context'
     command: |
-      cat > /output/context.md <<'EOF'
+      cat > /output/context.md <<'ROVER_PERSIST_BLOCK'
       {{steps.context.outputs.context_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: plan
     type: agent
@@ -194,9 +194,9 @@ steps:
     type: command
     name: 'Persist Plan'
     command: |
-      cat > /output/plan.md <<'EOF'
+      cat > /output/plan.md <<'ROVER_PERSIST_BLOCK'
       {{steps.plan.outputs.plan_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: implement
     type: agent
@@ -286,9 +286,9 @@ steps:
     type: command
     name: 'Persist Changes'
     command: |
-      cat > /output/changes.md <<'EOF'
+      cat > /output/changes.md <<'ROVER_PERSIST_BLOCK'
       {{steps.implement.outputs.changes_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: review
     type: agent
@@ -442,18 +442,18 @@ steps:
     name: 'Persist Review'
     if: steps.review.outputs.issues_found == true
     command: |
-      cat > /output/review.md <<'EOF'
+      cat > /output/review.md <<'ROVER_PERSIST_BLOCK'
       {{steps.review.outputs.review_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: persist_review_fixes
     type: command
     name: 'Persist Review Fixes'
     if: steps.apply_review.outputs.fixes_applied == true
     command: |
-      cat > /output/review_fixes.md <<'EOF'
+      cat > /output/review_fixes.md <<'ROVER_PERSIST_BLOCK'
       {{steps.apply_review.outputs.review_fixes_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK
 
   - id: summary
     type: agent
@@ -524,6 +524,6 @@ steps:
     type: command
     name: 'Persist Summary'
     command: |
-      cat > /output/summary.md <<'EOF'
+      cat > /output/summary.md <<'ROVER_PERSIST_BLOCK'
       {{steps.summary.outputs.summary_markdown}}
-      EOF
+      ROVER_PERSIST_BLOCK

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -105,7 +105,7 @@ function getWorkspaceDescriptionRepositoriesResult(
 ): WorkspaceDescriptionLookupResult {
   const { iterationCount, descriptionPaths: persistedDescriptionPaths } =
     getIterationWorkspaceDescriptionPaths(taskBasePath);
-  let foundPersistedState = iterationCount > 0;
+  let foundPersistedState = persistedDescriptionPaths.length > 0;
 
   for (const descriptionPath of persistedDescriptionPaths) {
     const repositories = parseWorkspaceDescription(

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve, relative, isAbsolute } from 'node:path';
 import type { ProjectConfigManager } from 'rover-core';
 
 export interface WorkspaceRepository {
@@ -19,6 +19,19 @@ interface WorkspaceDescriptionProject {
 
 interface WorkspaceDescription {
   projects?: WorkspaceDescriptionProject[];
+}
+
+/**
+ * Validate that a project path stays within the task worktree root.
+ * Rejects absolute paths and paths containing `..` traversal sequences.
+ */
+function isPathWithinRoot(rootPath: string, projectPath: string): boolean {
+  if (isAbsolute(projectPath)) {
+    return false;
+  }
+  const resolved = resolve(rootPath, projectPath);
+  const rel = relative(rootPath, resolved);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }
 
 function getLatestIterationWorkspaceDescriptionPath(
@@ -71,7 +84,8 @@ function parseWorkspaceDescription(
         } =>
           typeof project?.name === 'string' &&
           typeof project?.path === 'string' &&
-          typeof project?.repository === 'string'
+          typeof project?.repository === 'string' &&
+          isPathWithinRoot(taskWorktreePath, project.path as string)
       )
       .map(project => ({
         name: project.name,
@@ -121,7 +135,8 @@ export function getConfiguredWorkspaceRepositories(
       } =>
         typeof project.name === 'string' &&
         typeof project.path === 'string' &&
-        typeof project.repository === 'string'
+        typeof project.repository === 'string' &&
+        isPathWithinRoot(taskWorktreePath, project.path)
     )
     .map(project => ({
       name: project.name,

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -23,9 +23,8 @@ interface WorkspaceDescription {
 }
 
 function getLatestIterationWorkspaceDescriptionPath(
-  taskWorktreePath: string
+  taskBasePath: string
 ): string | undefined {
-  const taskBasePath = dirname(taskWorktreePath);
   const iterationsPath = join(taskBasePath, 'iterations');
 
   if (!existsSync(iterationsPath)) {
@@ -61,44 +60,41 @@ function parseWorkspaceDescription(
     const projects = Array.isArray(parsed.projects) ? parsed.projects : [];
 
     return projects
-      .filter(
-        (
-          project
-        ): project is {
-          name: string;
-          path: string;
-          repository: string;
-          ref?: string;
-        } =>
-          typeof project?.name === 'string' &&
-          typeof project?.path === 'string' &&
-          typeof project?.repository === 'string' &&
-          resolvePathWithinRoot(taskWorktreePath, project.path as string) !==
-            null
-      )
       .map(project => {
+        if (
+          typeof project?.name !== 'string' ||
+          typeof project?.path !== 'string' ||
+          typeof project?.repository !== 'string'
+        ) {
+          return null;
+        }
         const resolvedPath = resolvePathWithinRoot(
           taskWorktreePath,
-          project.path
+          project.path as string
         );
+        if (resolvedPath === null) {
+          return null;
+        }
         return {
-          name: project.name,
-          relativePath: project.path,
-          worktreePath: resolvedPath ?? join(taskWorktreePath, project.path),
-          repository: project.repository,
+          name: project.name as string,
+          relativePath: project.path as string,
+          worktreePath: resolvedPath,
+          repository: project.repository as string,
           ref: typeof project.ref === 'string' ? project.ref : undefined,
         };
-      });
+      })
+      .filter((entry): entry is WorkspaceRepository => entry !== null);
   } catch {
     return [];
   }
 }
 
 export function getWorkspaceDescriptionRepositories(
-  taskWorktreePath: string
+  taskWorktreePath: string,
+  taskBasePath: string = dirname(taskWorktreePath)
 ): WorkspaceRepository[] {
   const persistedDescriptionPath =
-    getLatestIterationWorkspaceDescriptionPath(taskWorktreePath);
+    getLatestIterationWorkspaceDescriptionPath(taskBasePath);
   if (persistedDescriptionPath) {
     return parseWorkspaceDescription(
       persistedDescriptionPath,
@@ -119,40 +115,41 @@ export function getConfiguredWorkspaceRepositories(
   projectConfig: ProjectConfigManager
 ): WorkspaceRepository[] {
   return (projectConfig.projects ?? [])
-    .filter(
-      (
-        project
-      ): project is {
-        name: string;
-        path: string;
-        repository: string;
-        ref?: string;
-      } =>
-        typeof project.name === 'string' &&
-        typeof project.path === 'string' &&
-        typeof project.repository === 'string' &&
-        resolvePathWithinRoot(taskWorktreePath, project.path) !== null
-    )
     .map(project => {
+      if (
+        typeof project.name !== 'string' ||
+        typeof project.path !== 'string' ||
+        typeof project.repository !== 'string'
+      ) {
+        return null;
+      }
       const resolvedPath = resolvePathWithinRoot(
         taskWorktreePath,
         project.path
       );
+      if (resolvedPath === null) {
+        return null;
+      }
       return {
         name: project.name,
         relativePath: project.path,
-        worktreePath: resolvedPath ?? join(taskWorktreePath, project.path),
+        worktreePath: resolvedPath,
         repository: project.repository,
         ref: project.ref,
       };
-    });
+    })
+    .filter((entry): entry is WorkspaceRepository => entry !== null);
 }
 
 export function getWorkspaceRepositories(
   taskWorktreePath: string,
+  taskBasePath: string,
   projectConfig: ProjectConfigManager
 ): WorkspaceRepository[] {
-  const fromDescription = getWorkspaceDescriptionRepositories(taskWorktreePath);
+  const fromDescription = getWorkspaceDescriptionRepositories(
+    taskWorktreePath,
+    taskBasePath
+  );
   if (fromDescription.length > 0) {
     return fromDescription;
   }

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type { ProjectConfigManager } from 'rover-core';
 
 export interface WorkspaceRepository {
@@ -21,14 +21,39 @@ interface WorkspaceDescription {
   projects?: WorkspaceDescriptionProject[];
 }
 
-export function getWorkspaceDescriptionRepositories(
+function getLatestIterationWorkspaceDescriptionPath(
   taskWorktreePath: string
-): WorkspaceRepository[] {
-  const descriptionPath = join(taskWorktreePath, '.rover-workspace.json');
-  if (!existsSync(descriptionPath)) {
-    return [];
+): string | undefined {
+  const taskBasePath = dirname(taskWorktreePath);
+  const iterationsPath = join(taskBasePath, 'iterations');
+
+  if (!existsSync(iterationsPath)) {
+    return undefined;
   }
 
+  const latestIteration = readdirSync(iterationsPath, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => Number.parseInt(dirent.name, 10))
+    .filter(iteration => !Number.isNaN(iteration))
+    .sort((a, b) => b - a)[0];
+
+  if (latestIteration === undefined) {
+    return undefined;
+  }
+
+  const descriptionPath = join(
+    iterationsPath,
+    latestIteration.toString(),
+    'workspace-description.json'
+  );
+
+  return existsSync(descriptionPath) ? descriptionPath : undefined;
+}
+
+function parseWorkspaceDescription(
+  descriptionPath: string,
+  taskWorktreePath: string
+): WorkspaceRepository[] {
   try {
     const raw = readFileSync(descriptionPath, 'utf8');
     const parsed = JSON.parse(raw) as WorkspaceDescription;
@@ -58,6 +83,26 @@ export function getWorkspaceDescriptionRepositories(
   } catch {
     return [];
   }
+}
+
+export function getWorkspaceDescriptionRepositories(
+  taskWorktreePath: string
+): WorkspaceRepository[] {
+  const persistedDescriptionPath =
+    getLatestIterationWorkspaceDescriptionPath(taskWorktreePath);
+  if (persistedDescriptionPath) {
+    return parseWorkspaceDescription(
+      persistedDescriptionPath,
+      taskWorktreePath
+    );
+  }
+
+  const legacyDescriptionPath = join(taskWorktreePath, '.rover-workspace.json');
+  if (!existsSync(legacyDescriptionPath)) {
+    return [];
+  }
+
+  return parseWorkspaceDescription(legacyDescriptionPath, taskWorktreePath);
 }
 
 export function getConfiguredWorkspaceRepositories(

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, join, resolve, relative, isAbsolute } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { ProjectConfigManager } from 'rover-core';
+import { resolvePathWithinRoot } from '../utils/path-safety.js';
 
 export interface WorkspaceRepository {
   name: string;
@@ -19,19 +20,6 @@ interface WorkspaceDescriptionProject {
 
 interface WorkspaceDescription {
   projects?: WorkspaceDescriptionProject[];
-}
-
-/**
- * Validate that a project path stays within the task worktree root.
- * Rejects absolute paths and paths containing `..` traversal sequences.
- */
-function isPathWithinRoot(rootPath: string, projectPath: string): boolean {
-  if (isAbsolute(projectPath)) {
-    return false;
-  }
-  const resolved = resolve(rootPath, projectPath);
-  const rel = relative(rootPath, resolved);
-  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }
 
 function getLatestIterationWorkspaceDescriptionPath(
@@ -85,15 +73,22 @@ function parseWorkspaceDescription(
           typeof project?.name === 'string' &&
           typeof project?.path === 'string' &&
           typeof project?.repository === 'string' &&
-          isPathWithinRoot(taskWorktreePath, project.path as string)
+          resolvePathWithinRoot(taskWorktreePath, project.path as string) !==
+            null
       )
-      .map(project => ({
-        name: project.name,
-        relativePath: project.path,
-        worktreePath: join(taskWorktreePath, project.path),
-        repository: project.repository,
-        ref: typeof project.ref === 'string' ? project.ref : undefined,
-      }));
+      .map(project => {
+        const resolvedPath = resolvePathWithinRoot(
+          taskWorktreePath,
+          project.path
+        );
+        return {
+          name: project.name,
+          relativePath: project.path,
+          worktreePath: resolvedPath ?? join(taskWorktreePath, project.path),
+          repository: project.repository,
+          ref: typeof project.ref === 'string' ? project.ref : undefined,
+        };
+      });
   } catch {
     return [];
   }
@@ -136,15 +131,21 @@ export function getConfiguredWorkspaceRepositories(
         typeof project.name === 'string' &&
         typeof project.path === 'string' &&
         typeof project.repository === 'string' &&
-        isPathWithinRoot(taskWorktreePath, project.path)
+        resolvePathWithinRoot(taskWorktreePath, project.path) !== null
     )
-    .map(project => ({
-      name: project.name,
-      relativePath: project.path,
-      worktreePath: join(taskWorktreePath, project.path),
-      repository: project.repository,
-      ref: project.ref,
-    }));
+    .map(project => {
+      const resolvedPath = resolvePathWithinRoot(
+        taskWorktreePath,
+        project.path
+      );
+      return {
+        name: project.name,
+        relativePath: project.path,
+        worktreePath: resolvedPath ?? join(taskWorktreePath, project.path),
+        repository: project.repository,
+        ref: project.ref,
+      };
+    });
 }
 
 export function getWorkspaceRepositories(

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -60,7 +60,7 @@ function parseWorkspaceDescription(
     const projects = Array.isArray(parsed.projects) ? parsed.projects : [];
 
     return projects
-      .map(project => {
+      .map<WorkspaceRepository | null>(project => {
         if (
           typeof project?.name !== 'string' ||
           typeof project?.path !== 'string' ||
@@ -80,7 +80,7 @@ function parseWorkspaceDescription(
           relativePath: project.path as string,
           worktreePath: resolvedPath,
           repository: project.repository as string,
-          ref: typeof project.ref === 'string' ? project.ref : undefined,
+          ...(typeof project.ref === 'string' ? { ref: project.ref } : {}),
         };
       })
       .filter((entry): entry is WorkspaceRepository => entry !== null);
@@ -115,7 +115,7 @@ export function getConfiguredWorkspaceRepositories(
   projectConfig: ProjectConfigManager
 ): WorkspaceRepository[] {
   return (projectConfig.projects ?? [])
-    .map(project => {
+    .map<WorkspaceRepository | null>(project => {
       if (
         typeof project.name !== 'string' ||
         typeof project.path !== 'string' ||
@@ -135,7 +135,7 @@ export function getConfiguredWorkspaceRepositories(
         relativePath: project.path,
         worktreePath: resolvedPath,
         repository: project.repository,
-        ref: project.ref,
+        ...(typeof project.ref === 'string' ? { ref: project.ref } : {}),
       };
     })
     .filter((entry): entry is WorkspaceRepository => entry !== null);

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -1,0 +1,100 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { ProjectConfigManager } from 'rover-core';
+
+export interface WorkspaceRepository {
+  name: string;
+  relativePath: string;
+  worktreePath: string;
+  repository: string;
+  ref?: string;
+}
+
+interface WorkspaceDescriptionProject {
+  name?: unknown;
+  path?: unknown;
+  repository?: unknown;
+  ref?: unknown;
+}
+
+interface WorkspaceDescription {
+  projects?: WorkspaceDescriptionProject[];
+}
+
+export function getWorkspaceDescriptionRepositories(
+  taskWorktreePath: string
+): WorkspaceRepository[] {
+  const descriptionPath = join(taskWorktreePath, '.rover-workspace.json');
+  if (!existsSync(descriptionPath)) {
+    return [];
+  }
+
+  try {
+    const raw = readFileSync(descriptionPath, 'utf8');
+    const parsed = JSON.parse(raw) as WorkspaceDescription;
+    const projects = Array.isArray(parsed.projects) ? parsed.projects : [];
+
+    return projects
+      .filter(
+        (
+          project
+        ): project is {
+          name: string;
+          path: string;
+          repository: string;
+          ref?: string;
+        } =>
+          typeof project?.name === 'string' &&
+          typeof project?.path === 'string' &&
+          typeof project?.repository === 'string'
+      )
+      .map(project => ({
+        name: project.name,
+        relativePath: project.path,
+        worktreePath: join(taskWorktreePath, project.path),
+        repository: project.repository,
+        ref: typeof project.ref === 'string' ? project.ref : undefined,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+export function getConfiguredWorkspaceRepositories(
+  taskWorktreePath: string,
+  projectConfig: ProjectConfigManager
+): WorkspaceRepository[] {
+  return (projectConfig.projects ?? [])
+    .filter(
+      (
+        project
+      ): project is {
+        name: string;
+        path: string;
+        repository: string;
+        ref?: string;
+      } =>
+        typeof project.name === 'string' &&
+        typeof project.path === 'string' &&
+        typeof project.repository === 'string'
+    )
+    .map(project => ({
+      name: project.name,
+      relativePath: project.path,
+      worktreePath: join(taskWorktreePath, project.path),
+      repository: project.repository,
+      ref: project.ref,
+    }));
+}
+
+export function getWorkspaceRepositories(
+  taskWorktreePath: string,
+  projectConfig: ProjectConfigManager
+): WorkspaceRepository[] {
+  const fromDescription = getWorkspaceDescriptionRepositories(taskWorktreePath);
+  if (fromDescription.length > 0) {
+    return fromDescription;
+  }
+
+  return getConfiguredWorkspaceRepositories(taskWorktreePath, projectConfig);
+}

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -22,8 +22,9 @@ interface WorkspaceDescription {
   projects?: WorkspaceDescriptionProject[];
 }
 
-interface WorkspaceDescriptionLookupResult {
+export interface WorkspaceDescriptionLookupResult {
   foundPersistedState: boolean;
+  hasPersistedParseErrors: boolean;
   repositories: WorkspaceRepository[];
 }
 
@@ -106,6 +107,7 @@ function getWorkspaceDescriptionRepositoriesResult(
   const { iterationCount, descriptionPaths: persistedDescriptionPaths } =
     getIterationWorkspaceDescriptionPaths(taskBasePath);
   let foundPersistedState = persistedDescriptionPaths.length > 0;
+  let hasPersistedParseErrors = false;
 
   for (const descriptionPath of persistedDescriptionPaths) {
     const repositories = parseWorkspaceDescription(
@@ -113,20 +115,56 @@ function getWorkspaceDescriptionRepositoriesResult(
       taskWorktreePath
     );
     if (repositories !== undefined) {
-      return { foundPersistedState: true, repositories };
+      return {
+        foundPersistedState: true,
+        hasPersistedParseErrors,
+        repositories,
+      };
     }
+    hasPersistedParseErrors = true;
   }
 
   const legacyDescriptionPath = join(taskWorktreePath, '.rover-workspace.json');
   if (!existsSync(legacyDescriptionPath)) {
-    return { foundPersistedState, repositories: [] };
+    return { foundPersistedState, hasPersistedParseErrors, repositories: [] };
   }
 
   foundPersistedState = true;
+  const legacyRepositories = parseWorkspaceDescription(
+    legacyDescriptionPath,
+    taskWorktreePath
+  );
+  if (legacyRepositories === undefined) {
+    hasPersistedParseErrors = true;
+  }
+
   return {
     foundPersistedState,
-    repositories:
-      parseWorkspaceDescription(legacyDescriptionPath, taskWorktreePath) ?? [],
+    hasPersistedParseErrors,
+    repositories: legacyRepositories ?? [],
+  };
+}
+
+export function getWorkspaceRepositoriesLookupResult(
+  taskWorktreePath: string,
+  taskBasePath: string,
+  projectConfig: ProjectConfigManager
+): WorkspaceDescriptionLookupResult {
+  const fromDescription = getWorkspaceDescriptionRepositoriesResult(
+    taskWorktreePath,
+    taskBasePath
+  );
+  if (fromDescription.foundPersistedState) {
+    return fromDescription;
+  }
+
+  return {
+    foundPersistedState: false,
+    hasPersistedParseErrors: false,
+    repositories: getConfiguredWorkspaceRepositories(
+      taskWorktreePath,
+      projectConfig
+    ),
   };
 }
 
@@ -176,13 +214,9 @@ export function getWorkspaceRepositories(
   taskBasePath: string,
   projectConfig: ProjectConfigManager
 ): WorkspaceRepository[] {
-  const fromDescription = getWorkspaceDescriptionRepositoriesResult(
+  return getWorkspaceRepositoriesLookupResult(
     taskWorktreePath,
-    taskBasePath
-  );
-  if (fromDescription.foundPersistedState) {
-    return fromDescription.repositories;
-  }
-
-  return getConfiguredWorkspaceRepositories(taskWorktreePath, projectConfig);
+    taskBasePath,
+    projectConfig
+  ).repositories;
 }

--- a/packages/cli/src/lib/workspace-repositories.ts
+++ b/packages/cli/src/lib/workspace-repositories.ts
@@ -22,38 +22,44 @@ interface WorkspaceDescription {
   projects?: WorkspaceDescriptionProject[];
 }
 
-function getLatestIterationWorkspaceDescriptionPath(
-  taskBasePath: string
-): string | undefined {
+interface WorkspaceDescriptionLookupResult {
+  foundPersistedState: boolean;
+  repositories: WorkspaceRepository[];
+}
+
+function getIterationWorkspaceDescriptionPaths(taskBasePath: string): {
+  iterationCount: number;
+  descriptionPaths: string[];
+} {
   const iterationsPath = join(taskBasePath, 'iterations');
 
   if (!existsSync(iterationsPath)) {
-    return undefined;
+    return { iterationCount: 0, descriptionPaths: [] };
   }
 
-  const latestIteration = readdirSync(iterationsPath, { withFileTypes: true })
+  const iterationIds = readdirSync(iterationsPath, { withFileTypes: true })
     .filter(dirent => dirent.isDirectory())
     .map(dirent => Number.parseInt(dirent.name, 10))
     .filter(iteration => !Number.isNaN(iteration))
-    .sort((a, b) => b - a)[0];
+    .sort((a, b) => b - a);
 
-  if (latestIteration === undefined) {
-    return undefined;
-  }
-
-  const descriptionPath = join(
-    iterationsPath,
-    latestIteration.toString(),
-    'workspace-description.json'
-  );
-
-  return existsSync(descriptionPath) ? descriptionPath : undefined;
+  return {
+    iterationCount: iterationIds.length,
+    descriptionPaths: iterationIds.flatMap(iterationId => {
+      const descriptionPath = join(
+        iterationsPath,
+        iterationId.toString(),
+        'workspace-description.json'
+      );
+      return existsSync(descriptionPath) ? [descriptionPath] : [];
+    }),
+  };
 }
 
 function parseWorkspaceDescription(
   descriptionPath: string,
   taskWorktreePath: string
-): WorkspaceRepository[] {
+): WorkspaceRepository[] | undefined {
   try {
     const raw = readFileSync(descriptionPath, 'utf8');
     const parsed = JSON.parse(raw) as WorkspaceDescription;
@@ -84,30 +90,54 @@ function parseWorkspaceDescription(
         };
       })
       .filter((entry): entry is WorkspaceRepository => entry !== null);
-  } catch {
-    return [];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `Warning: failed to parse workspace description at ${descriptionPath}: ${message}\n`
+    );
+    return undefined;
   }
+}
+
+function getWorkspaceDescriptionRepositoriesResult(
+  taskWorktreePath: string,
+  taskBasePath: string = dirname(taskWorktreePath)
+): WorkspaceDescriptionLookupResult {
+  const { iterationCount, descriptionPaths: persistedDescriptionPaths } =
+    getIterationWorkspaceDescriptionPaths(taskBasePath);
+  let foundPersistedState = iterationCount > 0;
+
+  for (const descriptionPath of persistedDescriptionPaths) {
+    const repositories = parseWorkspaceDescription(
+      descriptionPath,
+      taskWorktreePath
+    );
+    if (repositories !== undefined) {
+      return { foundPersistedState: true, repositories };
+    }
+  }
+
+  const legacyDescriptionPath = join(taskWorktreePath, '.rover-workspace.json');
+  if (!existsSync(legacyDescriptionPath)) {
+    return { foundPersistedState, repositories: [] };
+  }
+
+  foundPersistedState = true;
+  return {
+    foundPersistedState,
+    repositories:
+      parseWorkspaceDescription(legacyDescriptionPath, taskWorktreePath) ?? [],
+  };
 }
 
 export function getWorkspaceDescriptionRepositories(
   taskWorktreePath: string,
   taskBasePath: string = dirname(taskWorktreePath)
 ): WorkspaceRepository[] {
-  const persistedDescriptionPath =
-    getLatestIterationWorkspaceDescriptionPath(taskBasePath);
-  if (persistedDescriptionPath) {
-    return parseWorkspaceDescription(
-      persistedDescriptionPath,
-      taskWorktreePath
-    );
-  }
-
-  const legacyDescriptionPath = join(taskWorktreePath, '.rover-workspace.json');
-  if (!existsSync(legacyDescriptionPath)) {
-    return [];
-  }
-
-  return parseWorkspaceDescription(legacyDescriptionPath, taskWorktreePath);
+  return getWorkspaceDescriptionRepositoriesResult(
+    taskWorktreePath,
+    taskBasePath
+  ).repositories;
 }
 
 export function getConfiguredWorkspaceRepositories(
@@ -146,12 +176,12 @@ export function getWorkspaceRepositories(
   taskBasePath: string,
   projectConfig: ProjectConfigManager
 ): WorkspaceRepository[] {
-  const fromDescription = getWorkspaceDescriptionRepositories(
+  const fromDescription = getWorkspaceDescriptionRepositoriesResult(
     taskWorktreePath,
     taskBasePath
   );
-  if (fromDescription.length > 0) {
-    return fromDescription;
+  if (fromDescription.foundPersistedState) {
+    return fromDescription.repositories;
   }
 
   return getConfiguredWorkspaceRepositories(taskWorktreePath, projectConfig);

--- a/packages/cli/src/output-types.ts
+++ b/packages/cli/src/output-types.ts
@@ -138,6 +138,8 @@ export interface TaskPushOutput extends CLIJsonOutput {
   committed: boolean;
   commitMessage?: string;
   pushed: boolean;
+  /** Repos that were successfully pushed (useful for diagnosing partial failures). */
+  pushedRepos?: string[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -366,14 +366,19 @@ export function createProgram(
     .command('resume')
     .description('Resume a paused or failed task from checkpoint')
     .argument('<taskId>', 'Task ID to resume')
-    .option('-a, --agent <agent>', 'Override agent (e.g., claude:opus, codex:spark)')
+    .option(
+      '-a, --agent <agent>',
+      'Override agent (e.g., claude:opus, codex:spark)'
+    )
     .option('--json', 'Output the result in JSON format')
     .action(resumeCmd.action);
 
   // Pause a running task (preserves state for resume)
   program
     .command('pause')
-    .description('Gracefully pause a running task (preserves checkpoint for resume)')
+    .description(
+      'Gracefully pause a running task (preserves checkpoint for resume)'
+    )
     .argument('<taskId>', 'Task ID to pause')
     .option('-r, --reason <reason>', 'Reason for pausing the task')
     .option('--json', 'Output the result in JSON format')

--- a/packages/cli/src/utils/__tests__/repository-reference.test.ts
+++ b/packages/cli/src/utils/__tests__/repository-reference.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isLocalRepositoryReference,
+  resolveRepositoryHostPath,
+} from '../repository-reference.js';
+
+describe('isLocalRepositoryReference', () => {
+  it('treats absolute paths as local repositories', () => {
+    expect(isLocalRepositoryReference('/tmp/frontend.git')).toBe(true);
+    expect(isLocalRepositoryReference('/workspace/sources/frontend.git')).toBe(
+      true
+    );
+  });
+
+  it('treats file URLs as local repositories', () => {
+    expect(
+      isLocalRepositoryReference('file:///workspace/sources/frontend.git')
+    ).toBe(true);
+  });
+
+  it('treats remote URLs and scp-like git remotes as remote repositories', () => {
+    expect(
+      isLocalRepositoryReference('https://github.com/endorhq/rover.git')
+    ).toBe(false);
+    expect(isLocalRepositoryReference('git@github.com:endorhq/rover.git')).toBe(
+      false
+    );
+  });
+
+  it('treats relative paths as local repositories', () => {
+    expect(isLocalRepositoryReference('../repos/frontend.git')).toBe(true);
+  });
+
+  it('rejects empty repository references', () => {
+    expect(isLocalRepositoryReference('')).toBe(false);
+  });
+});
+
+describe('resolveRepositoryHostPath', () => {
+  it('strips /workspace/ prefix and resolves relative to project root', () => {
+    expect(
+      resolveRepositoryHostPath(
+        '/workspace/sources/backend.git',
+        '/tmp/my-project'
+      )
+    ).toBe('/tmp/my-project/sources/backend.git');
+  });
+
+  it('resolves /workspace to project root', () => {
+    expect(resolveRepositoryHostPath('/workspace', '/tmp/my-project')).toBe(
+      '/tmp/my-project'
+    );
+  });
+
+  it('resolves relative paths against project root', () => {
+    expect(
+      resolveRepositoryHostPath('./repos/frontend.git', '/tmp/my-project')
+    ).toBe('/tmp/my-project/repos/frontend.git');
+  });
+
+  it('resolves non-workspace absolute paths as-is', () => {
+    expect(
+      resolveRepositoryHostPath('/opt/repos/frontend.git', '/tmp/my-project')
+    ).toBe('/opt/repos/frontend.git');
+  });
+});

--- a/packages/cli/src/utils/__tests__/repository-reference.test.ts
+++ b/packages/cli/src/utils/__tests__/repository-reference.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   isLocalRepositoryReference,
+  resolveLocalRepositoryReference,
   resolveRepositoryHostPath,
 } from '../repository-reference.js';
 
@@ -62,5 +63,16 @@ describe('resolveRepositoryHostPath', () => {
     expect(
       resolveRepositoryHostPath('/opt/repos/frontend.git', '/tmp/my-project')
     ).toBe('/opt/repos/frontend.git');
+  });
+});
+
+describe('resolveLocalRepositoryReference', () => {
+  it('maps file URLs under /workspace back to the host project root', () => {
+    expect(
+      resolveLocalRepositoryReference(
+        'file:///workspace/sources/backend.git',
+        '/tmp/my-project'
+      )
+    ).toBe('/tmp/my-project/sources/backend.git');
   });
 });

--- a/packages/cli/src/utils/path-safety.ts
+++ b/packages/cli/src/utils/path-safety.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import path from 'node:path';
 
 type PathApi = Pick<
@@ -6,46 +6,68 @@ type PathApi = Pick<
   'resolve' | 'relative' | 'isAbsolute' | 'dirname'
 >;
 
+export const isSafeRelativePath = (
+  relativePath: string,
+  pathApi: Pick<typeof path, 'isAbsolute'> = path
+): boolean => {
+  if (relativePath.length === 0 || pathApi.isAbsolute(relativePath)) {
+    return false;
+  }
+
+  const segments = relativePath
+    .split(/[\\/]+/)
+    .filter(segment => segment.length > 0);
+
+  return segments.length > 0 && segments.every(segment => segment !== '..');
+};
+
+const findNearestExistingPath = (
+  candidatePath: string,
+  pathApi: Pick<typeof path, 'dirname'> = path
+): string | null => {
+  let current = candidatePath;
+
+  while (!existsSync(current)) {
+    const parent = pathApi.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+
+  return current;
+};
+
 export const resolvePathWithinRoot = (
   rootPath: string,
   filePath: string,
   pathApi: PathApi = path
 ): string | null => {
+  if (!isSafeRelativePath(filePath, pathApi)) {
+    return null;
+  }
+
   const resolvedRoot = pathApi.resolve(rootPath);
   const resolvedPath = pathApi.resolve(resolvedRoot, filePath);
   const relativePath = pathApi.relative(resolvedRoot, resolvedPath);
 
-  if (
-    relativePath === '' ||
-    (!relativePath.startsWith('..') && !pathApi.isAbsolute(relativePath))
-  ) {
-    // Additionally resolve symlinks to prevent symlink-based traversal.
+  if (!relativePath.startsWith('..') && !pathApi.isAbsolute(relativePath)) {
+    // Resolve the nearest existing ancestor to catch symlink escapes even
+    // when the target path itself does not exist yet.
     try {
       const realRoot = realpathSync(resolvedRoot);
-      const realPath = realpathSync(resolvedPath);
-      const realRelative = pathApi.relative(realRoot, realPath);
-      if (
-        realRelative !== '' &&
-        (realRelative.startsWith('..') || pathApi.isAbsolute(realRelative))
-      ) {
-        return null;
-      }
-    } catch {
-      // File doesn't exist yet — resolve the parent directory to catch
-      // symlinked parent directories that point outside the root.
-      try {
-        const realRoot = realpathSync(resolvedRoot);
-        const realParent = realpathSync(pathApi.dirname(resolvedPath));
-        const parentRelative = pathApi.relative(realRoot, realParent);
-        if (
-          parentRelative.startsWith('..') ||
-          pathApi.isAbsolute(parentRelative)
-        ) {
+      const existingPath = findNearestExistingPath(resolvedPath, pathApi);
+      if (existingPath) {
+        const realPath = realpathSync(existingPath);
+        const realRelative = pathApi.relative(realRoot, realPath);
+        if (realRelative.startsWith('..') || pathApi.isAbsolute(realRelative)) {
           return null;
         }
-      } catch {
-        // Parent doesn't exist either — textual check is sufficient
       }
+    } catch {
+      // Root or ancestors may not exist yet (for example in unit tests or
+      // before a workspace path is materialized). In that case, rely on the
+      // lexical containment check above.
     }
     return resolvedPath;
   }

--- a/packages/cli/src/utils/repository-reference.ts
+++ b/packages/cli/src/utils/repository-reference.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const REMOTE_URI_SCHEME = /^[a-z][a-z\d+.-]*:\/\//i;
 const SCP_LIKE_GIT_REMOTE = /^(?:[^@/:\s]+@)?[^/:\s]+:.+$/;
@@ -39,4 +40,15 @@ export function resolveRepositoryHostPath(
     return projectRoot;
   }
   return resolve(projectRoot, repository);
+}
+
+export function resolveLocalRepositoryReference(
+  repository: string,
+  projectRoot: string
+): string {
+  if (repository.startsWith('file://')) {
+    return resolveRepositoryHostPath(fileURLToPath(repository), projectRoot);
+  }
+
+  return resolveRepositoryHostPath(repository, projectRoot);
 }

--- a/packages/cli/src/utils/repository-reference.ts
+++ b/packages/cli/src/utils/repository-reference.ts
@@ -1,0 +1,22 @@
+import { isAbsolute } from 'node:path';
+
+const REMOTE_URI_SCHEME = /^[a-z][a-z\d+.-]*:\/\//i;
+const SCP_LIKE_GIT_REMOTE = /^(?:[^@/:\s]+@)?[^/:\s]+:.+$/;
+
+export function isLocalRepositoryReference(repository: string): boolean {
+  if (repository.startsWith('file://')) {
+    return true;
+  }
+
+  if (isAbsolute(repository)) {
+    return !repository.startsWith('/workspace/');
+  }
+
+  if (repository.length === 0) {
+    return false;
+  }
+
+  return (
+    !REMOTE_URI_SCHEME.test(repository) && !SCP_LIKE_GIT_REMOTE.test(repository)
+  );
+}

--- a/packages/cli/src/utils/repository-reference.ts
+++ b/packages/cli/src/utils/repository-reference.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
 
 const REMOTE_URI_SCHEME = /^[a-z][a-z\d+.-]*:\/\//i;
 const SCP_LIKE_GIT_REMOTE = /^(?:[^@/:\s]+@)?[^/:\s]+:.+$/;
@@ -9,7 +9,7 @@ export function isLocalRepositoryReference(repository: string): boolean {
   }
 
   if (isAbsolute(repository)) {
-    return !repository.startsWith('/workspace/');
+    return true;
   }
 
   if (repository.length === 0) {
@@ -19,4 +19,24 @@ export function isLocalRepositoryReference(repository: string): boolean {
   return (
     !REMOTE_URI_SCHEME.test(repository) && !SCP_LIKE_GIT_REMOTE.test(repository)
   );
+}
+
+/**
+ * Resolve a repository path that may use the container `/workspace/` prefix
+ * to the corresponding host path.
+ *
+ * Container configs often reference `/workspace/sources/foo.git` which maps
+ * to `<projectRoot>/sources/foo.git` on the host.
+ */
+export function resolveRepositoryHostPath(
+  repository: string,
+  projectRoot: string
+): string {
+  if (repository.startsWith('/workspace/')) {
+    return resolve(projectRoot, repository.slice('/workspace/'.length));
+  }
+  if (repository === '/workspace') {
+    return projectRoot;
+  }
+  return resolve(projectRoot, repository);
 }

--- a/packages/cli/src/utils/shell.ts
+++ b/packages/cli/src/utils/shell.ts
@@ -1,0 +1,9 @@
+/**
+ * Safely single-quote a value for shell interpolation.
+ *
+ * Replaces every embedded single-quote with the sequence `'"'"'` so the
+ * result can be dropped into a shell command as a single argument.
+ */
+export function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}

--- a/packages/cli/src/utils/task-status.ts
+++ b/packages/cli/src/utils/task-status.ts
@@ -4,7 +4,10 @@ import colors, { type StyleFunction } from 'ansi-colors';
  * Format task status for user-friendly display.
  * When a pauseReason is given for PAUSED status, includes it for context (e.g., "Paused (rate limit)").
  */
-export const formatTaskStatus = (status: string, pauseReason?: string): string => {
+export const formatTaskStatus = (
+  status: string,
+  pauseReason?: string
+): string => {
   switch (status.toUpperCase()) {
     case 'NEW':
       return 'New';

--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -277,4 +277,74 @@ describe('Git', () => {
       expect(existsSync(join(worktreePath, 'README.md'))).toBe(true);
     });
   });
+
+  describe('checkoutBranch', () => {
+    it('creates a missing local branch from the remote task branch when available', () => {
+      const remoteDir = join(
+        tmpdir(),
+        `git-remote-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const cloneDir = join(
+        tmpdir(),
+        `git-clone-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+
+      mkdirSync(remoteDir, { recursive: true });
+
+      try {
+        launchSync('git', ['init', '--bare', remoteDir]);
+        launchSync('git', ['remote', 'add', 'origin', remoteDir], {
+          cwd: testDir,
+        });
+
+        writeFileSync(join(testDir, 'README.md'), '# Test');
+        launchSync('git', ['add', '.'], { cwd: testDir });
+        launchSync('git', ['commit', '-m', 'Initial commit'], { cwd: testDir });
+        launchSync('git', ['branch', '-M', 'main'], { cwd: testDir });
+        launchSync('git', ['push', '-u', 'origin', 'main'], { cwd: testDir });
+
+        launchSync('git', ['checkout', '-b', 'task/test-branch'], {
+          cwd: testDir,
+        });
+        writeFileSync(join(testDir, 'task.txt'), 'remote task branch commit\n');
+        launchSync('git', ['add', '.'], { cwd: testDir });
+        launchSync('git', ['commit', '-m', 'Task branch commit'], {
+          cwd: testDir,
+        });
+        const remoteTaskCommit = launchSync('git', ['rev-parse', 'HEAD'], {
+          cwd: testDir,
+        })
+          .stdout?.toString()
+          .trim();
+        launchSync('git', ['push', '-u', 'origin', 'task/test-branch'], {
+          cwd: testDir,
+        });
+
+        launchSync('git', ['checkout', 'main'], { cwd: testDir });
+
+        launchSync('git', ['clone', remoteDir, cloneDir]);
+        launchSync('git', ['config', 'user.email', 'test@example.com'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'user.name', 'Test User'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'commit.gpgsign', 'false'], {
+          cwd: cloneDir,
+        });
+
+        const clonedGit = new Git({ cwd: cloneDir });
+        expect(clonedGit.branchExists('task/test-branch')).toBe(false);
+        expect(clonedGit.remoteBranchExists('task/test-branch')).toBe(true);
+
+        clonedGit.checkoutBranch('task/test-branch', { createIfMissing: true });
+
+        expect(clonedGit.getCurrentBranch()).toBe('task/test-branch');
+        expect(clonedGit.getCommitHash('HEAD')).toBe(remoteTaskCommit);
+      } finally {
+        rmSync(cloneDir, { recursive: true, force: true });
+        rmSync(remoteDir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -436,6 +436,104 @@ describe('Git', () => {
       }
     });
 
+    it('refreshes an existing remote-tracking ref before recreating a missing local branch', () => {
+      const remoteDir = join(
+        tmpdir(),
+        `git-remote-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const sourceDir = join(
+        tmpdir(),
+        `git-source-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const cloneDir = join(
+        tmpdir(),
+        `git-clone-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+
+      mkdirSync(remoteDir, { recursive: true });
+      mkdirSync(sourceDir, { recursive: true });
+
+      try {
+        launchSync('git', ['init', '--bare', remoteDir]);
+
+        launchSync('git', ['init'], { cwd: sourceDir });
+        launchSync('git', ['config', 'user.email', 'test@example.com'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['config', 'user.name', 'Test User'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['config', 'commit.gpgsign', 'false'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['remote', 'add', 'origin', remoteDir], {
+          cwd: sourceDir,
+        });
+
+        writeFileSync(join(sourceDir, 'README.md'), '# Test');
+        launchSync('git', ['add', '.'], { cwd: sourceDir });
+        launchSync('git', ['commit', '-m', 'Initial commit'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['branch', '-M', 'main'], { cwd: sourceDir });
+        launchSync('git', ['push', '-u', 'origin', 'main'], { cwd: sourceDir });
+
+        launchSync('git', ['checkout', '-b', 'task/test-branch'], {
+          cwd: sourceDir,
+        });
+        writeFileSync(join(sourceDir, 'task.txt'), 'first remote commit\n');
+        launchSync('git', ['add', '.'], { cwd: sourceDir });
+        launchSync('git', ['commit', '-m', 'First task branch commit'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['push', '-u', 'origin', 'task/test-branch'], {
+          cwd: sourceDir,
+        });
+
+        launchSync('git', ['clone', remoteDir, cloneDir]);
+        launchSync('git', ['config', 'user.email', 'test@example.com'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'user.name', 'Test User'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'commit.gpgsign', 'false'], {
+          cwd: cloneDir,
+        });
+
+        writeFileSync(join(sourceDir, 'task.txt'), 'second remote commit\n');
+        launchSync('git', ['add', '.'], { cwd: sourceDir });
+        launchSync('git', ['commit', '-m', 'Second task branch commit'], {
+          cwd: sourceDir,
+        });
+        const latestRemoteTaskCommit = launchSync(
+          'git',
+          ['rev-parse', 'HEAD'],
+          {
+            cwd: sourceDir,
+          }
+        )
+          .stdout?.toString()
+          .trim();
+        launchSync('git', ['push', 'origin', 'task/test-branch'], {
+          cwd: sourceDir,
+        });
+
+        const clonedGit = new Git({ cwd: cloneDir });
+        expect(clonedGit.branchExists('task/test-branch')).toBe(false);
+        expect(clonedGit.remoteBranchExists('task/test-branch')).toBe(true);
+
+        clonedGit.checkoutBranch('task/test-branch', { createIfMissing: true });
+
+        expect(clonedGit.getCurrentBranch()).toBe('task/test-branch');
+        expect(clonedGit.getCommitHash('HEAD')).toBe(latestRemoteTaskCommit);
+      } finally {
+        rmSync(cloneDir, { recursive: true, force: true });
+        rmSync(sourceDir, { recursive: true, force: true });
+        rmSync(remoteDir, { recursive: true, force: true });
+      }
+    });
+
     it('does not create a local task branch from HEAD when fetching the remote branch fails unexpectedly', () => {
       const cloneDir = join(
         tmpdir(),

--- a/packages/core/src/__tests__/git.test.ts
+++ b/packages/core/src/__tests__/git.test.ts
@@ -346,5 +346,141 @@ describe('Git', () => {
         rmSync(remoteDir, { recursive: true, force: true });
       }
     });
+
+    it('fetches a task branch before creating it locally when remote refs are stale', () => {
+      const remoteDir = join(
+        tmpdir(),
+        `git-remote-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const sourceDir = join(
+        tmpdir(),
+        `git-source-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      const cloneDir = join(
+        tmpdir(),
+        `git-clone-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+
+      mkdirSync(remoteDir, { recursive: true });
+      mkdirSync(sourceDir, { recursive: true });
+
+      try {
+        launchSync('git', ['init', '--bare', remoteDir]);
+
+        launchSync('git', ['init'], { cwd: sourceDir });
+        launchSync('git', ['config', 'user.email', 'test@example.com'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['config', 'user.name', 'Test User'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['config', 'commit.gpgsign', 'false'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['remote', 'add', 'origin', remoteDir], {
+          cwd: sourceDir,
+        });
+
+        writeFileSync(join(sourceDir, 'README.md'), '# Test');
+        launchSync('git', ['add', '.'], { cwd: sourceDir });
+        launchSync('git', ['commit', '-m', 'Initial commit'], {
+          cwd: sourceDir,
+        });
+        launchSync('git', ['branch', '-M', 'main'], { cwd: sourceDir });
+        launchSync('git', ['push', '-u', 'origin', 'main'], { cwd: sourceDir });
+
+        launchSync('git', ['clone', remoteDir, cloneDir]);
+        launchSync('git', ['config', 'user.email', 'test@example.com'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'user.name', 'Test User'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'commit.gpgsign', 'false'], {
+          cwd: cloneDir,
+        });
+
+        launchSync('git', ['checkout', '-b', 'task/test-branch'], {
+          cwd: sourceDir,
+        });
+        writeFileSync(
+          join(sourceDir, 'task.txt'),
+          'remote task branch commit\n'
+        );
+        launchSync('git', ['add', '.'], { cwd: sourceDir });
+        launchSync('git', ['commit', '-m', 'Task branch commit'], {
+          cwd: sourceDir,
+        });
+        const remoteTaskCommit = launchSync('git', ['rev-parse', 'HEAD'], {
+          cwd: sourceDir,
+        })
+          .stdout?.toString()
+          .trim();
+        launchSync('git', ['push', '-u', 'origin', 'task/test-branch'], {
+          cwd: sourceDir,
+        });
+
+        const clonedGit = new Git({ cwd: cloneDir });
+        expect(clonedGit.branchExists('task/test-branch')).toBe(false);
+        expect(clonedGit.remoteBranchExists('task/test-branch')).toBe(false);
+
+        clonedGit.checkoutBranch('task/test-branch', { createIfMissing: true });
+
+        expect(clonedGit.getCurrentBranch()).toBe('task/test-branch');
+        expect(clonedGit.getCommitHash('HEAD')).toBe(remoteTaskCommit);
+        expect(clonedGit.remoteBranchExists('task/test-branch')).toBe(true);
+      } finally {
+        rmSync(cloneDir, { recursive: true, force: true });
+        rmSync(sourceDir, { recursive: true, force: true });
+        rmSync(remoteDir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not create a local task branch from HEAD when fetching the remote branch fails unexpectedly', () => {
+      const cloneDir = join(
+        tmpdir(),
+        `git-clone-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+
+      mkdirSync(cloneDir, { recursive: true });
+
+      try {
+        launchSync('git', ['init'], { cwd: cloneDir });
+        launchSync('git', ['config', 'user.email', 'test@example.com'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'user.name', 'Test User'], {
+          cwd: cloneDir,
+        });
+        launchSync('git', ['config', 'commit.gpgsign', 'false'], {
+          cwd: cloneDir,
+        });
+
+        writeFileSync(join(cloneDir, 'README.md'), '# Test');
+        launchSync('git', ['add', '.'], { cwd: cloneDir });
+        launchSync('git', ['commit', '-m', 'Initial commit'], {
+          cwd: cloneDir,
+        });
+
+        launchSync(
+          'git',
+          ['remote', 'add', 'origin', 'https://127.0.0.1:1/repo.git'],
+          {
+            cwd: cloneDir,
+          }
+        );
+
+        const clonedGit = new Git({ cwd: cloneDir });
+
+        expect(() =>
+          clonedGit.checkoutBranch('task/test-branch', {
+            createIfMissing: true,
+          })
+        ).toThrow(/Failed to fetch remote branch 'origin\/task\/test-branch'/);
+        expect(clonedGit.branchExists('task/test-branch')).toBe(false);
+      } finally {
+        rmSync(cloneDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/packages/core/src/files/__tests__/project-config.test.ts
+++ b/packages/core/src/files/__tests__/project-config.test.ts
@@ -48,7 +48,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     expect(existsSync('rover.json')).toBe(true);
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
 
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
 
     // Optional fields should not be present if undefined
     expect('envs' in jsonData).toBe(false);
@@ -148,7 +148,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     const config = ProjectConfigManager.load(testDir);
 
     // Should be migrated to 1.2
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
 
     // Optional fields should not be present
     expect(config.envs).toBeUndefined();
@@ -156,7 +156,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     // Check saved file
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect('envs' in jsonData).toBe(false);
     expect('envsFile' in jsonData).toBe(false);
   });
@@ -182,7 +182,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     const config = ProjectConfigManager.load(testDir);
 
     // Should be migrated to 1.2
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
 
     // Should preserve custom fields
     expect(config.envs).toEqual(['NODE_ENV']);
@@ -190,7 +190,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     // Check saved file
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.envs).toEqual(['NODE_ENV']);
     expect(jsonData.envsFile).toBe('.env');
   });
@@ -214,11 +214,11 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
 
     // Check saved file has been migrated to 1.2
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.envs).toEqual(['NODE_ENV']);
   });
 
@@ -240,7 +240,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
     expect(config.languages).toEqual(['typescript', 'python']);
     expect(config.packageManagers).toEqual(['npm', 'pip']);
     expect(config.taskManagers).toEqual(['make']);
@@ -323,7 +323,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     const config = ProjectConfigManager.load(testDir);
 
     // Should remain at version 1.2
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
 
     // All fields should be preserved exactly
     expect(config.languages).toEqual(['typescript']);
@@ -336,7 +336,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     // Check saved file remains unchanged
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.mcps).toEqual([]);
     expect(jsonData.envs).toEqual(['NODE_ENV']);
     expect(jsonData.envsFile).toBe('.env');
@@ -457,7 +457,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     const config = ProjectConfigManager.load(testDir);
 
     // Should be migrated to 1.2
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
 
     // Should preserve custom fields
     expect(config.agentImage).toBe('custom/agent:legacy');
@@ -465,7 +465,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     // Check saved file
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.sandbox.agentImage).toBe('custom/agent:legacy');
     expect(jsonData.sandbox.initScript).toBe('init.sh');
   });
@@ -489,12 +489,12 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
     expect(config.agentImage).toBe('ghcr.io/custom/rover:v1.0');
 
     // Check saved file has been migrated to 1.2
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.sandbox.agentImage).toBe('ghcr.io/custom/rover:v1.0');
   });
 
@@ -520,7 +520,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
     expect(config.languages).toEqual(['typescript', 'python']);
     expect(config.packageManagers).toEqual(['npm', 'pip']);
     expect(config.taskManagers).toEqual(['make']);
@@ -653,7 +653,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     const config = ProjectConfigManager.load(testDir);
 
     // Should be migrated to 1.2
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
 
     // Should preserve hooks field
     expect(config.hooks).toEqual({
@@ -662,7 +662,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     // Check saved file
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.hooks).toEqual({
       onMerge: ['echo "migrated hook"'],
     });
@@ -721,7 +721,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
     expect(config.languages).toEqual(['typescript', 'python']);
     expect(config.packageManagers).toEqual(['npm', 'pip']);
     expect(config.taskManagers).toEqual(['make']);
@@ -749,7 +749,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     expect(config.excludePatterns).toBeUndefined();
 
     // Check saved file
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect('excludePatterns' in jsonData).toBe(false);
   });
 
@@ -774,14 +774,14 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
     const config = ProjectConfigManager.load(testDir);
 
     // Should be migrated to current version
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
 
     // Should preserve excludePatterns
     expect(config.excludePatterns).toEqual(['secret/**', '*.key']);
 
     // Check saved file
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.excludePatterns).toEqual(['secret/**', '*.key']);
   });
 
@@ -835,7 +835,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
     expect(config.languages).toEqual(['typescript', 'python']);
     expect(config.packageManagers).toEqual(['npm', 'pip']);
     expect(config.taskManagers).toEqual(['make']);
@@ -873,8 +873,8 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    // Should be migrated to 1.4
-    expect(config.version).toBe('1.4');
+    // Should be migrated to current version
+    expect(config.version).toBe('1.5');
 
     // All fields should be preserved exactly
     expect(config.languages).toEqual(['typescript']);
@@ -888,7 +888,7 @@ describe('ProjectConfigManager - Environment Variable Configuration', () => {
 
     // Check saved file
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.mcps).toEqual([]);
     expect(jsonData.envs).toEqual(['NODE_ENV']);
     expect(jsonData.envsFile).toBe('.env');
@@ -921,7 +921,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
     const config = ProjectConfigManager.create(testDir);
 
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect('projects' in jsonData).toBe(false);
     expect(config.projects).toBeUndefined();
   });
@@ -931,7 +931,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: ['typescript'],
           mcps: [],
           packageManagers: ['pnpm'],
@@ -966,7 +966,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
     expect(config.projects?.[1].name).toBe('frontend');
   });
 
-  it('should migrate from 1.3 to 1.4 preserving projects field', () => {
+  it('should migrate from 1.3 to current version preserving projects field', () => {
     writeFileSync(
       'rover.json',
       JSON.stringify(
@@ -988,16 +988,16 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
     expect(config.projects).toHaveLength(1);
     expect(config.projects?.[0].name).toBe('api');
 
     const jsonData = JSON.parse(readFileSync('rover.json', 'utf8'));
-    expect(jsonData.version).toBe('1.4');
+    expect(jsonData.version).toBe('1.5');
     expect(jsonData.projects).toHaveLength(1);
   });
 
-  it('should migrate from 1.3 to 1.4 without projects field', () => {
+  it('should migrate from 1.3 to current version without projects field', () => {
     writeFileSync(
       'rover.json',
       JSON.stringify(
@@ -1016,7 +1016,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
 
     const config = ProjectConfigManager.load(testDir);
 
-    expect(config.version).toBe('1.4');
+    expect(config.version).toBe('1.5');
     expect(config.projects).toBeUndefined();
   });
 
@@ -1025,7 +1025,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: ['typescript', 'python'],
           mcps: [],
           packageManagers: [],
@@ -1058,7 +1058,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: ['typescript'],
           mcps: [],
           packageManagers: [],
@@ -1079,7 +1079,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: ['pnpm'],
@@ -1109,7 +1109,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: [],
@@ -1137,7 +1137,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: [],
@@ -1174,7 +1174,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: [],
@@ -1199,7 +1199,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: [],
@@ -1238,7 +1238,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: [],
@@ -1298,7 +1298,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: [],
@@ -1326,7 +1326,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: [],
           mcps: [],
           packageManagers: [],
@@ -1359,7 +1359,7 @@ describe('ProjectConfigManager - Multi-Project Workspace Support', () => {
       'rover.json',
       JSON.stringify(
         {
-          version: '1.4',
+          version: '1.5',
           languages: ['typescript'],
           mcps: [],
           packageManagers: ['pnpm'],

--- a/packages/core/src/files/__tests__/task-description.test.ts
+++ b/packages/core/src/files/__tests__/task-description.test.ts
@@ -26,7 +26,12 @@ describe('TaskDescriptionManager', () => {
   });
 
   const readLifecycleEvents = () => {
-    const logPath = join(testDir, '.rover', 'logs', 'task-status-history.jsonl');
+    const logPath = join(
+      testDir,
+      '.rover',
+      'logs',
+      'task-status-history.jsonl'
+    );
     const raw = readFileSync(logPath, 'utf8')
       .trim()
       .split('\n')
@@ -367,7 +372,8 @@ describe('TaskDescriptionManager', () => {
       task.markInProgress('2026-03-18T10:00:00.000Z');
       task.updateExecutionStatus('failed', {
         exitCode: 1,
-        error: 'Workflow stopped due to step failure: failing for observability test',
+        error:
+          'Workflow stopped due to step failure: failing for observability test',
       });
 
       const events = readLifecycleEvents();

--- a/packages/core/src/files/project-config.ts
+++ b/packages/core/src/files/project-config.ts
@@ -20,6 +20,7 @@ import {
   type HooksConfig,
   type NetworkConfig,
   type SubProject,
+  type ServiceContainer,
 } from 'rover-schemas';
 import { GlobalConfigManager } from './global-config.js';
 
@@ -282,6 +283,9 @@ export class ProjectConfigManager {
   }
   get projects(): SubProject[] | undefined {
     return this.data.projects;
+  }
+  get services(): ServiceContainer[] | undefined {
+    return this.data.sandbox?.services;
   }
 
   /**

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -1023,14 +1023,14 @@ export class TaskDescriptionManager {
     return join(this.roverDir(), 'logs', 'task-status-history.jsonl');
   }
 
-  private deriveLifecycleReasonCode(reason?: string, changeKind?: string): string {
+  private deriveLifecycleReasonCode(
+    reason?: string,
+    changeKind?: string
+  ): string {
     const text = String(reason || '').toLowerCase();
     if (changeKind === 'deleted') return 'task_deleted';
     if (!text) return '';
-    if (
-      text.includes('at capacity') ||
-      text.includes('waiting for slot')
-    ) {
+    if (text.includes('at capacity') || text.includes('waiting for slot')) {
       return 'capacity_wait';
     }
     if (text.includes('blocked (resets in') || text.includes(' blocked')) {
@@ -1050,16 +1050,27 @@ export class TaskDescriptionManager {
     if (text.includes('rate limit') || text.includes('too many requests')) {
       return 'rate_limit';
     }
-    if (text.includes('auth') || text.includes('login') || text.includes('sign in')) {
+    if (
+      text.includes('auth') ||
+      text.includes('login') ||
+      text.includes('sign in')
+    ) {
       return 'auth_required';
     }
-    if (text.includes('network') || text.includes('timeout') || text.includes('timed out')) {
+    if (
+      text.includes('network') ||
+      text.includes('timeout') ||
+      text.includes('timed out')
+    ) {
       return 'network_timeout';
     }
     if (text.includes('step failure') || text.includes('step failed')) {
       return 'workflow_step_failed';
     }
-    if (text.includes('container') && (text.includes('exit') || text.includes('crash'))) {
+    if (
+      text.includes('container') &&
+      (text.includes('exit') || text.includes('crash'))
+    ) {
       return 'container_crashed';
     }
     if (text.includes('signal')) {
@@ -1092,17 +1103,11 @@ export class TaskDescriptionManager {
       changeKind ??
       (previousStatus === status ? 'reason_update' : 'transition');
 
-    if (
-      kind === 'transition' &&
-      previousStatus === status
-    ) {
+    if (kind === 'transition' && previousStatus === status) {
       return;
     }
 
-    if (
-      kind === 'reason_update' &&
-      (!reason || reason === previousReason)
-    ) {
+    if (kind === 'reason_update' && (!reason || reason === previousReason)) {
       return;
     }
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -43,6 +43,7 @@ export type GitWorktreeOptions = {
 
 export type GitRemoteBranchOptions = GitWorktreeOptions & {
   refreshIfMissing?: boolean;
+  refresh?: boolean;
 };
 
 export type GitCheckoutOptions = GitWorktreeOptions & {
@@ -718,6 +719,12 @@ export class Git {
   ): boolean {
     const effectiveCwd = options.worktreePath ?? this.cwd;
 
+    if (options.refresh) {
+      return this.refreshRemoteBranch(branch, remote, {
+        worktreePath: effectiveCwd,
+      });
+    }
+
     try {
       const exists =
         launchSync(
@@ -798,7 +805,7 @@ export class Git {
       if (
         this.remoteBranchExists(branch, 'origin', {
           worktreePath: effectiveCwd,
-          refreshIfMissing: true,
+          refresh: true,
         })
       ) {
         launchSync(

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -9,6 +9,13 @@ export class GitError extends Error {
   }
 }
 
+function isMissingRemoteRefError(message: string): boolean {
+  return (
+    message.includes("couldn't find remote ref") ||
+    message.includes('remote ref does not exist')
+  );
+}
+
 export type GitDiffOptions = {
   worktreePath?: string;
   filePath?: string;
@@ -32,6 +39,10 @@ export type GitDiffStatsResult = {
 
 export type GitWorktreeOptions = {
   worktreePath?: string;
+};
+
+export type GitRemoteBranchOptions = GitWorktreeOptions & {
+  refreshIfMissing?: boolean;
 };
 
 export type GitCheckoutOptions = GitWorktreeOptions & {
@@ -703,10 +714,12 @@ export class Git {
   remoteBranchExists(
     branch: string,
     remote: string = 'origin',
-    options: GitWorktreeOptions = {}
+    options: GitRemoteBranchOptions = {}
   ): boolean {
+    const effectiveCwd = options.worktreePath ?? this.cwd;
+
     try {
-      return (
+      const exists =
         launchSync(
           'git',
           [
@@ -715,12 +728,60 @@ export class Git {
             '--quiet',
             `refs/remotes/${remote}/${branch}`,
           ],
-          { reject: false, cwd: options.worktreePath ?? this.cwd }
-        ).exitCode === 0
-      );
+          { reject: false, cwd: effectiveCwd }
+        ).exitCode === 0;
+
+      if (exists || !options.refreshIfMissing) {
+        return exists;
+      }
     } catch (error) {
+      if (!options.refreshIfMissing) {
+        return false;
+      }
+    }
+
+    return this.refreshRemoteBranch(branch, remote, {
+      worktreePath: effectiveCwd,
+    });
+  }
+
+  private refreshRemoteBranch(
+    branch: string,
+    remote: string = 'origin',
+    options: GitWorktreeOptions = {}
+  ): boolean {
+    const effectiveCwd = options.worktreePath ?? this.cwd;
+    const fetchResult = launchSync(
+      'git',
+      [
+        'fetch',
+        '--no-tags',
+        remote,
+        `refs/heads/${branch}:refs/remotes/${remote}/${branch}`,
+      ],
+      {
+        reject: false,
+        cwd: effectiveCwd,
+      }
+    );
+
+    if (fetchResult.exitCode === 0) {
+      return this.remoteBranchExists(branch, remote, {
+        worktreePath: effectiveCwd,
+      });
+    }
+
+    const stderr = fetchResult.stderr?.toString() || '';
+    const stdout = fetchResult.stdout?.toString() || '';
+    const errorMessage = stderr || stdout || 'Unknown git fetch error';
+
+    if (isMissingRemoteRefError(errorMessage)) {
       return false;
     }
+
+    throw new GitError(
+      `Failed to fetch remote branch '${remote}/${branch}': ${errorMessage}`
+    );
   }
 
   checkoutBranch(branch: string, options: GitCheckoutOptions = {}): void {
@@ -737,6 +798,7 @@ export class Git {
       if (
         this.remoteBranchExists(branch, 'origin', {
           worktreePath: effectiveCwd,
+          refreshIfMissing: true,
         })
       ) {
         launchSync(
@@ -757,7 +819,6 @@ export class Git {
 
     throw new GitError(`Branch '${branch}' does not exist`);
   }
-
   /**
    * Create worktree
    */

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -700,6 +700,29 @@ export class Git {
     }
   }
 
+  remoteBranchExists(
+    branch: string,
+    remote: string = 'origin',
+    options: GitWorktreeOptions = {}
+  ): boolean {
+    try {
+      return (
+        launchSync(
+          'git',
+          [
+            'show-ref',
+            '--verify',
+            '--quiet',
+            `refs/remotes/${remote}/${branch}`,
+          ],
+          { reject: false, cwd: options.worktreePath ?? this.cwd }
+        ).exitCode === 0
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
   checkoutBranch(branch: string, options: GitCheckoutOptions = {}): void {
     const effectiveCwd = options.worktreePath ?? this.cwd;
 
@@ -711,6 +734,21 @@ export class Git {
     }
 
     if (options.createIfMissing) {
+      if (
+        this.remoteBranchExists(branch, 'origin', {
+          worktreePath: effectiveCwd,
+        })
+      ) {
+        launchSync(
+          'git',
+          ['checkout', '-B', branch, `refs/remotes/origin/${branch}`],
+          {
+            cwd: effectiveCwd,
+          }
+        );
+        return;
+      }
+
       launchSync('git', ['checkout', '-b', branch], {
         cwd: effectiveCwd,
       });

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -1,6 +1,6 @@
 import { createReadStream } from 'node:fs';
-import { launchSync } from './os.js';
 import { join, resolve } from 'node:path';
+import { launchSync } from './os.js';
 
 export class GitError extends Error {
   constructor(reason: string) {
@@ -32,6 +32,10 @@ export type GitDiffStatsResult = {
 
 export type GitWorktreeOptions = {
   worktreePath?: string;
+};
+
+export type GitCheckoutOptions = GitWorktreeOptions & {
+  createIfMissing?: boolean;
 };
 
 export type GitRecentCommitOptions = {
@@ -682,18 +686,38 @@ export class Git {
   /**
    * Check if a given branch exists
    */
-  branchExists(branch: string): boolean {
+  branchExists(branch: string, options: GitWorktreeOptions = {}): boolean {
     try {
       return (
         launchSync(
           'git',
           ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
-          { reject: false, cwd: this.cwd }
+          { reject: false, cwd: options.worktreePath ?? this.cwd }
         ).exitCode === 0
       );
     } catch (error) {
       return false;
     }
+  }
+
+  checkoutBranch(branch: string, options: GitCheckoutOptions = {}): void {
+    const effectiveCwd = options.worktreePath ?? this.cwd;
+
+    if (this.branchExists(branch, { worktreePath: effectiveCwd })) {
+      launchSync('git', ['checkout', branch], {
+        cwd: effectiveCwd,
+      });
+      return;
+    }
+
+    if (options.createIfMissing) {
+      launchSync('git', ['checkout', '-b', branch], {
+        cwd: effectiveCwd,
+      });
+      return;
+    }
+
+    throw new GitError(`Branch '${branch}' does not exist`);
   }
 
   /**

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -142,6 +142,8 @@ export type {
   NetworkRule,
   NetworkConfig,
   SandboxConfig,
+  ServiceHealthcheck,
+  ServiceContainer,
   HooksConfig,
   SubProject,
   ProjectConfig,
@@ -158,6 +160,8 @@ export {
   PROJECT_CONFIG_FILENAME,
   ProjectConfigSchema,
   SubProjectSchema,
+  ServiceContainerSchema,
+  ServiceHealthcheckSchema,
   NETWORK_MODE_VALUES,
 } from './project-config/schema.js';
 

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -142,8 +142,6 @@ export type {
   NetworkRule,
   NetworkConfig,
   SandboxConfig,
-  ServiceHealthcheck,
-  ServiceContainer,
   HooksConfig,
   SubProject,
   ProjectConfig,
@@ -160,8 +158,6 @@ export {
   PROJECT_CONFIG_FILENAME,
   ProjectConfigSchema,
   SubProjectSchema,
-  ServiceContainerSchema,
-  ServiceHealthcheckSchema,
   NETWORK_MODE_VALUES,
 } from './project-config/schema.js';
 

--- a/packages/schemas/src/project-config/__tests__/schema.test.ts
+++ b/packages/schemas/src/project-config/__tests__/schema.test.ts
@@ -118,7 +118,7 @@ describe('SubProjectSchema', () => {
 
 describe('ProjectConfigSchema with projects', () => {
   const baseConfig = {
-    version: '1.5',
+    version: '1.4',
     languages: ['typescript'] as const,
     mcps: [],
     packageManagers: ['pnpm'] as const,

--- a/packages/schemas/src/project-config/__tests__/schema.test.ts
+++ b/packages/schemas/src/project-config/__tests__/schema.test.ts
@@ -193,6 +193,34 @@ describe('ProjectConfigSchema with projects', () => {
     ).toThrow(/Duplicate project path/);
   });
 
+  it('should reject blank network rule hosts', () => {
+    expect(() =>
+      ProjectConfigSchema.parse({
+        ...baseConfig,
+        sandbox: {
+          network: {
+            mode: 'allowlist',
+            rules: [{ host: '   ' }],
+          },
+        },
+      })
+    ).toThrow(/Host must not be empty/);
+  });
+
+  it('should trim valid network rule hosts during parsing', () => {
+    const result = ProjectConfigSchema.parse({
+      ...baseConfig,
+      sandbox: {
+        network: {
+          mode: 'allowlist',
+          rules: [{ host: '  api.github.com  ' }],
+        },
+      },
+    });
+
+    expect(result.sandbox?.network?.rules[0]?.host).toBe('api.github.com');
+  });
+
   it('should accept valid sandbox service names', () => {
     const result = ProjectConfigSchema.parse({
       ...baseConfig,
@@ -224,5 +252,45 @@ describe('ProjectConfigSchema with projects', () => {
         },
       })
     ).toThrow(/valid lowercase hostname label/);
+  });
+
+  it('should accept valid volume mount formats', () => {
+    const result = ProjectConfigSchema.parse({
+      ...baseConfig,
+      sandbox: {
+        services: [
+          {
+            name: 'postgres',
+            image: 'postgres:16',
+            volumes: [
+              'pgdata:/var/lib/postgresql/data',
+              '/host/path:/container/path:ro',
+              'named-vol:/data:rw',
+              '/host/cache:/cache:Z,ro',
+              'C:\\data:/container/data:ro',
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(result.sandbox?.services?.[0]?.volumes).toHaveLength(5);
+  });
+
+  it('should reject malformed volume mount strings', () => {
+    expect(() =>
+      ProjectConfigSchema.parse({
+        ...baseConfig,
+        sandbox: {
+          services: [
+            {
+              name: 'postgres',
+              image: 'postgres:16',
+              volumes: ['no-colon-separator'],
+            },
+          ],
+        },
+      })
+    ).toThrow(/source:target/);
   });
 });

--- a/packages/schemas/src/project-config/__tests__/schema.test.ts
+++ b/packages/schemas/src/project-config/__tests__/schema.test.ts
@@ -192,4 +192,37 @@ describe('ProjectConfigSchema with projects', () => {
       })
     ).toThrow(/Duplicate project path/);
   });
+
+  it('should accept valid sandbox service names', () => {
+    const result = ProjectConfigSchema.parse({
+      ...baseConfig,
+      sandbox: {
+        services: [{ name: 'postgres-1', image: 'postgres:16' }],
+      },
+    });
+
+    expect(result.sandbox?.services?.[0]?.name).toBe('postgres-1');
+  });
+
+  it('should reject invalid sandbox service names', () => {
+    expect(() =>
+      ProjectConfigSchema.parse({
+        ...baseConfig,
+        sandbox: {
+          services: [{ name: 'Postgres DB', image: 'postgres:16' }],
+        },
+      })
+    ).toThrow(/valid lowercase hostname label/);
+  });
+
+  it('should reject sandbox service names longer than 63 characters', () => {
+    expect(() =>
+      ProjectConfigSchema.parse({
+        ...baseConfig,
+        sandbox: {
+          services: [{ name: `a${'b'.repeat(62)}c`, image: 'postgres:16' }],
+        },
+      })
+    ).toThrow(/valid lowercase hostname label/);
+  });
 });

--- a/packages/schemas/src/project-config/__tests__/schema.test.ts
+++ b/packages/schemas/src/project-config/__tests__/schema.test.ts
@@ -118,7 +118,7 @@ describe('SubProjectSchema', () => {
 
 describe('ProjectConfigSchema with projects', () => {
   const baseConfig = {
-    version: '1.4',
+    version: '1.5',
     languages: ['typescript'] as const,
     mcps: [],
     packageManagers: ['pnpm'] as const,

--- a/packages/schemas/src/project-config/schema.ts
+++ b/packages/schemas/src/project-config/schema.ts
@@ -120,7 +120,12 @@ export const ServiceHealthcheckSchema = z.object({
  */
 export const ServiceContainerSchema = z.object({
   /** Service name — used as the hostname on the task network */
-  name: z.string(),
+  name: z
+    .string()
+    .refine(value => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(value), {
+      message:
+        'Service name must be a valid lowercase hostname label (1-63 chars, letters, numbers, and hyphens only)',
+    }),
   /** Docker/Podman image to use */
   image: z.string(),
   /** Container ports (informational — all ports are reachable on the task network) */

--- a/packages/schemas/src/project-config/schema.ts
+++ b/packages/schemas/src/project-config/schema.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { posix as path } from 'node:path';
 
 // Current schema version
-export const CURRENT_PROJECT_SCHEMA_VERSION = '1.4';
+export const CURRENT_PROJECT_SCHEMA_VERSION = '1.5';
 
 // Filename constant
 export const PROJECT_CONFIG_FILENAME = 'rover.json';
@@ -98,6 +98,46 @@ export const NetworkConfigSchema = z.object({
 });
 
 /**
+ * Healthcheck configuration for a service container
+ */
+export const ServiceHealthcheckSchema = z.object({
+  /** Command to run inside the container to check health */
+  cmd: z.string(),
+  /** Interval between checks in seconds */
+  interval: z.number().int().positive().default(5),
+  /** Timeout for each check in seconds */
+  timeout: z.number().int().positive().default(5),
+  /** Number of retries before unhealthy */
+  retries: z.number().int().positive().default(3),
+  /** Start period in seconds before first check */
+  startPeriod: z.number().int().nonnegative().default(0),
+});
+
+/**
+ * Service container (sidecar) configuration.
+ * Services run as separate containers on a per-task Docker network.
+ * The task container can reach them by service name as hostname.
+ */
+export const ServiceContainerSchema = z.object({
+  /** Service name — used as the hostname on the task network */
+  name: z.string(),
+  /** Docker/Podman image to use */
+  image: z.string(),
+  /** Container ports (informational — all ports are reachable on the task network) */
+  ports: z.array(z.number().int().positive()).optional(),
+  /** Environment variables for the service container */
+  env: z.array(z.string()).optional(),
+  /** Volume mounts (named volumes or bind mounts) */
+  volumes: z.array(z.string()).optional(),
+  /** Healthcheck configuration — services with a healthcheck are polled before the task starts */
+  healthcheck: ServiceHealthcheckSchema.optional(),
+  /** Command override */
+  command: z.union([z.string(), z.array(z.string())]).optional(),
+  /** Max seconds to wait for the service to become healthy (default: 60) */
+  readyTimeout: z.number().int().positive().default(60),
+});
+
+/**
  * Sandbox configuration for custom agent images and initialization
  */
 export const SandboxConfigSchema = z.object({
@@ -111,6 +151,8 @@ export const SandboxConfigSchema = z.object({
   network: NetworkConfigSchema.optional(),
   /** Files whose contents are included in the cache hash for invalidation */
   cacheFiles: z.array(z.string()).optional(),
+  /** Service containers (sidecars) to run alongside task containers */
+  services: z.array(ServiceContainerSchema).optional(),
 });
 
 /**
@@ -215,5 +257,21 @@ export const ProjectConfigSchema = z
       }
 
       seenPaths.set(project.path, index);
+    }
+
+    const seenServiceNames = new Map<string, number>();
+
+    for (const [index, service] of config.sandbox?.services?.entries() ?? []) {
+      const previousIndex = seenServiceNames.get(service.name);
+      if (previousIndex !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['sandbox', 'services', index, 'name'],
+          message: `Duplicate service name "${service.name}" already used by sandbox.services[${previousIndex}]`,
+        });
+        continue;
+      }
+
+      seenServiceNames.set(service.name, index);
     }
   });

--- a/packages/schemas/src/project-config/schema.ts
+++ b/packages/schemas/src/project-config/schema.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { posix as path } from 'node:path';
 
 // Current schema version
-export const CURRENT_PROJECT_SCHEMA_VERSION = '1.5';
+export const CURRENT_PROJECT_SCHEMA_VERSION = '1.4';
 
 // Filename constant
 export const PROJECT_CONFIG_FILENAME = 'rover.json';
@@ -98,46 +98,6 @@ export const NetworkConfigSchema = z.object({
 });
 
 /**
- * Healthcheck configuration for a service container
- */
-export const ServiceHealthcheckSchema = z.object({
-  /** Command to run inside the container to check health */
-  cmd: z.string(),
-  /** Interval between checks in seconds */
-  interval: z.number().int().positive().default(5),
-  /** Timeout for each check in seconds */
-  timeout: z.number().int().positive().default(5),
-  /** Number of retries before unhealthy */
-  retries: z.number().int().positive().default(3),
-  /** Start period in seconds before first check */
-  startPeriod: z.number().int().nonnegative().default(0),
-});
-
-/**
- * Service container (sidecar) configuration.
- * Services run as separate containers on a per-task Docker network.
- * The task container can reach them by service name as hostname.
- */
-export const ServiceContainerSchema = z.object({
-  /** Service name — used as the hostname on the task network */
-  name: z.string(),
-  /** Docker/Podman image to use */
-  image: z.string(),
-  /** Container ports (informational — all ports are reachable on the task network) */
-  ports: z.array(z.number().int().positive()).optional(),
-  /** Environment variables for the service container */
-  env: z.array(z.string()).optional(),
-  /** Volume mounts (named volumes or bind mounts) */
-  volumes: z.array(z.string()).optional(),
-  /** Healthcheck configuration — services with a healthcheck are polled before the task starts */
-  healthcheck: ServiceHealthcheckSchema.optional(),
-  /** Command override */
-  command: z.union([z.string(), z.array(z.string())]).optional(),
-  /** Max seconds to wait for the service to become healthy (default: 60) */
-  readyTimeout: z.number().int().positive().default(60),
-});
-
-/**
  * Sandbox configuration for custom agent images and initialization
  */
 export const SandboxConfigSchema = z.object({
@@ -151,8 +111,6 @@ export const SandboxConfigSchema = z.object({
   network: NetworkConfigSchema.optional(),
   /** Files whose contents are included in the cache hash for invalidation */
   cacheFiles: z.array(z.string()).optional(),
-  /** Service containers (sidecars) to run alongside task containers */
-  services: z.array(ServiceContainerSchema).optional(),
 });
 
 /**
@@ -257,21 +215,5 @@ export const ProjectConfigSchema = z
       }
 
       seenPaths.set(project.path, index);
-    }
-
-    const seenServiceNames = new Map<string, number>();
-
-    for (const [index, service] of config.sandbox?.services?.entries() ?? []) {
-      const previousIndex = seenServiceNames.get(service.name);
-      if (previousIndex !== undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['sandbox', 'services', index, 'name'],
-          message: `Duplicate service name "${service.name}" already used by sandbox.services[${previousIndex}]`,
-        });
-        continue;
-      }
-
-      seenServiceNames.set(service.name, index);
     }
   });

--- a/packages/schemas/src/project-config/schema.ts
+++ b/packages/schemas/src/project-config/schema.ts
@@ -78,7 +78,7 @@ export const NETWORK_MODE_VALUES = NetworkModeSchema.options;
  */
 export const NetworkRuleSchema = z.object({
   /** Host pattern: domain name, IP address, or CIDR notation */
-  host: z.string(),
+  host: z.string().trim().min(1, { message: 'Host must not be empty' }),
   /** Optional description for documentation */
   description: z.string().optional(),
 });
@@ -113,6 +113,32 @@ export const ServiceHealthcheckSchema = z.object({
   startPeriod: z.number().int().nonnegative().default(0),
 });
 
+const isValidVolumeMount = (value: string): boolean => {
+  const parts = value.split(':');
+  if (parts.length < 2) {
+    return false;
+  }
+
+  let targetIndex = 1;
+  if (
+    parts.length >= 3 &&
+    /^[A-Za-z]$/.test(parts[0]) &&
+    /^[\\/]/.test(parts[1])
+  ) {
+    targetIndex = 2;
+  }
+
+  const source = parts.slice(0, targetIndex).join(':');
+  const target = parts[targetIndex];
+  const options = parts.slice(targetIndex + 1);
+
+  if (!source || !target || options.length > 1) {
+    return false;
+  }
+
+  return options.length === 0 || /^[A-Za-z]+(?:,[A-Za-z]+)*$/.test(options[0]);
+};
+
 /**
  * Service container (sidecar) configuration.
  * Services run as separate containers on a per-task Docker network.
@@ -132,8 +158,15 @@ export const ServiceContainerSchema = z.object({
   ports: z.array(z.number().int().positive()).optional(),
   /** Environment variables for the service container */
   env: z.array(z.string()).optional(),
-  /** Volume mounts (named volumes or bind mounts) */
-  volumes: z.array(z.string()).optional(),
+  /** Volume mounts (named volumes or bind mounts, e.g. "pgdata:/var/lib/postgresql/data" or "/host:/container:Z,ro") */
+  volumes: z
+    .array(
+      z.string().refine(isValidVolumeMount, {
+        message:
+          'Volume mount must be in the format "source:target" or "source:target:option[,option...]"',
+      })
+    )
+    .optional(),
   /** Healthcheck configuration — services with a healthcheck are polled before the task starts */
   healthcheck: ServiceHealthcheckSchema.optional(),
   /** Command override */

--- a/packages/schemas/src/project-config/types.ts
+++ b/packages/schemas/src/project-config/types.ts
@@ -12,8 +12,6 @@ import type {
   NetworkRuleSchema,
   NetworkConfigSchema,
   SandboxConfigSchema,
-  ServiceHealthcheckSchema,
-  ServiceContainerSchema,
   HooksConfigSchema,
   SubProjectSchema,
   ProjectConfigSchema,
@@ -28,8 +26,6 @@ export type NetworkMode = z.infer<typeof NetworkModeSchema>;
 export type NetworkRule = z.infer<typeof NetworkRuleSchema>;
 export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;
-export type ServiceHealthcheck = z.infer<typeof ServiceHealthcheckSchema>;
-export type ServiceContainer = z.infer<typeof ServiceContainerSchema>;
 export type HooksConfig = z.infer<typeof HooksConfigSchema>;
 export type SubProject = z.infer<typeof SubProjectSchema>;
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;

--- a/packages/schemas/src/project-config/types.ts
+++ b/packages/schemas/src/project-config/types.ts
@@ -12,6 +12,8 @@ import type {
   NetworkRuleSchema,
   NetworkConfigSchema,
   SandboxConfigSchema,
+  ServiceHealthcheckSchema,
+  ServiceContainerSchema,
   HooksConfigSchema,
   SubProjectSchema,
   ProjectConfigSchema,
@@ -26,6 +28,8 @@ export type NetworkMode = z.infer<typeof NetworkModeSchema>;
 export type NetworkRule = z.infer<typeof NetworkRuleSchema>;
 export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
 export type SandboxConfig = z.infer<typeof SandboxConfigSchema>;
+export type ServiceHealthcheck = z.infer<typeof ServiceHealthcheckSchema>;
+export type ServiceContainer = z.infer<typeof ServiceContainerSchema>;
 export type HooksConfig = z.infer<typeof HooksConfigSchema>;
 export type SubProject = z.infer<typeof SubProjectSchema>;
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;


### PR DESCRIPTION
## Summary
- add multi-repo workspace support for build, setup, push, and rebase flows
- validate and document the Flutter + Go + Python demo workspace pattern
- update swe workflows to persist markdown outputs explicitly and avoid false missing-file warnings

## Validation
- pnpm --filter @endorhq/rover build
- pnpm --filter @endorhq/rover test -- src/lib/__tests__/workflow.test.ts
- fresh-clone Rover task ran swe-tdd with make validate successfully